### PR TITLE
Update VTEX - Orders API.json

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -519,6 +519,18 @@
                             "type": "string",
                             "default": "creationDate:[2016-01-01T02:00:00.000Z TO 2021-01-01T01:59:59.999Z]"
                         }
+                    },
+                    {
+                        "name": "f_hasInputInvoice",
+                        "in": "query",
+                        "description": "Filters list to return only orders with non `null` values for the `invoiceInput` field.",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
Inclusion of `f_hasInputInvoice` query param to GET List orders endpoint of the orders API.

- [x] Tested in Postman
- [x] Readme [preview](https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/Orders-filter-hasInputInvoice-02032021/VTEX%20-%20Orders%20API.json) 

(EDU-3145 - Feedback #932)

#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
