### PR TITLE
Add body text box examples

### DIFF
--- a/VTEX - Master Data API - v2.json
+++ b/VTEX - Master Data API - v2.json
@@ -78,7 +78,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/DocumentRequest"
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "Boolean": true,
@@ -190,7 +192,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/DocumentRequest"
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "id": "4e4c55ac-e491-11e6-94f4-0ac138d2d42e",
@@ -288,7 +292,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/DocumentRequest"
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "id": "4e4c55ac-e491-11e6-94f4-0ac138d2d42e",
@@ -488,8 +494,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "Boolean": true,
@@ -607,8 +614,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "Boolean": false
@@ -1346,11 +1354,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/ValidatedocumentbyclustersRequest"
-                                },
-                                "description": ""
+                                "type": "string",
+                                "format": "json",
+                                "default": "[\n    {\n        \"name\": \"male\",        \n        \"rule\": \"gender=male\"\n    },\n    {\n        \"name\": \"complex\",\n        \"rule\": \"((gender=male AND percent=0.35) AND any is null) AND (name=*go*)\"\n    },    \n    {\n        \"name\": \"complex2\",\n        \"rule\": \"((gender=male AND percent=0.35) AND any is not null) OR (name=*go*)\"\n    },\n    {\n        \"name\": \"createdIn\",\n        \"rule\": \"createdIn between 2015-10-28 AND 2015-10-30\"\n    }\n]"
                             },
                             "example": [
                                 {

--- a/VTEX - Master Data API - v2.json
+++ b/VTEX - Master Data API - v2.json
@@ -168,7 +168,7 @@
                     {
                         "name": "_schema",
                         "in": "query",
-                        "description": "Name of the schema that the document to be created needs to be compliant with",
+                        "description": "Name of the schema that the document to be created or updated needs to be compliant with",
                         "required": false,
                         "style": "form",
                         "schema": {
@@ -268,7 +268,7 @@
                     {
                         "name": "_schema",
                         "in": "query",
-                        "description": "Name of the schema that the document to be created needs to be compliant with",
+                        "description": "Name of the schema that the document to be created or updated needs to be compliant with",
                         "required": false,
                         "style": "form",
                         "schema": {
@@ -460,7 +460,7 @@
                     {
                         "name": "_schema",
                         "in": "query",
-                        "description": "Name of the schema that the document to be created needs to be compliant with",
+                        "description": "Name of the schema that the document to be updated needs to be compliant with",
                         "required": false,
                         "style": "form",
                         "schema": {
@@ -580,7 +580,7 @@
                     {
                         "name": "_schema",
                         "in": "query",
-                        "description": "Name of the schema that the document to be created needs to be compliant with",
+                        "description": "Name of the schema that the document to be updated needs to be compliant with",
                         "required": false,
                         "style": "form",
                         "schema": {

--- a/VTEX - MasterData API - v10.2.json
+++ b/VTEX - MasterData API - v10.2.json
@@ -825,8 +825,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "Boolean": true,
@@ -925,8 +926,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "id": "4e4c55ac-e491-11e6-94f4-0ac138d2d42e",
@@ -1015,8 +1017,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "id": "4e4c55ac-e491-11e6-94f4-0ac138d2d42e",
@@ -1192,8 +1195,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "Boolean": true,
@@ -1291,8 +1295,9 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "additionalProperties": true
+                                "type": "string",
+                                "format": "json",
+                                "default": "{\n    \"name\": \"Maria\",\n    \"birthDate\": \"1984-02-23\",\n    \"email\": \"maria@email.com\",\n    \"idNumber\": 8241563,\n    \"phoneNumber\": \"+15305816592\",\n    \"receiveNewsletter\": true\n}"
                             },
                             "example": {
                                 "Boolean": false


### PR DESCRIPTION
- Changed the body of the following endpoints in Master Data to a text box and included a JSON example
  - Create new document (v1 and v2)
  - Create or update entire document (v1 and v2)
  - Create or update partial document (v1 and v2)
  - Update entire document (v1 and v2)
  - Update partial document (v1 and v2)
  - Validate document by clusters (v2)
- Corrected the description of _schema query parameter in the following endpoints
  - Create or update entire document (v2)
  - Create or update partial document (v2)
  - Update entire document (v2)
  - Update partial document (v2)