### PR TITLE
Update VTEX - Orders API.json

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -9038,8 +9038,7 @@
                     },
                     "invoiceUrl": {
                         "type": "string",
-                        "nullable": true,
-                        "description": "URL of the invoice."
+                        "description": "URL of the invoice. Can be used to send the URL of an XML file, for example, which is useful for some integrations."
                     },
                     "embeddedInvoice": {
                         "type": "string",


### PR DESCRIPTION
Correcting `invoiceUrl`, which should not be required. This should have been changed with [PR 380](https://github.com/vtex/openapi-schemas/pull/380), but for some reason, the field still [shows as required](https://developers.vtex.com/vtex-developer-docs/reference/invoice).

[Readme preview](https://preview.readme.io/reference/InvoiceNotification?url=https%3A%2F%2Fraw.githubusercontent.com%2Fvtex%2Fopenapi-schemas%2FOrders-invoice-url-correction-26072021%2FVTEX+-+Orders+API.json) is ok.


#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
