### PR TITLE
Added: new Get Product by ID endpoint

### DIFF
--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -841,7 +841,7 @@
                 ],
                 "summary": "Get Product by id",
                 "description": "Retrieves a specific product by its ID.",
-                "operationId": "Productbyid",
+                "operationId": "GetProductbyid",
                 "parameters": [
                     {
                         "name": "accountName",

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -834,6 +834,313 @@
                 }
             }
         },
+        "/api/catalog/pvt/product/{productId}": {
+            "get": {
+                "tags": [
+                    "Product"
+                ],
+                "summary": "Get Product by id",
+                "description": "Retrieves a specific product by its ID.",
+                "operationId": "Productbyid",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Describes the type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand ",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "headers": {
+                            "Cache-Control": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "no-cache"
+                                    }
+                                }
+                            },
+                            "Connection": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "keep-alive"
+                                    }
+                                }
+                            },
+                            "Content-Length": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "507"
+                                    }
+                                }
+                            },
+                            "Date": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "Thu, 16 Feb 2017 15:22:06 GMT"
+                                    }
+                                }
+                            },
+                            "Expires": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "-1"
+                                    }
+                                }
+                            },
+                            "Pragma": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "no-cache"
+                                    }
+                                }
+                            },
+                            "Server": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "nginx"
+                                    }
+                                }
+                            },
+                            "X-CacheServer": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "janus-apicache-nginx11"
+                                    }
+                                }
+                            },
+                            "X-Powered-by-VTEX-Janus-ApiCache": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "v1.3.9"
+                                    }
+                                }
+                            },
+                            "X-Powered-by-VTEX-Janus-Edge": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "v1.36.0-beta"
+                                    }
+                                }
+                            },
+                            "X-Track": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "beta"
+                                    }
+                                }
+                            },
+                            "X-Translate": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "1"
+                                    }
+                                }
+                            },
+                            "X-Translate-BackEnd": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "http%3A%2F%2Fbeta.janus-router-v2.vtexinternal.com.br%2Fapi%2Fcatalog_system%2Fpvt%2Fproducts%2FProductGet%2F2001426"
+                                    }
+                                }
+                            },
+                            "X-VTEX-Cache-Status-Janus-ApiCache": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "MISS"
+                                    }
+                                }
+                            },
+                            "X-VTEX-Cache-Status-Janus-Edge": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "MISS"
+                                    }
+                                }
+                            },
+                            "X-VTEX-Janus-Router-Backend-App": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "prtapi-v1.4.691-beta.1+530"
+                                    }
+                                }
+                            },
+                            "no": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "-8NLU58HJKL2"
+                                    }
+                                }
+                            },
+                            "p3p": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "policyref=\"/w3c/p3p.xml\",CP=\"ADMa OUR NOR CNT NID DSP NOI COR\""
+                                    }
+                                }
+                            },
+                            "powered": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "vtex"
+                                    }
+                                }
+                            },
+                            "x-vtex-operation-id": {
+                                "content": {
+                                    "text/plain": {
+                                        "schema": {
+                                            "type": "string"
+                                        },
+                                        "example": "0bf9628d-040e-4fd5-878a-cab29c14a453"
+                                    }
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json; charset=utf-8": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Example3"
+                                },
+                                "example": {
+                                    "Id": 2001426,
+                                    "Name": "Tabela de Basquete",
+                                    "DepartmentId": 59,
+                                    "CategoryId": 59,
+                                    "BrandId": 2000018,
+                                    "LinkId": "Tabela-de-Basquete",
+                                    "RefId": "",
+                                    "IsVisible": true,
+                                    "Description": "Tabela de Basquete",
+                                    "DescriptionShort": "",
+                                    "ReleaseDate": "2014-04-30T00:00:00",
+                                    "KeyWords": "Basquete, NBA, Tabela, NBB",
+                                    "Title": "Tabela de Basquete",
+                                    "IsActive": true,
+                                    "TaxCode": "",
+                                    "MetaTagDescription": "Tabela de Basquete",
+                                    "SupplierId": 1,
+                                    "ShowWithoutStock": false,
+                                    "ListStoreId": [
+                                        1,
+                                        2,
+                                        3,
+                                        10
+                                    ],
+                                    "AdWordsRemarketingCode": null,
+                                    "LomadeeCampaignCode": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
         "/api/catalog/pvt/stockkeepingunit/{skuId}/file/{skuFileId}": {
             "post": {
                 "tags": [


### PR DESCRIPTION
New Catalog API has a `[GET] /api/catalog/pvt/product/{productId}` endpoint that has the same behavior as `[GET] /api/catalog_system/pvt/products/ProductGet/{productId}`, so I copied the latter and changed the endpoint + operationId so I could refer to it in my docs.

Desirable future: deprecate `catalog_system` when new Catalog API is fully up.