### PR TITLE
Update VTEX - Payment Provider Protocol.json

### DIFF
--- a/VTEX - Payment Provider Protocol.json
+++ b/VTEX - Payment Provider Protocol.json
@@ -86,7 +86,7 @@
 					"Payment Flow"
 				],
 				"summary": "Create Payment",
-				"description": "",
+				"description": "Creates a new payment and/or initiates the payment flow.",
 				"operationId": "CreatePayment",
 				"parameters": [
                     {
@@ -298,7 +298,7 @@
 					"Payment Flow"
 				],
 				"summary": "Cancel Payment",
-				"description": "",
+				"description": "Cancels a payment that was not yet approved or captured (settled).",
 				"operationId": "CancelPayment",
 				"parameters": [
                     {
@@ -531,7 +531,7 @@
 					"Payment Flow"
 				],
 				"summary": "Capture Payment",
-				"description": "",
+				"description": "Captures (settle) a payment that was previously approved.",
 				"operationId": "CapturePayment",
 				"parameters": [
                     {
@@ -738,7 +738,7 @@
 					"Payment Flow"
 				],
 				"summary": "Refund Payment",
-				"description": "",
+				"description": "Refunds a payment that was previously captured (settled). You can expect partial refunds.",
 				"operationId": "RefundPayment",
 				"parameters": [
                     {
@@ -963,7 +963,7 @@
 					"Payment Flow"
 				],
 				"summary": "Inbound Request (BETA)",
-				"description": "",
+				"description": "Forwards a request back to your endpoint using the inboundRequestsUrl provided in the POST /payments payload.",
 				"operationId": "InboundRequest(BETA)",
 				"parameters": [
                     {


### PR DESCRIPTION
Tinham alguns endpoints que já tinham descrição, mas estavam lá embaixo (na UI). Só fiz "subir" a mesma descrição para o código, assim ela fica logo abaixo do título da chamada. Também me certifiquei de tirar essas mesmas descrições no markdown :v: