### PR TITLE
Update VTEX - Checkout API.json

### DIFF
--- a/VTEX - Checkout API.json
+++ b/VTEX - Checkout API.json
@@ -602,7 +602,7 @@
         "deprecated": false
       }
     },
-    "/api/checkout/changeToAnonymousUser/{orderFormId}": {
+    "/checkout/changeToAnonymousUser/{orderFormId}": {
       "get": {
         "tags": ["OrderForm"],
         "summary": "Remove all personal data",


### PR DESCRIPTION
Removing `/api` from the path in the GET `Remove all personal data` endpoint.

(EDU-3093 - Feedback #918)
Readme [preview](https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/Checkout-fix-path-remove-personal-data-02032021/VTEX%20-%20Checkout%20API.json) 

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
