### PR TITLE
Subscriptions shipping address field correction 06/05/2021

### DIFF
--- a/VTEX - Subscriptions API (v3).json
+++ b/VTEX - Subscriptions API (v3).json
@@ -2505,11 +2505,13 @@
                 "properties": {
                     "addressId": {
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "description": "ID of shipping address."
                     },
                     "addressType": {
                         "type": "string",
-                        "nullable": true
+                        "nullable": true,
+                        "description": "Type of the address. Possible values are `residential` or `pickup`."
                     }
                 },
                 "additionalProperties": false

--- a/VTEX - Subscriptions API (v3).json
+++ b/VTEX - Subscriptions API (v3).json
@@ -2495,8 +2495,8 @@
                 },
                 "additionalProperties": false
             },
-            "AddressThinRequest": {
-                "title": "AddressRequest",
+            "shippingAddress": {
+                "title": "shippingAddress",
                 "required": [
                     "addressId",
                     "addressType"
@@ -2570,7 +2570,7 @@
                         "$ref": "#/components/schemas/PlanThinRequest"
                     },
                     "shippingAddress": {
-                        "$ref": "#/components/schemas/AddressThinRequest"
+                        "$ref": "#/components/schemas/shippingAddress"
                     },
                     "purchaseSettings": {
                         "$ref": "#/components/schemas/PurchaseSettingsThinRequest"
@@ -2628,7 +2628,7 @@
                         "$ref": "#/components/schemas/PlanThinRequest"
                     },
                     "shippingAddress": {
-                        "$ref": "#/components/schemas/AddressThinRequest"
+                        "$ref": "#/components/schemas/shippingAddress"
                     },
                     "purchaseSettings": {
                         "$ref": "#/components/schemas/PurchaseSettingsThinRequest"


### PR DESCRIPTION
#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Subscriptions API v3

Endpoints
> Create subscription
> Update subscription

- Updating the field previously shown as `AddressRequest` in the doc to its correct name `shippingAddress`.
- Updating `shippingAddress` field descriptions.

[Readme preview](https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/Subscriptions-shippingAddress-field-correction-06/05/2021/VTEX%20-%20Subscriptions%20API%20(v3).json)