### PR TITLE
Seller lead new fields

### DIFF
--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4050,7 +4050,8 @@
                 "default":"1"
               },
               "email": {
-                "type": "string"
+                "type": "string",
+                "default": ""
               },
               "sellerType": {
                 "type": "integer",
@@ -4062,7 +4063,29 @@
                 "type": "string",
                 "description": "Marketplace's account ID",
                 "default":"5fb38ace-d95e-45ad-970d-ee97cce9fbcd"
+              },
+              "document": {
+                "type": "string",
+                "description": "Company's legal document code.",
+                "default":"12345671000"
+              },
+              "hasAcceptedLegalTerms": {
+                "type": "boolean",
+                "description": "Indicates if the seller has accepted the platform's legal terms and conditions.",
+                "default":"true"
+              },
+              "address": {
+                "type": "object",
+                "description": "Marketplace's account ID",
+                "default":"5fb38ace-d95e-45ad-970d-ee97cce9fbcd"
+              },
+              "accountable": {
+                "type": "object",
+                "description": "Person responsable for the account",
+                "default":""
               }
+
+
             },
             "example": {
               "sellerEmail": "",

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4084,8 +4084,6 @@
                 "description": "Person responsable for the account",
                 "default":""
               }
-
-
             },
             "example": {
               "sellerEmail": "",

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4055,7 +4055,7 @@
               },
               "email": {
                 "type": "string",
-                "default": ""
+                "default": "email@email.com"
               },
               "sellerType": {
                 "type": "integer",

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4079,24 +4079,97 @@
                 "default":"true"
               },
               "address": {
-                "type": "object",
-                "description": "Marketplace's account ID",
-                "default":"5fb38ace-d95e-45ad-970d-ee97cce9fbcd"
+                "$ref": "#/components/schemas/address"
               },
               "accountable": {
-                "type": "object",
-                "description": "Person responsable for the account",
-                "default":""
+                "$ref": "#/components/schemas/accountable"
+                }  
               }
-            },
-            "example": {
-              "sellerEmail": "",
-              "sellerName": "",
-              "sellerAccountName": "",
-              "salesChannel": "",
-              "email": "",
-              "sellerType": 1,
-              "accountId": ""
+          },
+          "accountable": {
+            "type": "object",
+            "title": "accountable",
+            "required": [
+                "name",
+                "email",
+                "phone"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "name",
+                    "description": "Name of the person responsible for the seller.",
+                    "default": "Jane Smith"
+                },
+                "email": {
+                    "type": "string",
+                    "title": "email",
+                    "description": "Email address of the person responsible for the seller.",
+                    "default": "email@email.com"
+                },
+                "phone": {
+                    "type": "string",
+                    "title": "phone",
+                    "description": "Phone number of the person responsible for the seller.",
+                    "default": "1234567890"
+                }
+            }
+          },
+          "address": {
+            "type": "object",
+            "title": "address",
+            "required": [
+                "postalcode",
+                "complement",
+                "street",
+                "number",
+                "neighborhood",
+                "state",
+                "city"
+            ],
+            "properties": {
+                "postalcode": {
+                    "type": "string",
+                    "title": "postalCode",
+                    "description": "Postal code from the seller's address.",
+                    "default": "12345678"
+                },
+                "complement": {
+                    "type": "string",
+                    "title": "complement",
+                    "description": "Seller's address complement.",
+                    "default": "Appartment 1234"
+                },
+                "street": {
+                    "type": "string",
+                    "title": "street",
+                    "description": "Street information, from the seller's address.",
+                    "default": "VTEX street"
+                },
+                "number": {
+                    "type": "string",
+                    "title": "number",
+                    "description": "Street's number, from the seller's address.",
+                    "default": "25"
+                },
+                "neighborhood": {
+                    "type": "string",
+                    "title": "The neighborhood schema",
+                    "description": "Seller's address neighborhood.",
+                    "default": "VTEX quarter"
+                },
+                "state": {
+                    "type": "string",
+                    "title": "state",
+                    "description": "State, from the seller's address.",
+                    "default": "RJ"
+                },
+                "city": {
+                    "type": "string",
+                    "title": "city",
+                    "description": "City name, from the seller's address.",
+                    "default": "Rio de Janeiro"
+                }
             }
           },
           "AcceptSellerLeadRequest": {

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4225,18 +4225,18 @@
                     "type": "string",
                     "description": "Company's legal document code.",
                     "default":"12345671000"
-                  },
-                  "hasAcceptedLegalTerms": {
-                    "type": "boolean",
-                    "description": "Indicates if the seller has accepted the platform's legal terms and conditions.",
-                    "default":"true"
-                  },
-                  "address": {
-                    "$ref": "#/components/schemas/address"
-                  },
-                  "accountable": {
-                    "$ref": "#/components/schemas/accountable"
-                  }
+                },
+                "hasAcceptedLegalTerms": {
+                "type": "boolean",
+                "description": "Indicates if the seller has accepted the platform's legal terms and conditions.",
+                "default":"true"
+                },
+                "address": {
+                "$ref": "#/components/schemas/address"
+                },
+                "accountable": {
+                "$ref": "#/components/schemas/accountable"
+                }
             },
             "example": {
               "sellerEmail": "",

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4181,7 +4181,12 @@
               "salesChannel",
               "email",
               "sellerType",
-              "accountId"
+              "accountId",
+              "document",
+              "hasAcceptedLegalTerms",
+              "address",
+              "accountable"
+
             ],
             "type": "object",
             "properties": {

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4025,7 +4025,11 @@
               "salesChannel",
               "email",
               "sellerType",
-              "accountId"
+              "accountId",
+              "accountable",
+              "hasAcceptedLegalTerms",
+              "address",
+              "document"
             ],
             "type": "object",
             "properties": {

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -4083,8 +4083,8 @@
               },
               "accountable": {
                 "$ref": "#/components/schemas/accountable"
-                }  
-              }
+              }  
+            }
           },
           "accountable": {
             "type": "object",
@@ -4220,6 +4220,22 @@
                     "type": "string",
                     "description": "Marketplace's account ID",
                     "default":"5fb38ace-d95e-45ad-970d-ee97cce9fbcd"
+                },
+                "document": {
+                    "type": "string",
+                    "description": "Company's legal document code.",
+                    "default":"12345671000"
+                  },
+                  "hasAcceptedLegalTerms": {
+                    "type": "boolean",
+                    "description": "Indicates if the seller has accepted the platform's legal terms and conditions.",
+                    "default":"true"
+                  },
+                  "address": {
+                    "$ref": "#/components/schemas/address"
+                  },
+                  "accountable": {
+                    "$ref": "#/components/schemas/accountable"
                   }
             },
             "example": {


### PR DESCRIPTION
#### Types of changes
[x] New content (endpoints, descriptions or fields from scratch)

Four new fields were added to our Marketplace API, specifically on the [Seller Register endpoints](https://developers.vtex.com/vtex-rest-api/reference/seller-invite-1). The fields are:
- address
- accountable
- document
- hasAcceptedLegalTerms 

They were added on the following endpoints:
- Invite Seller Lead
- Create Seller from Lead
- Accept seller lead request