### PR TITLE
New get list brands

### DIFF
--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -12713,7 +12713,7 @@
                 ],
                 "summary": "Get Brand List Per Page",
                 "description": "Retrieves all Brands registered in the store's Catalog by page number.",
-                "operationId": "BrandList",
+                "operationId": "BrandListPerPage",
                 "parameters": [
                     {
                         "name": "accountName",
@@ -12926,7 +12926,7 @@
                                                 "page": {
                                                     "type": "integer",
                                                     "title": "page",
-                                                    "description": "Page number.",
+                                                    "description": "Page number of the brand list.",
                                                     "default": 1
                                                 },
                                                 "perPage": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -12781,10 +12781,180 @@
                 "responses": {
                     "200": {
                         "description": "",
-                        "headers": {}
+                        "content": {
+                            "application/json":{
+                                "example": {
+                                    "items": [
+                                        {
+                                            "id": 2000000,
+                                            "name": "Farm",
+                                            "isActive": true,
+                                            "title": "Farm",
+                                            "metaTagDescription": "Farm",
+                                            "imageUrl": null
+                                        },
+                                        {
+                                            "id": 2000001,
+                                            "name": "Adidas",
+                                            "isActive": true,
+                                            "title": "",
+                                            "metaTagDescription": "",
+                                            "imageUrl": null
+                                        },
+                                        {
+                                            "id": 2000002,
+                                            "name": "Brastemp",
+                                            "isActive": true,
+                                            "title": "Brastemp",
+                                            "metaTagDescription": "Brastemp",
+                                            "imageUrl": null
+                                        }
+                                    ],
+                                    "paging": {
+                                        "page": 1,
+                                        "perPage": 3,
+                                        "total": 6,
+                                        "pages": 2
+                                    }
+                                },
+                                "schema":{
+                                    "type": "object",
+                                    "title": "",
+                                    "required": [
+                                        "items",
+                                        "paging"
+                                    ],
+                                    "properties": {
+                                        "items": {
+                                            "type": "array",
+                                            "title": "items",
+                                            "description": "Array of objects with information of the store's brands.",
+                                            "default": [
+                                                {
+                                                    "id": 2000000,
+                                                    "name": "Farm",
+                                                    "isActive": true,
+                                                    "title": "Farm",
+                                                    "metaTagDescription": "Farm",
+                                                    "imageUrl": null
+                                                },
+                                                {
+                                                    "id": 2000001,
+                                                    "name": "Adidas",
+                                                    "isActive": true,
+                                                    "title": "",
+                                                    "metaTagDescription": "",
+                                                    "imageUrl": null
+                                                }
+                                            ],
+                                            "items": {
+                                                "type": "object",
+                                                "title": "",
+                                                "default": {
+                                                    "id": 2000000,
+                                                    "name": "Farm",
+                                                    "isActive": true,
+                                                    "title": "Farm",
+                                                    "metaTagDescription": "Farm",
+                                                    "imageUrl": null
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "name",
+                                                    "isActive",
+                                                    "title",
+                                                    "metaTagDescription",
+                                                    "imageUrl"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "title": "id",
+                                                        "description": "Brand unique number identifier.",
+                                                        "default": 2000000
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "title": "name",
+                                                        "description": "Brand name.",
+                                                        "default": "Farm"
+                                                    },
+                                                    "isActive": {
+                                                        "type": "boolean",
+                                                        "title": "isActive",
+                                                        "description": "Condition if the brand is active or not.",
+                                                        "default": true
+                                                    },
+                                                    "title": {
+                                                        "type": "string",
+                                                        "title": "title",
+                                                        "description": "Title shown in the browser bar, which corresponds to the title of your page.",
+                                                        "default": "Farm"
+                                                    },
+                                                    "metaTagDescription": {
+                                                        "type": "string",
+                                                        "title": "metaTagDescription",
+                                                        "description": "A brief description of the brand, displayed by search engines. Since search engines can only display less than 150 characters, we recommend not exceeding this character limit when creating the description.",
+                                                        "default": "Farm"
+                                                    },
+                                                    "imageUrl": {
+                                                        "type": "string",
+                                                        "title": "imageUrl",
+                                                        "description": "Brand image URL.",
+                                                        "default": ""
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "paging": {
+                                            "type": "object",
+                                            "title": "paging",
+                                            "description": "Object with information about the paging.",
+                                            "default": {
+                                                "page": 1,
+                                                "perPage": 3,
+                                                "total": 6,
+                                                "pages": 2
+                                            },
+                                            "required": [
+                                                "page",
+                                                "perPage",
+                                                "total",
+                                                "pages"
+                                            ],
+                                            "properties": {
+                                                "page": {
+                                                    "type": "integer",
+                                                    "title": "page",
+                                                    "description": "Page number.",
+                                                    "default": 1
+                                                },
+                                                "perPage": {
+                                                    "type": "integer",
+                                                    "title": "perPage",
+                                                    "description": "Quantity of brands per page.",
+                                                    "default": 3
+                                                },
+                                                "total": {
+                                                    "type": "integer",
+                                                    "title": "total",
+                                                    "description": "Total of brands in the store.",
+                                                    "default": 6
+                                                },
+                                                "pages": {
+                                                    "type": "integer",
+                                                    "title": "pages",
+                                                    "description": "Total number of pages.",
+                                                    "default": 2
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
-                },
-                "deprecated": false
+                }
             }
         },
         "/api/catalog_system/pvt/brand/{brandId}": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -12706,6 +12706,87 @@
                 "deprecated": false
             }
         },
+        "/api/catalog_system/pvt/brand/pagedlist": {
+            "get": {
+                "tags": [
+                    "Brand"
+                ],
+                "summary": "Get Brand List Per Page",
+                "description": "Retrieves all Brands registered in the store's Catalog by page number.",
+                "operationId": "BrandList",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Describes the type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand ",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "required": true,
+                        "description": "Quantity of brands per page",
+                        "schema": {
+                            "type": "integer",
+                            "default": 5
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": true,
+                        "description": "Page number of the brand list",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "headers": {}
+                    }
+                },
+                "deprecated": false
+            }
+        },
         "/api/catalog_system/pvt/brand/{brandId}": {
             "get": {
                 "tags": [


### PR DESCRIPTION
#### Types of changes
- [X] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

New `Get Brand List Per Page` endpoint
[Preview](https://preview.readme.io/reference/BrandListPerPage?url=https%3A%2F%2Fraw.githubusercontent.com%2Fvtex%2Fopenapi-schemas%2FNew-Get-List-Brands%2FVTEX+-+Catalog+API.json)