### PR TITLE
Checkout allow outdated data 29042021

### DIFF
--- a/VTEX - Checkout API.json
+++ b/VTEX - Checkout API.json
@@ -736,6 +736,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "allowOutdatedData",
+            "in": "query",
+            "description": "In order to optimize performance, this parameter allows some information to not be updated when there are changes in the minicart. For instance, if a shopper adds another unit of a given SKU to the cart, it may not be necessary to recalculate shipping or payment information, which could impact performance.",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array"
+            },
+            "example": [
+              "shippingData",
+              "paymentData"
+            ]
           }
         ],
         "requestBody": {

--- a/VTEX - Checkout API.json
+++ b/VTEX - Checkout API.json
@@ -740,7 +740,7 @@
           {
             "name": "allowOutdatedData",
             "in": "query",
-            "description": "In order to optimize performance, this parameter allows some information to not be updated when there are changes in the minicart. For instance, if a shopper adds another unit of a given SKU to the cart, it may not be necessary to recalculate shipping or payment information, which could impact performance.",
+            "description": "In order to optimize performance, this parameter allows some information to not be updated when there are changes in the minicart. For instance, if a shopper adds another unit of a given SKU to the cart, it may not be necessary to recalculate payment information, which could impact performance.\n\r\n\rCurrently, this arrays accepts strings and possible values that can be included are `”shippingData”` and/or `”paymentData”`.",
             "required": false,
             "style": "form",
             "schema": {


### PR DESCRIPTION
#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Checkout API
Update cart endpoint

Inclusion of new parameter `allowOutdatedField`.

[Readme Preview](https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/Checkout-allowOutdatedData-29042021/VTEX%20-%20Checkout%20API.json)