### PR TITLE
Update VTEX - Logistics API.json

### DIFF
--- a/VTEX - Logistics API.json
+++ b/VTEX - Logistics API.json
@@ -141,6 +141,140 @@
                         "description": "OK"
                     }
                 }
+            },
+            "put": {
+                "tags": [
+                    "Shipping Policies"
+                ],
+                "summary": "Update Shipping Policy",
+                "description": "This endpoint updates information on existing Shipping Policies from carriers.",
+                "parameters": [{
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "example": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "example": "application/json"
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "description": "Shipping policy's ID",
+                        "schema": {
+                            "type": "string",
+                            "default": "shippingpolicyid1"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "title": "Request body",
+                                "default": {},
+                                "required": [
+                                    "name",
+                                    "shippingMethod",
+                                    "deliveryOnWeekends",
+                                    "maxDimension",
+                                    "isActive"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "name",
+                                        "description": "Name of the shipping policy",
+                                        "default": "Correios PAC"
+                                    },
+                                    "shippingMethod": {
+                                        "type": "string",
+                                        "title": "shippingMethod",
+                                        "description": "Type of shipping available for this shipping policy (carrier). Options shown on freight simulation.",
+                                        "default": "Normal"
+                                    },
+                                    "deliveryOnWeekends": {
+                                        "type": "boolean",
+                                        "title": "deliveryOnWeekends",
+                                        "description": "If the shipping policy (carrier) delivers on weekends",
+                                        "default": false
+                                    },
+                                    "maxDimension": {
+                                        "type": "object",
+                                        "title": "maxDimension",
+                                        "description": "Object containing attributes of maximum dimension permitted by the shipping policy (carrier).",
+                                        "default": {},
+                                        "required": [
+                                            "largestMeasure",
+                                            "maxMeasureSum"
+                                        ],
+                                        "properties": {
+                                            "largestMeasure": {
+                                                "type": "number",
+                                                "title": "largestMeasure",
+                                                "description": "Largest measure of the package.",
+                                                "default": 0.0
+                                            },
+                                            "maxMeasureSum": {
+                                                "type": "number",
+                                                "title": "maxMeasureSum",
+                                                "description": "Sum of all maximum measures of the package.",
+                                                "default": 0.0
+                                            }
+                                        }
+                                    },
+                                    "isActive": {
+                                        "type": "boolean",
+                                        "title": "isActive",
+                                        "description": "If the shipping policy is active or not.",
+                                        "default": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/shipping-policies": {
@@ -603,140 +737,6 @@
                                         "title": "isActive",
                                         "description": "",
                                         "default": false
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "Shipping Policies"
-                ],
-                "summary": "Update Shipping Policy",
-                "description": "This endpoint updates information on existing Shipping Policies from carriers.",
-                "parameters": [{
-                        "name": "accountName",
-                        "in": "path",
-                        "required": true,
-                        "description": "Name of the VTEX account. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "apiexamples"
-                        }
-                    },
-                    {
-                        "name": "environment",
-                        "in": "path",
-                        "required": true,
-                        "description": "Environment to use. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "vtexcommercestable"
-                        }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "example": "application/json"
-                        }
-                    },
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Type of the content being sent",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "example": "application/json"
-                        }
-                    },
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "description": "Shipping policy's ID",
-                        "schema": {
-                            "type": "string",
-                            "default": "shippingpolicyid1"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "requestBody": {
-                    "description": "",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "title": "Request body",
-                                "default": {},
-                                "required": [
-                                    "name",
-                                    "shippingMethod",
-                                    "deliveryOnWeekends",
-                                    "maxDimension",
-                                    "isActive"
-                                ],
-                                "properties": {
-                                    "name": {
-                                        "type": "string",
-                                        "title": "name",
-                                        "description": "Name of the shipping policy",
-                                        "default": "Correios PAC"
-                                    },
-                                    "shippingMethod": {
-                                        "type": "string",
-                                        "title": "shippingMethod",
-                                        "description": "Type of shipping available for this shipping policy (carrier). Options shown on freight simulation.",
-                                        "default": "Normal"
-                                    },
-                                    "deliveryOnWeekends": {
-                                        "type": "boolean",
-                                        "title": "deliveryOnWeekends",
-                                        "description": "If the shipping policy (carrier) delivers on weekends",
-                                        "default": false
-                                    },
-                                    "maxDimension": {
-                                        "type": "object",
-                                        "title": "maxDimension",
-                                        "description": "Object containing attributes of maximum dimension permitted by the shipping policy (carrier).",
-                                        "default": {},
-                                        "required": [
-                                            "largestMeasure",
-                                            "maxMeasureSum"
-                                        ],
-                                        "properties": {
-                                            "largestMeasure": {
-                                                "type": "number",
-                                                "title": "largestMeasure",
-                                                "description": "Largest measure of the package.",
-                                                "default": 0.0
-                                            },
-                                            "maxMeasureSum": {
-                                                "type": "number",
-                                                "title": "maxMeasureSum",
-                                                "description": "Sum of all maximum measures of the package.",
-                                                "default": 0.0
-                                            }
-                                        }
-                                    },
-                                    "isActive": {
-                                        "type": "boolean",
-                                        "title": "isActive",
-                                        "description": "If the shipping policy is active or not.",
-                                        "default": true
                                     }
                                 }
                             }


### PR DESCRIPTION
Logistics API
Shipping policies section

Migrated the `PUT` call to the `/shipping-policies/{id}` path, where it should actually be, since the call updates a specific shipping policy.

This is the result of an informal docs feedback from the Logistics team.

[Readme preview](https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/Logistics-correct-shipping-policies-put-path-13042021/VTEX%20-%20Logistics%20API.json)

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
