### PR TITLE
Remove Update User endpoint in License Manager API

### DIFF
--- a/VTEX - License Manager API.json
+++ b/VTEX - License Manager API.json
@@ -79,66 +79,6 @@
                     }
                 },
                 "deprecated": false
-            },
-            "put": {
-                "tags": ["User"],
-                "summary": "Update User",
-                "description": "",
-                "operationId": "UpdateUser",
-                "parameters": [
-                    {
-                        "name": "accountName",
-                        "in": "path",
-                        "required": true,
-                        "description": "Name of the VTEX account. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "apiexamples"
-                        }
-                    },
-                    {
-                        "name": "environment",
-                        "in": "path",
-                        "required": true,
-                        "description": "Environment to use. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "vtexcommercestable"
-                        }
-                    },
-                    {
-                        "name": "userId",
-                        "in": "path",
-                        "description": "",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateUserRequest"
-                            },
-                            "example": {
-                                "email": "mynewuser@mydomain.com",
-                                "name": "My New User Name Changed"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "headers": {}
-                    }
-                },
-                "deprecated": false
             }
         },
         "/api/license-manager/users": {


### PR DESCRIPTION
Removing endpoint like described in the task [EDU-2109](https://vtex-dev.atlassian.net/browse/EDU-2109) and this [slack thread](https://vtex.slack.com/archives/C01665CRT5Z/p1598626315003500).