### PR TITLE
Seller comissions

### DIFF
--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -2602,9 +2602,7 @@
           }
         },
         "deprecated": false
-      }
-    },
-    "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories/{categoryId}": {
+      },
       "delete": {
         "tags": [
           "Seller Commissions"
@@ -2685,7 +2683,9 @@
           }
         },
         "deprecated": false
-      },
+      }      
+    },
+    "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories/{categoryId}": {
       "get": {
         "tags": [
           "Seller Commissions"

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -2683,9 +2683,7 @@
           }
         },
         "deprecated": false
-      }      
-    },
-    "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories/{categoryId}": {
+      },
       "get": {
         "tags": [
           "Seller Commissions"
@@ -2766,7 +2764,7 @@
           }
         },
         "deprecated": false
-      }
+      }            
     },
     "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers": {
         "put": {

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -2504,7 +2504,7 @@
         "deprecated": false
       }
     },
-    "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories/{categoryId}": {
+    "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}":{
       "put": {
         "tags": [
           "Seller Commissions"
@@ -2602,7 +2602,9 @@
           }
         },
         "deprecated": false
-      },
+      }
+    },
+    "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories/{categoryId}": {
       "delete": {
         "tags": [
           "Seller Commissions"

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -2330,7 +2330,7 @@
         }
     },
     "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories": {
-        "put": {
+      "put": {
           "tags": [
             "Seller Commissions"
           ],
@@ -2430,77 +2430,79 @@
             }
           },
           "deprecated": false
-        },
-        "get": {
-          "tags": [
-            "Seller Commissions"
-          ],
-          "summary": "List Seller Commissions by seller ID",
-          "description": "This endpoint retrieves all comissions configured for a specific seller.",
-          "operationId": "ListSellerCommissions",
-          "parameters": [
-            {
-              "name": "accountName",
-              "in": "path",
-              "description": "Name of the VTEX account that belongs to the marketplace. All data extracted, and changes added will be posted into this account.",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "default": "apiexamples"
-              }
-            },
-            {
-              "name": "environment",
-              "in": "path",
-              "required": true,
-              "description": "Environment to use. Used as part of the URL.",
-              "schema": {
-                "type": "string",
-                "default": "vtexcommercestable"
-              }
-            },
-            {
-              "name": "sellerId",
-              "in": "path",
-              "description": "A string that identifies the seller in the marketplace. This ID must be created by the marketplace.",
-              "required": true,
-              "style": "simple",
-              "schema": {
-                "type": "string",
-                "default": "seller123"
-              }
-            },
-            {
-              "name": "Accept",
-              "in": "header",
-              "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
-              "required": true,
-              "style": "simple",
-              "schema": {
-              "type": "string",
-              "default": "application/json"
-              }
-          },
+      }
+    },
+    "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions":{
+      "get": {
+        "tags": [
+          "Seller Commissions"
+        ],
+        "summary": "List Seller Commissions by seller ID",
+        "description": "This endpoint retrieves all comissions configured for a specific seller.",
+        "operationId": "ListSellerCommissions",
+        "parameters": [
           {
-              "name": "Content-Type",
-              "in": "header",
-              "description": "Describes the type of the content being sent.",
-              "required": true,
-              "style": "simple",
-              "schema": {
-                  "type": "string",
-                  "default": "application/json"
-              }
-          }
-          ],
-          "responses": {
-            "200": {
-              "description": "",
-              "headers": {}
+            "name": "accountName",
+            "in": "path",
+            "description": "Name of the VTEX account that belongs to the marketplace. All data extracted, and changes added will be posted into this account.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "apiexamples"
             }
           },
-          "deprecated": false
+          {
+            "name": "environment",
+            "in": "path",
+            "required": true,
+            "description": "Environment to use. Used as part of the URL.",
+            "schema": {
+              "type": "string",
+              "default": "vtexcommercestable"
+            }
+          },
+          {
+            "name": "sellerId",
+            "in": "path",
+            "description": "A string that identifies the seller in the marketplace. This ID must be created by the marketplace.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string",
+              "default": "seller123"
+            }
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+            "type": "string",
+            "default": "application/json"
+            }
+        },
+        {
+            "name": "Content-Type",
+            "in": "header",
+            "description": "Describes the type of the content being sent.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+                "type": "string",
+                "default": "application/json"
+            }
         }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        },
+        "deprecated": false
+      }
     },
     "/{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories/{categoryId}": {
       "put": {


### PR DESCRIPTION
#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Some paths on the Seller Comissions API have changed, as [informed by the marketplace team](https://vtex.slack.com/archives/C016JGQCNF3/p1628624861014900). This PR corrects the paths in the following endpoints:

- Upsert Seller Commissions in Bulk: 
PUT `https://accountName.environment.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/categories`

- List Seller Commissions by seller ID: 
GET `https://accountName.environment.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions`

- Upsert Seller Commissions by Category ID: 
PUT `https://accountName.environment.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}`

- Remove Seller Commissions by Category ID: 
DELETE `https://accountName.environment.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}`

- Get Seller Commissions by Category ID: 
GET `https://accountName.environment.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}`
