### PR TITLE
Add cart on body of refund cancel with split

### DIFF
--- a/VTEX - Payments Gateway API.json
+++ b/VTEX - Payments Gateway API.json
@@ -5132,11 +5132,8 @@
 					"description": "",
 					"content": {
 						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/RefundthetransactionRequest"
-							},
-							"example": {
-								"value": 100,
+                            "example": {
+								"value": 2300,
                                 "minicart": {
                                     "items": [
                                         {
@@ -5159,6 +5156,9 @@
                                     "freight": 200,
                                     "tax": 0
                                 }
+							},
+							"schema": {
+								"$ref": "#/components/schemas/RefundthetransactionRequest"
 							}
 						}
 					},
@@ -5251,11 +5251,8 @@
 					"description": "",
 					"content": {
 						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CancelthetransactionRequest"
-							},
 							"example": {
-								"value": 100,
+                                "value": 2300,
                                 "minicart": {
                                     "items": [
                                         {
@@ -5278,6 +5275,9 @@
                                     "freight": 200,
                                     "tax": 0
                                 }
+                            },
+                            "schema": {
+								"$ref": "#/components/schemas/CancelthetransactionRequest"
 							}
 						}
 					},
@@ -8732,11 +8732,12 @@
 				"properties": {
 					"value": {
 						"type": "integer",
-						"format": "int32"
+						"format": "int32",
+                        "description": "Value of the purchase."
 					},
                     "minicart": {
                         "type": "object",
-                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment.",
+                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using [Get Orders](https://developers.vtex.com/vtex-rest-api/reference/orders#getorder) or [Transaction Details](https://developers.vtex.com/vtex-rest-api/reference/transaction-process#transactiondetails) endpoints. It should only be included for transactions with split payment.",
                         "properties": {
                             "items": {
                                 "type": "array"
@@ -8746,14 +8747,39 @@
                                 "format": "int32"
                             },
                             "tax": {
-                                "type": "intgeger",
+                                "type": "integer",
                                 "format": "int32"
+                            }
+                        },
+                        "default": {
+                            "value": 2300,
+                            "minicart": {
+                                "items": [
+                                    {
+                                        "id": "122323",
+                                        "name": "Tenis Preto I",
+                                        "value": 1000,
+                                        "quantity": 1,
+                                        "shippingDiscount": 0,
+                                        "discount": 50
+                                    },
+                                    {
+                                        "id": "122324",
+                                        "name": "Tenis Nike Azul",
+                                        "value": 1100,
+                                        "quantity": 1,
+                                        "shippingDiscount": 0,
+                                        "discount": 50
+                                    }
+                                ],
+                                "freight": 200,
+                                "tax": 0
                             }
                         }
                     }
 				},
-				"example": {
-					"value": 100,
+				"default": {
+					"value": 2300,
                     "minicart": {
                         "items": [
                             {
@@ -8787,11 +8813,12 @@
 				"properties": {
 					"value": {
 						"type": "integer",
-						"format": "int32"
+						"format": "int32",
+                        "description": "Value of the purchase."
 					},
                     "minicart": {
                         "type": "object",
-                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment.",
+                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using [Get Orders](https://developers.vtex.com/vtex-rest-api/reference/orders#getorder) or [Transaction Details](https://developers.vtex.com/vtex-rest-api/reference/transaction-process#transactiondetails) endpoints. It should only be included for transactions with split payment.",
                         "properties": {
                             "items": {
                                 "type": "array"
@@ -8801,14 +8828,39 @@
                                 "format": "int32"
                             },
                             "tax": {
-                                "type": "intgeger",
+                                "type": "integer",
                                 "format": "int32"
+                            }
+                        },
+                        "default": {
+                            "value": 2300,
+                            "minicart": {
+                                "items": [
+                                    {
+                                        "id": "122323",
+                                        "name": "Tenis Preto I",
+                                        "value": 1000,
+                                        "quantity": 1,
+                                        "shippingDiscount": 0,
+                                        "discount": 50
+                                    },
+                                    {
+                                        "id": "122324",
+                                        "name": "Tenis Nike Azul",
+                                        "value": 1100,
+                                        "quantity": 1,
+                                        "shippingDiscount": 0,
+                                        "discount": 50
+                                    }
+                                ],
+                                "freight": 200,
+                                "tax": 0
                             }
                         }
                     }
 				},
-				"example": {
-					"value": 100,
+				"default": {
+					"value": 2300,
                     "minicart": {
                         "items":[
                             {

--- a/VTEX - Payments Gateway API.json
+++ b/VTEX - Payments Gateway API.json
@@ -5136,7 +5136,29 @@
 								"$ref": "#/components/schemas/RefundthetransactionRequest"
 							},
 							"example": {
-								"value": 100
+								"value": 100,
+                                "minicart": {
+                                    "items": [
+                                        {
+                                            "id": "122323",
+                                            "name": "Tenis Preto I",
+                                            "value": 1000,
+                                            "quantity": 1,
+                                            "shippingDiscount": 0,
+                                            "discount": 50
+                                        },
+                                        {
+                                            "id": "122324",
+                                            "name": "Tenis Nike Azul",
+                                            "value": 1100,
+                                            "quantity": 1,
+                                            "shippingDiscount": 0,
+                                            "discount": 50
+                                        }
+                                    ],
+                                    "freight": 200,
+                                    "tax": 0
+                                }
 							}
 						}
 					},
@@ -5233,7 +5255,29 @@
 								"$ref": "#/components/schemas/CancelthetransactionRequest"
 							},
 							"example": {
-								"value": 100
+								"value": 100,
+                                "minicart": {
+                                    "items": [
+                                        {
+                                            "id": "122323",
+                                            "name": "Tenis Preto I",
+                                            "value": 1000,
+                                            "quantity": 1,
+                                            "shippingDiscount": 0,
+                                            "discount": 50
+                                        },
+                                        {
+                                            "id": "122324",
+                                            "name": "Tenis Nike Azul",
+                                            "value": 1100,
+                                            "quantity": 1,
+                                            "shippingDiscount": 0,
+                                            "discount": 50
+                                        }
+                                    ],
+                                    "freight": 200,
+                                    "tax": 0
+                                }
 							}
 						}
 					},
@@ -8689,10 +8733,36 @@
 					"value": {
 						"type": "integer",
 						"format": "int32"
-					}
+					},
+                    "minicart": {
+                        "type": "object",
+                        "description": "This field should only be included for transactions with split payment"
+                    }
 				},
 				"example": {
-					"value": 100
+					"value": 100,
+                    "minicart": {
+                        "items": [
+                            {
+                                "id": "122323",
+                                "name": "Tenis Preto I",
+                                "value": 1000,
+                                "quantity": 1,
+                                "shippingDiscount": 0,
+                                "discount": 50
+                            },
+                            {
+                                "id": "122324",
+                                "name": "Tenis Nike Azul",
+                                "value": 1100,
+                                "quantity": 1,
+                                "shippingDiscount": 0,
+                                "discount": 50
+                            }
+                        ],
+                        "freight": 200,
+                        "tax": 0
+                    }
 				}
 			},
 			"CancelthetransactionRequest": {
@@ -8705,10 +8775,36 @@
 					"value": {
 						"type": "integer",
 						"format": "int32"
-					}
+					},
+                    "minicart": {
+                        "type": "object",
+                        "description": "This field should only be included for transactions with split payment"
+                    }
 				},
 				"example": {
-					"value": 100
+					"value": 100,
+                    "minicart": {
+                        "items":[
+                            {
+                                "id": "122323",
+                                "name": "Tenis Preto I",
+                                "value": 1000,
+                                "quantity": 1,
+                                "shippingDiscount": 0,
+                                "discount": 50
+                            },
+                            {
+                                "id": "122324",
+                                "name": "Tenis Nike Azul",
+                                "value": 1100,
+                                "quantity": 1,
+                                "shippingDiscount": 0,
+                                "discount": 50
+                            }
+                        ],
+                        "freight": 200,
+                        "tax": 0
+                    }
 				}
 			}
 		},

--- a/VTEX - Payments Gateway API.json
+++ b/VTEX - Payments Gateway API.json
@@ -8736,7 +8736,20 @@
 					},
                     "minicart": {
                         "type": "object",
-                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment."
+                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment.",
+                        "properties": {
+                            "items": {
+                                "type": "array"
+                            },
+                            "freight": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "tax": {
+                                "type": "intgeger",
+                                "format": "int32"
+                            }
+                        }
                     }
 				},
 				"example": {
@@ -8778,7 +8791,20 @@
 					},
                     "minicart": {
                         "type": "object",
-                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment."
+                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment.",
+                        "properties": {
+                            "items": {
+                                "type": "array"
+                            },
+                            "freight": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "tax": {
+                                "type": "intgeger",
+                                "format": "int32"
+                            }
+                        }
                     }
 				},
 				"example": {

--- a/VTEX - Payments Gateway API.json
+++ b/VTEX - Payments Gateway API.json
@@ -8736,7 +8736,7 @@
 					},
                     "minicart": {
                         "type": "object",
-                        "description": "This field should only be included for transactions with split payment"
+                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment."
                     }
 				},
 				"example": {
@@ -8778,7 +8778,7 @@
 					},
                     "minicart": {
                         "type": "object",
-                        "description": "This field should only be included for transactions with split payment"
+                        "description": "This field is filled with the content of the cart of the transaction, which can be obtained using Get Orders or Transaction Details endpoints. It should only be included for transactions with split payment."
                     }
 				},
 				"example": {
@@ -8831,11 +8831,11 @@
 		},
 		{
 			"name": "Transaction Process",
-			"description": "This is meant to explain the requests that are necessary to complete a transaction using PCI Gateway"
+			"description": "This is meant to explain the requests that are necessary to complete a transaction using PCI Gateway."
 		},
 		{
 			"name": "Transaction Flow",
-			"description": "After one transaction is authorized, there is remaining to do some calls in order to complete a transaction and its payments. We explain the settle process, cancel authorized payments process, and refund process by using examples. "
+			"description": "After one transaction is authorized, there is remaining to do some calls in order to complete a transaction and its payments. We explain the settle process, cancel authorized payments process, and refund process by using examples."
 		}
 	],
 	"security": [


### PR DESCRIPTION
#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Added new field (`minicart`) in the request body of Cancel Transaction and Refund Transaction endpoints with description and example. This field has to be used only in transactions with split payment (i.e.: paying with two credit cards). The field contains the content of the cart of the transaction, which can be obtained using the [Transaction Details](https://developers.vtex.com/vtex-rest-api/reference/transaction-process#transactiondetails) or the [Get Orders](https://developers.vtex.com/vtex-rest-api/reference/orders#getorder) endpoints.