### PR TITLE
Added list endpoints in License Manager

### DIFF
--- a/VTEX - License Manager API.json
+++ b/VTEX - License Manager API.json
@@ -1016,6 +1016,203 @@
                 },
                 "deprecated": false
             }
+        },
+        "/api/license-manager/site/pvt/logins/list/paged": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get List of Users",
+                "description": "Returns a list of registered users. The response is divided in pages. The query paramter numItems defines the number of items in each page, and consequently the amount of pages for the whole list.",
+                "operationId": "GetListUsers",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable",
+                            "example": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json",
+                            "example": "application/json"
+                        }
+                    },
+                    {
+                        "name": "numItems",
+                        "in": "query",
+                        "description": "Number of items in the returned page",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "integer",
+                            "default": "10",
+                            "example": "10"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Which page from the whole list will be returned",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "integer",
+                            "default": "1",
+                            "example": "1"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Chooses the field that the list will be sorted by",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "string",
+                            "default": "name",
+                            "example": "name"
+                        }
+                    },
+                    {
+                        "name": "sortType",
+                        "in": "query",
+                        "description": "Defines the sorting order. ASC is used for ascendant order. DSC is used for descendant order",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "string",
+                            "default": "ASC",
+                            "example": "ASC"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "headers": {}
+                    }
+                }
+            }
+        },
+        "/api/license-manager/site/pvt/roles/list/paged": {
+            "get": {
+                "tags": [
+                    "Roles"
+                ],
+                "summary": "Get List of Roles",
+                "description": "Returns a list of available roles. The response is divided in pages. The query paramter numItems defines the number of items in each page, and consequently the amount of pages for the whole list.",
+                "operationId": "GetListRoles",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json",
+                            "example": "application/json"
+                        }
+                    },
+                    {
+                        "name": "numItems",
+                        "in": "query",
+                        "description": "Number of items in the returned page",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "integer",
+                            "default": "10",
+                            "example": "10"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Which page from the whole list will be returned",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "integer",
+                            "default": "1",
+                            "example": "1"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Chooses the field that the list will be sorted by",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "string",
+                            "default": "id",
+                            "example": "id"
+                        }
+                    },
+                    {
+                        "name": "sortType",
+                        "in": "query",
+                        "description": "Defines the sorting order. ASC is used for ascendant order. DSC is used for descendant order",
+                        "required": false,
+                        "style": "form",
+                        "schema": {
+                            "type": "string",
+                            "default": "ASC",
+                            "example": "ASC"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "headers": {}
+                    }
+                }
+            }
         }
     },
     "security": [


### PR DESCRIPTION
- Added two GET endpoints in License Manager. One to list users and another to list roles. The responses of the endpoints are a page of the whole list. Both the endpoints have the following query parameters:
  - **numItems**: Number of items in the returned page
  - **pageNumber**: Which page from the whole list will be returned
  - **sort**: Chooses the field that the list will be sorted by
  - **sortType**: Defines the sorting order. ASC is used for ascendant order. DSC is used for descendant order