### PR TITLE
Update VTEX - Giftcard Provider Protocol.json

### DIFF
--- a/VTEX - Giftcard Provider Protocol.json
+++ b/VTEX - Giftcard Provider Protocol.json
@@ -265,7 +265,6 @@
 									"balance": 5.9,
 									"emissionDate": "2018-03-20T09:37:13.797",
 									"expiringDate": "2020-03-18T11:42:55.183",
-									"discount": false,
 									"transaction": {
 										"href": "/gatewayqa/giftcards/3b1abc17-988e-4a14-8b7f-31fc6a5b955c_24/transactions"
 									}


### PR DESCRIPTION
#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [X] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

#### What has changed:
The `discount` field is deprecated so it has been removed from the response example (200 OK) of the https://developers.vtex.com/vtex-rest-api/reference/gift-card#getgiftcardbyid endpoint.

Preview link: https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/fda328c7adc266bc2326705b8632c16530e4526e/VTEX%20-%20Giftcard%20Provider%20Protocol.json