### PR TITLE
Update VTEX - Orders API.json

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -9010,7 +9010,6 @@
                     "issuanceDate",
                     "invoiceNumber",
                     "invoiceValue",
-                    "invoiceUrl",
                     "items"
                 ],
                 "type": "object",


### PR DESCRIPTION
Orders API

Making the field `invoiceUrl` optional in the invoice notification endpoint, according to feedback in EDU-2621.

[Readme preview](https://preview.readme.io/?selected=https://raw.githubusercontent.com/vtex/openapi-schemas/Orders-invoice-notification-correction-26052021/VTEX%20-%20Orders%20API.json)

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
