### PR TITLE
Update VTEX - Catalog API.json

### DIFF
--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -5438,7 +5438,7 @@
                         "name": "complementTypeId",
                         "in": "path",
                         "required": true,
-                        "description": " Type of the Compliment you are inserting the SKU as. `1` = assessor; `2` = suggestion; `3` = similar; `5` = show together",
+                        "description": " Type of the complement you are inserting on the SKU. The possible values are: `1` to *assessor*; `2` to *suggestion*; `3` to *similar*; 5 to *show together*.",
                         "schema": {
                             "type": "integer",
                             "default": 1
@@ -5448,6 +5448,123 @@
                 "responses": {
                     "200": {
                         "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/catalog_system/pvt/sku/complements/{skuId}/{type}": {
+            "get": {
+                "tags": [
+                    "SKU Complement"
+                ],
+                "summary": "Get SKU complements by type",
+                "description": "Retrieves all the existing SKU complements with the same complement type ID of a specific SKU",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL.",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL.",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand ",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "skuId",
+                        "in": "path",
+                        "required": true,
+                        "description": " SKU’s unique numerical identifier",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "path",
+                        "required": true,
+                        "description": " Type of the complement you are inserting on the SKU. The possible values are: `1` to *assessor*; `2` to *suggestion*; `3` to *similar*; 5 to *show together*.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json":{
+                                "schema":{
+                                    "type": "object",
+                                    "title": "",
+                                    "required": [
+                                        "ParentSkuId",
+                                        "ComplementSkuIds",
+                                        "Type"
+                                    ],
+                                    "properties": {
+                                        "ParentSkuId": {
+                                            "type": "integer",
+                                            "title": "ParentSkuId",
+                                            "description": "SKU in which you are inserting the complement",
+                                            "default": 1
+                                        },
+                                        "ComplementSkuIds": {
+                                            "type": "array",
+                                            "title": "ComplementSkuIds",
+                                            "description": "Array with SKU complements IDs",
+                                            "default": [7],
+                                            "items": {
+                                                "type": "integer",
+                                                "title": "",
+                                                "description": "SKU Complement ID",
+                                                "default": 7
+                                            }
+                                        },
+                                        "Type": {
+                                            "type": "string",
+                                            "title": "Type",
+                                            "description": "Type of the complement you are inserting on the SKU. The possible values are: `1` to *assessor*; `2` to *suggestion*; `3` to *similar*; 5 to *show together*.",
+                                            "default": "1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -5536,7 +5653,7 @@
                                     "ComplementTypeId": {
                                         "type": "integer",
                                         "title": "ComplementTypeId",
-                                        "description": "Type of the Compliment you are inserting the SKU as. 1 = assessor; 2 = suggestion; 3 = similar; 5 = show together",
+                                        "description": "Type of the complement you are inserting on the SKU. The possible values are: `1` to *assessor*; `2` to *suggestion*; `3` to *similar*; 5 to *show together*.",
                                         "default": 1
                                     }
                                 }
@@ -5706,7 +5823,7 @@
                                     "ComplementTypeId": {
                                         "type": "integer",
                                         "title": "ComplementTypeId",
-                                        "description": "Type of the Compliment you are inserting the SKU as. 1 = assessor; 2 = suggestion; 3 = similar; 5 = show together",
+                                        "description": "Type of the complement you are inserting on the SKU. The possible values are: `1` to *assessor*; `2` to *suggestion*; `3` to *similar*; 5 to *show together*.",
                                         "default": 1
                                     }
                                 }
@@ -6971,7 +7088,7 @@
                                     "ComplementTypeId": {
                                         "type": "integer",
                                         "title": "ComplementTypeId",
-                                        "description": "Type of the Compliment you are inserting the SKU as. 1 = assessor; 2 = suggestion; 3 = similar; 5 = show together",
+                                        "description": "Type of the complement you are inserting on the SKU. The possible values are: `1` to *assessor*; `2` to *suggestion*; `3` to *similar*; 5 to *show together*.",
                                         "default": 1
                                     }
                                 }


### PR DESCRIPTION
Adding the `Get SKU complements by type` endpoint and improving some descriptions

#### Types of changes
- [X] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

[Preview](https://preview.readme.io/reference/get_api-catalog-system-pvt-sku-complements-skuid-type)