### PR TITLE
Orders new feed and hook config 19022021

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -4696,7 +4696,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/TestJSONExpression"
+                                "$ref": "#/components/schemas/TestJSONataExpression"
                             },
                             "example": {
                                 "Expression": "status = \"canceled\"",

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -2762,8 +2762,8 @@
         "/api/orders/feed/config": {
             "post": {
                 "tags": ["Feed v3"],
-                "summary": "Update Feed Configuration",
-                "description": "Configures the filter rule applied to Feed V3.",
+                "summary": "Create or update feed configuration",
+                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions in our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
                 "operationId": "FeedConfiguration",
                 "parameters": [
                     {
@@ -2816,22 +2816,33 @@
                             "schema": {
                                 "$ref": "#/components/schemas/FeedConfigurationRequest"
                             },
-                            "example": {
-                                "filter": {
-                                    "status": [
-                                        "order-completed",
-                                        "start-handling",
-                                        "handling",
-                                        "ready-for-handling",
-                                        "waiting-ffmt-authorization",
-                                        "cancel"
-                                    ]
+                            "example": [
+                                {
+                                    "filter": {
+                                        "type": "FromOrders",
+                                        "expression": "value > 100",
+                                        "disableSingleFire": false
+                                    },
+                                    "queue": {
+                                        "visibilityTimeoutInSeconds": 250,
+                                        "MessageRetentionPeriodInSeconds": 345600
+                                    }
                                 },
-                                "queue": {
-                                    "visibilityTimeoutInSeconds": 250,
-                                    "MessageRetentionPeriodInSeconds": 345600
+                                {
+                                    "filter": {
+                                        "type": "FromWorkflow",
+                                        "status": [
+                                            "handling",
+                                            "ready-for-handling",
+                                            "start-handling"
+                                        ]
+                                    },
+                                    "queue": {
+                                        "visibilityTimeoutInSeconds": 250,
+                                        "MessageRetentionPeriodInSeconds": 345600
+                                    }
                                 }
-                            }
+                            ]
                         }
                     },
                     "required": true
@@ -9589,45 +9600,63 @@
                         "$ref": "#/components/schemas/Queue"
                     }
                 },
-                "example": {
-                    "filter": {
-                        "status": [
-                            "order-completed",
-                            "start-handling",
-                            "handling",
-                            "ready-for-handling",
-                            "waiting-ffmt-authorization",
-                            "cancel"
-                        ]
+                "example": [
+                    {
+                        "filter": {
+                            "type": "FromWorkflow",
+                            "status": [
+                                "order-completed",
+                                "start-handling",
+                                "handling",
+                                "ready-for-handling",
+                                "waiting-ffmt-authorization",
+                                "cancel"
+                            ]
+                        },
+                        "queue": {
+                            "visibilityTimeoutInSeconds": 250,
+                            "MessageRetentionPeriodInSeconds": 345600
+                        }
                     },
-                    "queue": {
-                        "visibilityTimeoutInSeconds": 250,
-                        "MessageRetentionPeriodInSeconds": 345600
+                    {
+                        "filter": {
+                            "type": "FromOrders",
+                            "expression": "value > 100",
+                            "disableSingleFire": false
+                        },
+                        "queue": {
+                            "visibilityTimeoutInSeconds": 250,
+                            "MessageRetentionPeriodInSeconds": 345600
+                        }
                     }
-                }
+                ]
             },
             "Filter": {
                 "title": "Filter",
-                "required": ["status"],
+                "required": ["type"],
                 "type": "object",
                 "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Determines what orders appear in the feed and how they are filtered. If a feed has the `FromWorkflow` type configuration, it will receive order updates only when order’s statuses change and orders can be filtered by status, using the `status` field. A feed with the `FromOrders` type configuration gets updates whenever any change is made to an order. in this case, orders can be filtered by any property, according to JSONata expressions passed in the `expression` field.",
+                        "default": "FromWorkflow"
+                    },
                     "status": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         },
-                        "description": ""
+                        "description": "List of order statuses that should be included in the feed. Should only be used in case `type` is `FromWorkflow`."
+                    },
+                    "expression": {
+                        "type": "string",
+                        "description": "JSONata query expression that defines what conditions must be met for an order to be included in the feed. Should only be used in case `type` is `FromOrders`."
+                    },
+                    "disableSingleFire": {
+                        "type": "boolean",
+                        "description": "Sets a limit to how many times a specific order shows on the feed, after it first meets filtering conditions. Using the `FromOrders` type configuration with JSONata filtering expressions might cause orders to appear more than once on a feed, whenever changes are made to that order. If this field is `false` orders will appear in the feed only once.",
+                        "default": false
                     }
-                },
-                "example": {
-                    "status": [
-                        "order-completed",
-                        "start-handling",
-                        "handling",
-                        "ready-for-handling",
-                        "waiting-ffmt-authorization",
-                        "cancel"
-                    ]
                 }
             },
             "Queue": {

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -2647,7 +2647,7 @@
             "post": {
                 "tags": ["Feed v3"],
                 "summary": "Create or update feed configuration",
-                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
+                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/test-jsonata-expression).",
                 "operationId": "FeedConfiguration",
                 "parameters": [
                     {
@@ -3043,9 +3043,9 @@
                 "deprecated": false
             },
             "post": {
-                "tags": ["Order Hook"],
+                "tags": ["Order hook"],
                 "summary": "Create or update hook configuration",
-                "description": "Configures filtering rules applied to Order Hook.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
+                "description": "Configures filtering rules applied to Order Hook.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/test-jsonata-expression).",
                 "operationId": "HookConfiguration",
                 "parameters": [
                     {
@@ -4624,6 +4624,97 @@
                                     },
                                     "authorizedDate": "2019-01-28T20:33:04+00:00",
                                     "invoicedDate": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/orders/expressions/jsonata": {
+            "post": {
+                "tags": ["Feed V3", "Order hook"],
+                "summary": "Test JSONata expression",
+                "description": "This endpoint allows you to test a JSON document with a JSONata expression, returning `true` if the document meets the criteria posed in the expression or `false` if it does not.\n\r\n\rSince JSONata expressions can be used to filter order updates in the [Orders API feed and hook](https://developers.vtex.com/vtex-developer-docs/reference/feed-v3), this endpoint can be used to test an expression’s results before configuring the [feed](https://developers.vtex.com/vtex-developer-docs/reference/feed-v3#feedconfiguration) or [hook](https://developers.vtex.com/vtex-developer-docs/reference/order-hook#hookconfiguration).\n\r\n\rLearn more about how to use JSONata expressions, in the [JSONata documentation](https://docs.jsonata.org/overview.html).",
+                "operationId": "TestJSONataExpression",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TestJSONExpression"
+                            },
+                            "example": {
+                                "Expression": "status = \"canceled\"",
+                                "Document": "{\"status\":\"canceled\"}"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {},
+                        "content": {
+                            "text/plain": {
+                                "examples": {
+                                    "response": {
+                                        "value": "True"
+                                    }
                                 }
                             }
                         }
@@ -11574,6 +11665,20 @@
                     "authorizedDate": "2019-01-28T20:33:04+00:00",
                     "invoicedDate": null
                 }
+            },
+            "TestJSONataExpression": {
+                    "type": "object",
+                    "required": ["Expression", "Document"],
+                    "properties": {
+                        "Expression": {
+                            "type": "string",
+                            "description": "JSONata expression to be tested."
+                        },
+                        "Document": {
+                            "type": "string",
+                            "description": "JSON document to be evaluated by the expression."
+                        }
+                    }
             }
         }
     },
@@ -11598,14 +11703,14 @@
             "description": "Check this article to learn more about the OMS feed: https://help.vtex.com/en/tutorial/how-the-oms-feed-works"
         },
         {
-            "name": "Order Hook"
+            "name": "Order hook"
         },
         {
-            "name": "Export Order Report",
+            "name": "Export order report",
             "description": "Check export request by status"
         },
         {
-            "name": "User Orders"
+            "name": "User orders"
         }
     ]
 }

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -4699,8 +4699,8 @@
                                 "$ref": "#/components/schemas/TestJSONataExpression"
                             },
                             "example": {
-                                "Expression": "status = \"canceled\"",
-                                "Document": "{\"status\":\"canceled\"}"
+                                "Expression": "status = \\\"canceled\\\"",
+                                "Document": "{\\\"status\\\":\\\"canceled\\\"}"
                             }
                         }
                     }

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -4699,8 +4699,8 @@
                                 "$ref": "#/components/schemas/TestJSONataExpression"
                             },
                             "example": {
-                                "Expression": "status = \"\"canceled\"\"",
-                                "Document": "{\"\"status\"\":\"\"canceled\"\"}"
+                                "Expression": "status = \"canceled\"",
+                                "Document": "{\"status\":\"canceled\"}"
                             }
                         }
                     }

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -16,7 +16,7 @@
         "/api/oms/pvt/orders/{orderId}": {
             "get": {
                 "tags": ["Orders"],
-                "summary": "Get Order",
+                "summary": "Get order",
                 "description": "Lists order details by searching through order ID.",
                 "operationId": "GetOrder",
                 "parameters": [
@@ -462,7 +462,7 @@
         "/api/oms/pvt/orders": {
             "get": {
                 "tags": ["Orders"],
-                "summary": "List Orders",
+                "summary": "List orders",
                 "description": "Retrieve a list of orders according to the filters described below.",
                 "operationId": "ListOrders",
                 "parameters": [
@@ -1194,7 +1194,7 @@
         "/api/oms/pvt/orders/{orderId}/start-handling": {
             "post": {
                 "tags": ["Orders"],
-                "summary": "Start Handling Order",
+                "summary": "Start handling order",
                 "description": "Change a Status Order to start-handling by Order ID. For example: in case you need change to {{start-handling}} the order status of order Id {{v5025004rjc-09}}, you will have to replace the variables {{orderId}} for {{v5025004rjc-09}} and status to {{start-handling}}",
                 "operationId": "StartHandling",
                 "parameters": [
@@ -1275,7 +1275,7 @@
         "/api/oms/pvt/orders/{orderId}/cancel": {
             "post": {
                 "tags": ["Orders"],
-                "summary": "Cancel Order",
+                "summary": "Cancel order",
                 "description": "You should use this endpoint to cancel an order by its order identification number (the `orderId`).\n\nA common scenario is one where the seller has a problem with the order fulfillment and needs to request the order cancellation to the marketplace. To do this, the seller would need to make this request, passing the `orderId` in the URL.\n\nThere should be no body in this request.\n\nYou should expect a response with the date when the notification was received, the orderId, and a receipt protocol code.\n\nBe aware that if the order status is already `Invoiced`, the order can only be canceled if—before using this request—you send a return invoice through the [Order Invoice Notification endpoint](https://developers.vtex.com/reference/invoice#invoicenotification).",
                 "operationId": "CancelOrder",
                 "parameters": [
@@ -1344,7 +1344,7 @@
         "/api/oms/pvt/orders/{orderId}/changes": {
             "post": {
                 "tags": ["Orders"],
-                "summary": "Register Change on Order",
+                "summary": "Register change on order",
                 "description": "Register an order change of product or amount. Order status that allows Order Change: {{handling}}, {{waiting-for-fulfillment}}, and {{ready-for-invoicing}}.",
                 "operationId": "RegisterChange",
                 "parameters": [
@@ -1455,7 +1455,7 @@
         "/api/oms/pvt/orders/{orderId}/interactions": {
             "post": {
                 "tags": ["Orders"],
-                "summary": "Add Log in Orders",
+                "summary": "Add log in orders",
                 "description": "Add a Log in Interactions Order Array.",
                 "operationId": "AddLog",
                 "parameters": [
@@ -1539,7 +1539,7 @@
         "/api/oms/pvt/orders/{orderId}/message-attachment": {
             "get": {
                 "tags": ["Orders"],
-                "summary": "List Order Attachment",
+                "summary": "List order attachment",
                 "description": "Retrieve an order attachment, by its name and order ID. For example, in case you need to get an attachment from order ID {{v5025004rjc-09}}, you should replace the variables {{orderId}} for {{v5025004rjc-09}} and {{attachmentName}} for the correspondent name of the attachment you're searching for.",
                 "operationId": "GetAttachment",
                 "parameters": [
@@ -1620,7 +1620,7 @@
         "/api/oms/pvt/orders/{orderId}/invoice": {
             "post": {
                 "tags": ["Invoice"],
-                "summary": "Order Invoice Notification",
+                "summary": "Order invoice notification",
                 "description": "Once the order is invoiced, the seller should use this request to send the invoice information to the marketplace.\n\nWe strongly recommend that you always send the object of the invoiced items. With this practice, rounding errors will be avoided.\n\nIt is not allowed to use the same `invoiceNumber` in more than one request to the Order Invoice Notification endpoint.\n\nBe aware that this endpoint is also used by the seller to send the order tracking information. This, however, should be done in a separate moment, once the seller has the tracking information.",
                 "operationId": "InvoiceNotification",
                 "parameters": [
@@ -1731,7 +1731,7 @@
         "/api/oms/pvt/orders/{orderId}/invoice/{invoiceNumber}": {
             "patch": {
                 "tags": ["Invoice"],
-                "summary": "Update Order's partial invoice (Send Tracking Number)",
+                "summary": "Update order's partial invoice (send tracking number)",
                 "description": "Update invoice of a given order, with its tracking number.",
                 "operationId": "Updatepartialinvoice.SendTrackingNumber",
                 "parameters": [
@@ -1839,7 +1839,7 @@
         "/api/oms/pvt/orders/{orderId}/invoice/{invoiceNumber}/tracking": {
             "put": {
                 "tags": ["Tracking"],
-                "summary": "Update Order Tracking Status",
+                "summary": "Update order tracking status",
                 "description": "Sends a tracking event to an order, by order ID.",
                 "operationId": "UpdateTrackingStatus",
                 "parameters": [
@@ -2070,7 +2070,7 @@
         "/api/oms/pvt/orders/{orderId}/conversation-message": {
             "get": {
                 "tags": ["Conversation"],
-                "summary": "Retrieve Order Conversation",
+                "summary": "Retrieve order conversation",
                 "description": "Lists all order conversations by Order ID. For example: in case you need to get details from the conversation in the Order {{v5025004rjc-09}}, you will have to replace the variables {{orderId}} for {{v5025004rjc-09}}.",
                 "operationId": "GetConversation",
                 "parameters": [
@@ -2330,7 +2330,7 @@
         "/api/oms/pvt/orders/{orderId}/payment-transaction": {
             "get": {
                 "tags": ["Payment"],
-                "summary": "Retrieve Payment transaction",
+                "summary": "Retrieve payment transaction",
                 "description": "Retrievew transaction details by order ID.",
                 "operationId": "GetPaymenttransaction",
                 "parameters": [
@@ -2439,7 +2439,7 @@
         "/api/oms/pvt/orders/{orderId}/payments/{paymentId}/payment-notification": {
             "post": {
                 "tags": ["Payment"],
-                "summary": "Send Payment Notification",
+                "summary": "Send payment notification",
                 "description": "Send a payment notification of a given order, by order ID.",
                 "operationId": "SendPaymentNotification",
                 "parameters": [
@@ -2763,7 +2763,7 @@
             "post": {
                 "tags": ["Feed v3"],
                 "summary": "Create or update feed configuration",
-                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
+                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
                 "operationId": "FeedConfiguration",
                 "parameters": [
                     {
@@ -2988,7 +2988,7 @@
             "post": {
                 "tags": ["Order Hook"],
                 "summary": "Create or update hook configuration",
-                "description": "Configure filter rules to Order Hook",
+                "description": "Configures filtering rules applied to Order Hook.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
                 "operationId": "HookConfiguration",
                 "parameters": [
                     {
@@ -3173,7 +3173,7 @@
         "/api/oms/pvt/admin/reports/completed": {
             "get": {
                 "tags": ["Export Order Report"],
-                "summary": "Export Order Report with Status 'Completed'",
+                "summary": "Export order report with status 'Completed'",
                 "description": "Retrieves a list of all order reports that are 'completed', by 'accountName'.",
                 "operationId": "StatusCompleted",
                 "parameters": [
@@ -3383,7 +3383,7 @@
         "/api/oms/pvt/admin/reports/inprogress": {
             "get": {
                 "tags": ["Export Order Report"],
-                "summary": "Export Order Report with Status 'In Progress'",
+                "summary": "Export order report with status 'In Progress'",
                 "description": "Retrieves a list of all order reports that are 'in progress', by 'accountName'.",
                 "operationId": "StatusInProgress",
                 "parameters": [
@@ -3583,7 +3583,7 @@
         "/api/oms/user/orders": {
             "get": {
                 "tags": ["User Orders"],
-                "summary": "Retrieve User's orders",
+                "summary": "Retrieve user's orders",
                 "description": "Lists all orders from a given client, filtering by their email.",
                 "operationId": "Userorderslist",
                 "parameters": [
@@ -4120,7 +4120,7 @@
         "/api/oms/user/orders/{orderId}": {
             "get": {
                 "tags": ["User Orders"],
-                "summary": "Retrieve User Order Details",
+                "summary": "Retrieve user order details",
                 "description": "Lists all details from a user's order, through client's perspective.",
                 "operationId": "Userorderdetails",
                 "parameters": [

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -9861,10 +9861,12 @@
                 "properties": {
                     "visibilityTimeoutInSeconds": {
                         "type": "integer",
+                        "description": "Period of time for which an item is not visible in the feed after it has been retrieved with the Get feed items request. Measured in seconds.",
                         "format": "int32"
                     },
                     "MessageRetentionPeriodInSeconds": {
                         "type": "integer",
+                        "description": "Maximum life span of an order update after it gets to the feed. When a feed item is on the feed for this period of time, it is removed from the feed. Measured in seconds.",
                         "format": "int32"
                     }
                 },

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -4699,8 +4699,8 @@
                                 "$ref": "#/components/schemas/TestJSONataExpression"
                             },
                             "example": {
-                                "Expression": "status = \"canceled\"",
-                                "Document": "{\"status\":\"canceled\"}"
+                                "Expression": "status = \"\"canceled\"\"",
+                                "Document": "{\"\"status\"\":\"\"canceled\"\"}"
                             }
                         }
                     }

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -2586,12 +2586,12 @@
                 "deprecated": false
             }
         },
-        "/api/orders/feed": {
+        "/api/orders/feed/config": {
             "get": {
                 "tags": ["Feed v3"],
-                "summary": "Retrieve feed order status",
-                "description": "Lists feed order events.",
-                "operationId": "Getfeedorderstatus1",
+                "summary": "Get feed configuration",
+                "description": "Lists a given Feed's configuration details.",
+                "operationId": "GetFeedConfiguration",
                 "parameters": [
                     {
                         "name": "accountName",
@@ -2614,15 +2614,14 @@
                         }
                     },
                     {
-                        "name": "maxlot",
-                        "in": "query",
-                        "description": "",
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
                         "required": true,
-                        "style": "form",
-                        "explode": true,
+                        "style": "simple",
                         "schema": {
                             "type": "string",
-                            "default": "{{maxLot}}"
+                            "default": "application/json"
                         }
                     },
                     {
@@ -2635,135 +2634,20 @@
                             "type": "string",
                             "default": "application/json"
                         }
-                    },
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Type of the content being sent",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Getfeedorderstatus"
-                                    }
-                                },
-                                "example": [
-                                    {
-                                        "eventId": "ED423DDED4C1AE580CADAC1A4D02DA3F",
-                                        "handle": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoidnRleGFwcGtleS1wYXJ0bmVyc2xhdGFtLVJNQkpNUyIsIkFwcEtleSI6InZ0ZXhhcHBrZXktcGFydG5lcnNsYXRhbS1STUJKTVMiLCJBY2NvdW50IjoicGFydG5lcnNsYXRhbSIsIkhhbmRsZSI6IkFRRUIzbmtWR0piOXhhNGRjYlpkOTFVVWMyL2JObHc0Qnp3ZlNLV201Rjg2QXgrSGlRM053bEJkb2NwM2wvVytLdjFNQTZ4d3ZLcFYwYjlSeUttNVRpb3hrSVFMSG1Uck9xenB2aFlwU29uMzRrVmlNaWZHY2lnZFFqalBJdk00eWU4amVuaS9QKytaTmVxOFZWeFNGay81Yzg3YS84MTRjTFg2WGZPR2x2WitlTnVjTzA3S3UxK0xXaU5vQmJEY0cycGxKekxkRks3Qld3b1NTV3BmSWhrOGhmSFNkSzlzZVpJeG01QXFLbHFrUHNDNGk5emVaYVpBUVVrSi9aZWo3UjRrRDVRaXFjNmpjcnFheEdHc1lsNHMzUWM0ZmtWdmhYblJVQ2l2ZGdpMEtUYS8zcXlWWU9QTktIV2huTlZxMEZHNDNjME4vaWh6dDc0d1laNVl6aDFJRitHU2t1YTkrN1pCdnQ2VGs1cFRhZmVVclk0ckNPL2Fobnl1eXFLOG53ZkorVWxUTmt2ZVNFS29FdTNiUWQzSmc5R1lYWHlXOVVxRGo5dHJIZ1N5M3ZZa0dBWjd0MDZNZWUwQnBsdFBxWExaIiwiT3JkZXJJZCI6Ijk1MzcxMjAwNDEyNi0wMSIsIk1lc3NhZ2VJZCI6ImI5YjI4NDkwLTNjNzAtNDdjNi1hMTE3LWNhN2FjMTk2MDY1OSIsIkRvbWFpbiI6IkZ1bGZpbGxtZW50IiwiU3RhdGUiOiJyZWFkeS1mb3ItaGFuZGxpbmciLCJMYXN0U3RhdGUiOiJ3aW5kb3ctdG8tY2FuY2VsIiwiTGFzdENoYW5nZSI6IjA4LzEyLzIwMTkgMjA6NTQ6MDEiLCJDdXJyZW50Q2hhbmdlIjoiMDgvMTIvMjAxOSAyMDo1NDoyMyIsIkNyZWF0ZWRBdCI6IjA4LzEyLzIwMTkgMjE6MDE6MzAiLCJpc3MiOiJicm9hZGNhc3QtYXBpLnZ0ZXhjb21tZXJjZS5jb20uYnIiLCJhdWQiOiJwYXJ0bmVyc2xhdGFtX3Z0ZXhhcHBrZXktcGFydG5lcnNsYXRhbS1STUJKTVMifQ.7RQBZQb6pHhFhA_jMKTiSoJbDck7awgD3Xx7sdJcW6w",
-                                        "domain": "Fulfillment",
-                                        "state": "ready-for-handling",
-                                        "lastState": "window-to-cancel",
-                                        "orderId": "953712004126-01",
-                                        "lastChange": "2019-08-12T20:54:01.134057Z",
-                                        "currentChange": "2019-08-12T20:54:23.7153839Z"
-                                    }
-                                ]
-                            }
-                        }
+                        "headers": {}
                     }
                 },
                 "deprecated": false
             },
             "post": {
                 "tags": ["Feed v3"],
-                "summary": "Commit item feed order status",
-                "description": "Acknowledges an item's feed order status.",
-                "operationId": "Commititemfeedorderstatus",
-                "parameters": [
-                    {
-                        "name": "accountName",
-                        "in": "path",
-                        "required": true,
-                        "description": "Name of the VTEX account. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "apiexamples"
-                        }
-                    },
-                    {
-                        "name": "environment",
-                        "in": "path",
-                        "required": true,
-                        "description": "Environment to use. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "vtexcommercestable"
-                        }
-                    },
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Type of the content being sent",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CommititemfeedorderstatusRequest"
-                            },
-                            "example": {
-                                "handles": [
-                                    "AQEBSM/bSqonHYtx+UrHdbuJ0i7M9yMbI2jtYwMIPdEc4BenuneaCTC9VEJ3dgAy1XtfQvHBvgwZTO8LvGObIKNqiKXDZiMKY25vK+pblZEqf1pWdLMugu5XoHA5ZAd4IcBcXrBcrlr1GU8uvPEBoVLOsVBP9IAxIZkkeEedIDg3K6GPyEXVuPlTEYb/0OCunEGxWF+AZ1frFdXh7ulORTcuqO5oDlBGbpD+QYzCmF4mUZtQ0VVWh9icM1QBVh6PlJ0D/lfwnJKWpBn3jf8c+DTm7sD7wb1Lcz9uWMLhDtPwvH9vue4MvKU9sCahEQe7K5jWuwwb54szGbFKdfcACsTSQ9WlyBfMdbV83c27k68G3cnaBFExkC1MLHHE9UzpQ6l4s43BT4k95ocgMXffnj/HMUYXn+OCvlvjytY59x1OCRE="
-                                ]
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "headers": {},
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/orders/feed/config": {
-            "post": {
-                "tags": ["Feed v3"],
                 "summary": "Create or update feed configuration",
-                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
+                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
                 "operationId": "FeedConfiguration",
                 "parameters": [
                     {
@@ -2861,64 +2745,7 @@
                     }
                 },
                 "deprecated": false
-            },
-            "get": {
-                "tags": ["Feed v3"],
-                "summary": "Retrieve feed configuration",
-                "description": "Lists a given Feed's configuration details.",
-                "operationId": "GetFeedConfiguration",
-                "parameters": [
-                    {
-                        "name": "accountName",
-                        "in": "path",
-                        "required": true,
-                        "description": "Name of the VTEX account. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "apiexamples"
-                        }
-                    },
-                    {
-                        "name": "environment",
-                        "in": "path",
-                        "required": true,
-                        "description": "Environment to use. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "vtexcommercestable"
-                        }
-                    },
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Type of the content being sent",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "headers": {}
-                    }
-                },
-                "deprecated": false
-            },
+            },            
             "delete": {
                 "tags": ["Feed v3"],
                 "summary": "Delete feed configuration",
@@ -2984,11 +2811,241 @@
                 "deprecated": false
             }
         },
+        "/api/orders/feed": {
+            "get": {
+                "tags": ["Feed v3"],
+                "summary": "Retrieve feed items",
+                "description": "Retrieve items from feed queue.",
+                "operationId": "Getfeedorderstatus1",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "maxlot",
+                        "in": "query",
+                        "description": "Lot quantity to retrieve. Maximum accepted value is 10.",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "default": "{{maxLot}}"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Getfeedorderstatus"
+                                    }
+                                },
+                                "example": [
+                                    {
+                                        "eventId": "ED423DDED4C1AE580CADAC1A4D02DA3F",
+                                        "handle": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoidnRleGFwcGtleS1wYXJ0bmVyc2xhdGFtLVJNQkpNUyIsIkFwcEtleSI6InZ0ZXhhcHBrZXktcGFydG5lcnNsYXRhbS1STUJKTVMiLCJBY2NvdW50IjoicGFydG5lcnNsYXRhbSIsIkhhbmRsZSI6IkFRRUIzbmtWR0piOXhhNGRjYlpkOTFVVWMyL2JObHc0Qnp3ZlNLV201Rjg2QXgrSGlRM053bEJkb2NwM2wvVytLdjFNQTZ4d3ZLcFYwYjlSeUttNVRpb3hrSVFMSG1Uck9xenB2aFlwU29uMzRrVmlNaWZHY2lnZFFqalBJdk00eWU4amVuaS9QKytaTmVxOFZWeFNGay81Yzg3YS84MTRjTFg2WGZPR2x2WitlTnVjTzA3S3UxK0xXaU5vQmJEY0cycGxKekxkRks3Qld3b1NTV3BmSWhrOGhmSFNkSzlzZVpJeG01QXFLbHFrUHNDNGk5emVaYVpBUVVrSi9aZWo3UjRrRDVRaXFjNmpjcnFheEdHc1lsNHMzUWM0ZmtWdmhYblJVQ2l2ZGdpMEtUYS8zcXlWWU9QTktIV2huTlZxMEZHNDNjME4vaWh6dDc0d1laNVl6aDFJRitHU2t1YTkrN1pCdnQ2VGs1cFRhZmVVclk0ckNPL2Fobnl1eXFLOG53ZkorVWxUTmt2ZVNFS29FdTNiUWQzSmc5R1lYWHlXOVVxRGo5dHJIZ1N5M3ZZa0dBWjd0MDZNZWUwQnBsdFBxWExaIiwiT3JkZXJJZCI6Ijk1MzcxMjAwNDEyNi0wMSIsIk1lc3NhZ2VJZCI6ImI5YjI4NDkwLTNjNzAtNDdjNi1hMTE3LWNhN2FjMTk2MDY1OSIsIkRvbWFpbiI6IkZ1bGZpbGxtZW50IiwiU3RhdGUiOiJyZWFkeS1mb3ItaGFuZGxpbmciLCJMYXN0U3RhdGUiOiJ3aW5kb3ctdG8tY2FuY2VsIiwiTGFzdENoYW5nZSI6IjA4LzEyLzIwMTkgMjA6NTQ6MDEiLCJDdXJyZW50Q2hhbmdlIjoiMDgvMTIvMjAxOSAyMDo1NDoyMyIsIkNyZWF0ZWRBdCI6IjA4LzEyLzIwMTkgMjE6MDE6MzAiLCJpc3MiOiJicm9hZGNhc3QtYXBpLnZ0ZXhjb21tZXJjZS5jb20uYnIiLCJhdWQiOiJwYXJ0bmVyc2xhdGFtX3Z0ZXhhcHBrZXktcGFydG5lcnNsYXRhbS1STUJKTVMifQ.7RQBZQb6pHhFhA_jMKTiSoJbDck7awgD3Xx7sdJcW6w",
+                                        "domain": "Fulfillment",
+                                        "state": "ready-for-handling",
+                                        "lastState": "window-to-cancel",
+                                        "orderId": "953712004126-01",
+                                        "lastChange": "2019-08-12T20:54:01.134057Z",
+                                        "currentChange": "2019-08-12T20:54:23.7153839Z"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "post": {
+                "tags": ["Feed v3"],
+                "summary": "Commit feed items",
+                "description": "Commit items in the feed queue.",
+                "operationId": "Commititemfeedorderstatus",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CommititemfeedorderstatusRequest"
+                            },
+                            "example": {
+                                "handles": [
+                                    "AQEBSM/bSqonHYtx+UrHdbuJ0i7M9yMbI2jtYwMIPdEc4BenuneaCTC9VEJ3dgAy1XtfQvHBvgwZTO8LvGObIKNqiKXDZiMKY25vK+pblZEqf1pWdLMugu5XoHA5ZAd4IcBcXrBcrlr1GU8uvPEBoVLOsVBP9IAxIZkkeEedIDg3K6GPyEXVuPlTEYb/0OCunEGxWF+AZ1frFdXh7ulORTcuqO5oDlBGbpD+QYzCmF4mUZtQ0VVWh9icM1QBVh6PlJ0D/lfwnJKWpBn3jf8c+DTm7sD7wb1Lcz9uWMLhDtPwvH9vue4MvKU9sCahEQe7K5jWuwwb54szGbFKdfcACsTSQ9WlyBfMdbV83c27k68G3cnaBFExkC1MLHHE9UzpQ6l4s43BT4k95ocgMXffnj/HMUYXn+OCvlvjytY59x1OCRE="
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "headers": {},
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
         "/api/orders/hook/config": {
+            "get": {
+                "tags": ["Order Hook"],
+                "summary": "Get hook configuration",
+                "description": "Lists a given hook's configuration details.",
+                "operationId": "GetHookConfiguration",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "headers": {}
+                    }
+                },
+                "deprecated": false
+            },
             "post": {
                 "tags": ["Order Hook"],
                 "summary": "Create or update hook configuration",
-                "description": "Configures filtering rules applied to Order Hook.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
+                "description": "Configures filtering rules applied to Order Hook.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
                 "operationId": "HookConfiguration",
                 "parameters": [
                     {
@@ -3172,7 +3229,7 @@
         },
         "/api/oms/pvt/admin/reports/completed": {
             "get": {
-                "tags": ["Export Order Report"],
+                "tags": ["Export order report"],
                 "summary": "Export order report with status 'Completed'",
                 "description": "Retrieves a list of all order reports that are 'completed', by 'accountName'.",
                 "operationId": "StatusCompleted",
@@ -3382,7 +3439,7 @@
         },
         "/api/oms/pvt/admin/reports/inprogress": {
             "get": {
-                "tags": ["Export Order Report"],
+                "tags": ["Export order report"],
                 "summary": "Export order report with status 'In Progress'",
                 "description": "Retrieves a list of all order reports that are 'in progress', by 'accountName'.",
                 "operationId": "StatusInProgress",
@@ -3582,7 +3639,7 @@
         },
         "/api/oms/user/orders": {
             "get": {
-                "tags": ["User Orders"],
+                "tags": ["User orders"],
                 "summary": "Retrieve user's orders",
                 "description": "Lists all orders from a given client, filtering by their email.",
                 "operationId": "Userorderslist",
@@ -4119,7 +4176,7 @@
         },
         "/api/oms/user/orders/{orderId}": {
             "get": {
-                "tags": ["User Orders"],
+                "tags": ["User orders"],
                 "summary": "Retrieve user order details",
                 "description": "Lists all details from a user's order, through client's perspective.",
                 "operationId": "Userorderdetails",
@@ -9595,7 +9652,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": ""
+                        "description": "List of item handles to commit"
                     }
                 },
                 "example": {
@@ -9610,7 +9667,7 @@
                 "type": "object",
                 "properties": {
                     "filter": {
-                        "$ref": "#/components/schemas/Filter"
+                        "$ref": "#/components/schemas/FeedFilter"
                     },
                     "queue": {
                         "$ref": "#/components/schemas/Queue"
@@ -9647,14 +9704,14 @@
                     }
                 ]
             },
-            "Filter": {
+            "FeedFilter": {
                 "title": "Filter",
                 "required": ["type"],
                 "type": "object",
                 "properties": {
                     "type": {
                         "type": "string",
-                        "description": "Determines what orders appear in the feed / hook and how they are filtered. If a feed / hook has the `FromWorkflow` type configuration, it will receive order updates only when order’s statuses change and orders can be filtered by status, using the `status` field. A feed / hookwith the `FromOrders` type configuration gets updates whenever any change is made to an order. in this case, orders can be filtered by any property, according to JSONata expressions passed in the `expression` field.",
+                        "description": "Determines what orders appear in the feed and how they are filtered. If a feed has the `FromWorkflow` type configuration, it will receive order updates only when order’s statuses change and orders can be filtered by status, using the `status` field. A feed with the `FromOrders` type configuration gets updates whenever any change is made to an order. in this case, orders can be filtered by any property, according to JSONata expressions passed in the `expression` field.",
                         "default": "FromWorkflow"
                     },
                     "status": {
@@ -9662,15 +9719,43 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "List of order statuses that should be included in the feed / hook. This should only be used in case `type` is `FromWorkflow`."
+                        "description": "List of order statuses that should be included in the feed. This should only be used in case `type` is `FromWorkflow`."
                     },
                     "expression": {
                         "type": "string",
-                        "description": "JSONata query expression that defines what conditions must be met for an order to be included in the feed / hook. This should only be used in case `type` is `FromOrders`."
+                        "description": "JSONata query expression that defines what conditions must be met for an order to be included in the feed. This should only be used in case `type` is `FromOrders`."
                     },
                     "disableSingleFire": {
                         "type": "boolean",
-                        "description": "Sets a limit to how many times a specific order shows on the feed / hook, after it first meets filtering conditions. Using the `FromOrders` type configuration with JSONata filtering expressions might cause orders to appear more than once on a feed, whenever changes are made to that order. If this field is `false` orders will appear in the feed / hook only once.",
+                        "description": "Sets a limit to how many times a specific order shows on the feed, after it first meets filtering conditions. Using the `FromOrders` type configuration with JSONata filtering expressions might cause orders to appear more than once on a feed, whenever changes are made to that order. If this field is `false` orders will appear in the feed only once.",
+                        "default": false
+                    }
+                }
+            },
+            "HookFilter": {
+                "title": "Filter",
+                "required": ["type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Determines what orders appear in the hook and how they are filtered. If a hook has the `FromWorkflow` type configuration, it will receive order updates only when order’s statuses change and orders can be filtered by status, using the `status` field. A hook with the `FromOrders` type configuration gets updates whenever any change is made to an order. in this case, orders can be filtered by any property, according to JSONata expressions passed in the `expression` field.",
+                        "default": "FromWorkflow"
+                    },
+                    "status": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of order statuses that should be included in the hook. This should only be used in case `type` is `FromWorkflow`."
+                    },
+                    "expression": {
+                        "type": "string",
+                        "description": "JSONata query expression that defines what conditions must be met for an order to be included in the hook. This should only be used in case `type` is `FromOrders`."
+                    },
+                    "disableSingleFire": {
+                        "type": "boolean",
+                        "description": "Sets a limit to how many times a specific order shows on the hook, after it first meets filtering conditions. Using the `FromOrders` type configuration with JSONata filtering expressions might cause orders to appear more than once on a feed, whenever changes are made to that order. If this field is `false` orders will appear in the hook only once.",
                         "default": false
                     }
                 }
@@ -9703,7 +9788,7 @@
                 "type": "object",
                 "properties": {
                     "filter": {
-                        "$ref": "#/components/schemas/Filter"
+                        "$ref": "#/components/schemas/HookFilter"
                     },
                     "hook": {
                         "$ref": "#/components/schemas/Hook"

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -2763,7 +2763,7 @@
             "post": {
                 "tags": ["Feed v3"],
                 "summary": "Create or update feed configuration",
-                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions in our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
+                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/jsonata-expression-evaluation).",
                 "operationId": "FeedConfiguration",
                 "parameters": [
                     {
@@ -2864,7 +2864,7 @@
             },
             "get": {
                 "tags": ["Feed v3"],
-                "summary": "Retrieve Feed Configuration",
+                "summary": "Retrieve feed configuration",
                 "description": "Lists a given Feed's configuration details.",
                 "operationId": "GetFeedConfiguration",
                 "parameters": [
@@ -2921,7 +2921,7 @@
             },
             "delete": {
                 "tags": ["Feed v3"],
-                "summary": "Delete Feed Configuration",
+                "summary": "Delete feed configuration",
                 "description": "Deletes the configuration set up in Feed v3.",
                 "operationId": "FeedConfigurationDelete",
                 "parameters": [
@@ -2987,7 +2987,7 @@
         "/api/orders/hook/config": {
             "post": {
                 "tags": ["Order Hook"],
-                "summary": "Create or Update Hook Configuration",
+                "summary": "Create or update hook configuration",
                 "description": "Configure filter rules to Order Hook",
                 "operationId": "HookConfiguration",
                 "parameters": [
@@ -3041,23 +3041,39 @@
                             "schema": {
                                 "$ref": "#/components/schemas/HookConfigurationRequest"
                             },
-                            "example": {
-                                "filter": {
-                                    "status": [
-                                        "order-completed",
-                                        "handling",
-                                        "ready-for-handling",
-                                        "waiting-ffmt-authorization",
-                                        "cancel"
-                                    ]
+                            "example": [
+                                {
+                                    "filter": {
+                                        "type": "FromWorkflow",
+                                        "status": [
+                                            "order-completed",
+                                            "handling",
+                                            "ready-for-handling",
+                                            "waiting-ffmt-authorization",
+                                            "cancel"
+                                        ]
+                                    },
+                                    "hook": {
+                                        "url": "https://endpoint.example/path",
+                                        "headers": {
+                                            "key": "value"
+                                        }
+                                    }
                                 },
-                                "hook": {
-                                    "url": "https://endpoint.example/path",
-                                    "headers": {
-                                        "key": "value"
+                                {
+                                    "filter": {
+                                        "type": "FromOrders",
+                                        "expression": "value > 100",
+                                        "disableSingleFire": false
+                                    },
+                                    "hook": {
+                                        "url": "https://endpoint.example/path",
+                                        "headers": {
+                                            "key": "value"
+                                        }
                                     }
                                 }
-                            }
+                            ]
                         }
                     },
                     "required": true
@@ -3091,8 +3107,8 @@
             },
             "delete": {
                 "tags": ["Order Hook"],
-                "summary": "Delete Hook Configuration",
-                "description": "Deletes Hook configuration.",
+                "summary": "Delete hook configuration",
+                "description": "Deletes hook configuration.",
                 "operationId": "DeleteHookConfiguration",
                 "parameters": [
                     {
@@ -9638,7 +9654,7 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "description": "Determines what orders appear in the feed and how they are filtered. If a feed has the `FromWorkflow` type configuration, it will receive order updates only when order’s statuses change and orders can be filtered by status, using the `status` field. A feed with the `FromOrders` type configuration gets updates whenever any change is made to an order. in this case, orders can be filtered by any property, according to JSONata expressions passed in the `expression` field.",
+                        "description": "Determines what orders appear in the feed / hook and how they are filtered. If a feed / hook has the `FromWorkflow` type configuration, it will receive order updates only when order’s statuses change and orders can be filtered by status, using the `status` field. A feed / hookwith the `FromOrders` type configuration gets updates whenever any change is made to an order. in this case, orders can be filtered by any property, according to JSONata expressions passed in the `expression` field.",
                         "default": "FromWorkflow"
                     },
                     "status": {
@@ -9646,15 +9662,15 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "List of order statuses that should be included in the feed. Should only be used in case `type` is `FromWorkflow`."
+                        "description": "List of order statuses that should be included in the feed / hook. This should only be used in case `type` is `FromWorkflow`."
                     },
                     "expression": {
                         "type": "string",
-                        "description": "JSONata query expression that defines what conditions must be met for an order to be included in the feed. Should only be used in case `type` is `FromOrders`."
+                        "description": "JSONata query expression that defines what conditions must be met for an order to be included in the feed / hook. This should only be used in case `type` is `FromOrders`."
                     },
                     "disableSingleFire": {
                         "type": "boolean",
-                        "description": "Sets a limit to how many times a specific order shows on the feed, after it first meets filtering conditions. Using the `FromOrders` type configuration with JSONata filtering expressions might cause orders to appear more than once on a feed, whenever changes are made to that order. If this field is `false` orders will appear in the feed only once.",
+                        "description": "Sets a limit to how many times a specific order shows on the feed / hook, after it first meets filtering conditions. Using the `FromOrders` type configuration with JSONata filtering expressions might cause orders to appear more than once on a feed, whenever changes are made to that order. If this field is `false` orders will appear in the feed / hook only once.",
                         "default": false
                     }
                 }
@@ -9693,23 +9709,39 @@
                         "$ref": "#/components/schemas/Hook"
                     }
                 },
-                "example": {
-                    "filter": {
-                        "status": [
-                            "order-completed",
-                            "handling",
-                            "ready-for-handling",
-                            "waiting-ffmt-authorization",
-                            "cancel"
-                        ]
+                "example": [
+                    {
+                        "filter": {
+                            "type": "FromWorkflow",
+                            "status": [
+                                "order-completed",
+                                "handling",
+                                "ready-for-handling",
+                                "waiting-ffmt-authorization",
+                                "cancel"
+                            ]
+                        },
+                        "hook": {
+                            "url": "https://endpoint.example/path",
+                            "headers": {
+                                "key": "value"
+                            }
+                        }
                     },
-                    "hook": {
-                        "url": "https://endpoint.example/path",
-                        "headers": {
-                            "key": "value"
+                    {
+                        "filter": {
+                            "type": "FromOrders",
+                            "expression": "value > 100",
+                            "disableSingleFire": false
+                        },
+                        "hook": {
+                            "url": "https://endpoint.example/path",
+                            "headers": {
+                                "key": "value"
+                            }
                         }
                     }
-                }
+                ]
             },
             "Hook": {
                 "title": "Hook",

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -2647,7 +2647,7 @@
             "post": {
                 "tags": ["Feed v3"],
                 "summary": "Create or update feed configuration",
-                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-developer-docs/reference/test-jsonata-expression).",
+                "description": "Configures filtering rules applied to Feed V3.\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [Test JSONata expression](https://developers.vtex.com/vtex-developer-docs/reference/test-jsonata-expression) endpoint.",
                 "operationId": "FeedConfiguration",
                 "parameters": [
                     {


### PR DESCRIPTION
#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Orders API
New filter configuration for the feed and hook.

Updated endpoints:
Create/update feed configuration
Create/update hook configuration

New endpoint:
Test JSONata expression

[Readme preview](https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/Orders-new-feed-and-hook-config-19022021/VTEX%20-%20Orders%20API.json)