### PR TITLE
Edu 3990 add is available flag on search docs

### DIFF
--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -45,7 +45,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -56,7 +56,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -3162,7 +3162,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -3173,7 +3173,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -6279,7 +6279,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -6290,7 +6290,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9396,7 +9396,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9407,7 +9407,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9477,7 +9477,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9488,7 +9488,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9558,7 +9558,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9569,7 +9569,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9639,7 +9639,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9650,7 +9650,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9720,7 +9720,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -9731,7 +9731,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -12837,7 +12837,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -12848,14 +12848,15 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
 							"example": "application/json"
 						}
-					}, {
+					}, 
+                    {
 						"name": "_from",
 						"in": "query",
 						"description": "Starter page range. These parameters allow the API to be paginated. Take into account that the initial and final pages cannot have a separation superior to 50 pages. Thus, it will be displayed 50 items per page.",
@@ -15997,7 +15998,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -16008,7 +16009,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -19087,7 +19088,7 @@
 				"tags": [
 					"Facets"
 				],
-				"summary": "Facets category",
+				"summary": "Search by Facets category",
 				"description": "",
 				"operationId": "Facetscategory",
 				"parameters": [
@@ -19126,7 +19127,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -19137,7 +19138,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -19152,7 +19153,8 @@
 						"required": true,
 						"style": "simple",
 						"schema": {
-							"type": "string"
+							"type": "string",
+                            "default": ""
 						}
 					},
 					{
@@ -19162,7 +19164,8 @@
 						"required": true,
 						"style": "simple",
 						"schema": {
-							"type": "string"
+							"type": "string",
+                            "default": ""
 						}
 					}
 				],
@@ -19584,7 +19587,7 @@
 					{
 						"name": "Accept",
 						"in": "header",
-						"description": "",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -19595,7 +19598,7 @@
 					{
 						"name": "Content-Type",
 						"in": "header",
-						"description": "",
+						"description": "Describes the type of the content being sent",
 						"required": true,
 						"style": "simple",
 						"schema": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -9693,8 +9693,8 @@
 				"tags": [
 					"Search"
 				],
-				"summary": "ProductSearch",
-				"description": "",
+				"summary": "Search for products",
+				"description": "Retrieves general information about the products related to the term searched.",
 				"operationId": "ProductSearch",
 				"parameters": [
                     {
@@ -9742,11 +9742,12 @@
 					{
 						"name": "search",
 						"in": "path",
-						"description": "",
+						"description": "Term used to search products",
 						"required": true,
 						"style": "simple",
 						"schema": {
-							"type": "string"
+							"type": "string",
+                            "default": "jacket"
 						}
 					}
 				],
@@ -12447,6 +12448,9 @@
 		},
 		{
 			"name": "Search"
+		},
+        {
+			"name": "Offers"
 		},
 		{
 			"name": "Facets"

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -9532,7 +9532,7 @@
 					"CrossSelling"
 				],
 				"summary": "ProductSearch Suggestions",
-				"description": "",
+				"description": "Retrieves general information about other product suggestions related to the product.",
 				"operationId": "ProductSearchSuggestions",
 				"parameters": [
                     {
@@ -9578,15 +9578,15 @@
 						}
 					},
 					{
-						"name": "productId",
-						"in": "path",
-						"description": "",
-						"required": true,
-						"style": "simple",
-						"schema": {
-							"type": "string"
-						}
-					}
+                        "name": "productId",
+                        "in": "path",
+                        "required": true,
+                        "description": "Product's unique identifier",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
 				],
 				"responses": {
 					"200": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -2222,92 +2222,92 @@
                                                                             },
                                                                             "DiscountHighLight": {
                                                                                 "type": "array",
-                                                                                "title": "The DiscountHighLight schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "DiscountHighLight",
+                                                                                "description": "Discount hightlight.",
                                                                                 "default": []
                                                                             },
                                                                             "GiftSkuIds": {
                                                                                 "type": "array",
-                                                                                "title": "The GiftSkuIds schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "GiftSkuIds",
+                                                                                "description": "Array of SKU gifts IDs.",
                                                                                 "default": []
                                                                             },
                                                                             "Teasers": {
                                                                                 "type": "array",
-                                                                                "title": "The Teasers schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "Teasers",
+                                                                                "description": "Teasers.",
                                                                                 "default": []
                                                                             },
                                                                             "BuyTogether": {
                                                                                 "type": "array",
-                                                                                "title": "The BuyTogether schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "BuyTogether",
+                                                                                "description": "Array of other products that can be bought together with the product in question.",
                                                                                 "default": []
                                                                             },
                                                                             "ItemMetadataAttachment": {
                                                                                 "type": "array",
-                                                                                "title": "The ItemMetadataAttachment schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "ItemMetadataAttachment",
+                                                                                "description": "Item metadata attachment.",
                                                                                 "default": []
                                                                             },
                                                                             "Price": {
                                                                                 "type": "number",
-                                                                                "title": "The Price schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "Price",
+                                                                                "description": "Price of the product.",
                                                                                 "default": 42.0
                                                                             },
                                                                             "ListPrice": {
                                                                                 "type": "number",
-                                                                                "title": "The ListPrice schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "ListPrice",
+                                                                                "description": "List price of the product.",
                                                                                 "default": 42.0
                                                                             },
                                                                             "PriceWithoutDiscount": {
                                                                                 "type": "number",
-                                                                                "title": "The PriceWithoutDiscount schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "PriceWithoutDiscount",
+                                                                                "description": "Price of the product without discount.",
                                                                                 "default": 42.0
                                                                             },
                                                                             "RewardValue": {
                                                                                 "type": "number",
-                                                                                "title": "The RewardValue schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "RewardValue",
+                                                                                "description": "Reward value of the product.",
                                                                                 "default": 0.0
                                                                             },
                                                                             "PriceValidUntil": {
                                                                                 "type": "string",
-                                                                                "title": "The PriceValidUntil schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "PriceValidUntil",
+                                                                                "description": "Price of the product valid until a certain date.",
                                                                                 "default": "4000-01-01T03:00:00Z"
                                                                             },
                                                                             "AvailableQuantity": {
                                                                                 "type": "integer",
-                                                                                "title": "The AvailableQuantity schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "AvailableQuantity",
+                                                                                "description": "Available quantity of the product.",
                                                                                 "default": 16
                                                                             },
                                                                             "IsAvailable": {
                                                                                 "type": "boolean",
-                                                                                "title": "The IsAvailable schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "IsAvailable",
+                                                                                "description": "If the product is available or not.",
                                                                                 "default": true
                                                                             },
                                                                             "Tax": {
                                                                                 "type": "number",
-                                                                                "title": "The Tax schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "Tax",
+                                                                                "description": "Tax of the product.",
                                                                                 "default": 0.0
                                                                             },
                                                                             "SaleChannel": {
                                                                                 "type": "integer",
-                                                                                "title": "The SaleChannel schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "SaleChannel",
+                                                                                "description": "Trade policy which the product is contained.",
                                                                                 "default": 0
                                                                             },
                                                                             "DeliverySlaSamples": {
                                                                                 "type": "array",
-                                                                                "title": "The DeliverySlaSamples schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "DeliverySlaSamples",
+                                                                                "description": "Delivery SLA samples.",
                                                                                 "default": [
                                                                                     {
                                                                                         "DeliverySlaPerTypes": [],
@@ -2316,8 +2316,7 @@
                                                                                 ],
                                                                                 "items": {
                                                                                     "type": "object",
-                                                                                    "title": "The first anyOf schema",
-                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                    "title": "",
                                                                                     "default": {
                                                                                         "DeliverySlaPerTypes": [],
                                                                                         "Region": null
@@ -2329,14 +2328,14 @@
                                                                                     "properties": {
                                                                                         "DeliverySlaPerTypes": {
                                                                                             "type": "array",
-                                                                                            "title": "The DeliverySlaPerTypes schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "DeliverySlaPerTypes",
+                                                                                            "description": "Delivery SLA per types.",
                                                                                             "default": []
                                                                                         },
                                                                                         "Region": {
                                                                                             "type": "string",
-                                                                                            "title": "The Region schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "Region",
+                                                                                            "description": "Region.",
                                                                                             "default": null
                                                                                         }
                                                                                     }
@@ -2344,20 +2343,20 @@
                                                                             },
                                                                             "GetInfoErrorMessage": {
                                                                                 "type": "string",
-                                                                                "title": "The GetInfoErrorMessage schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "GetInfoErrorMessage",
+                                                                                "description": "Get info error message.",
                                                                                 "default": null
                                                                             },
                                                                             "CacheVersionUsedToCallCheckout": {
                                                                                 "type": "string",
-                                                                                "title": "The CacheVersionUsedToCallCheckout schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "CacheVersionUsedToCallCheckout",
+                                                                                "description": "Cache version used to call checkout.",
                                                                                 "default": "95EF7E5476DF276E679167A399FE3103_"
                                                                             },
                                                                             "PaymentOptions": {
                                                                                 "type": "object",
-                                                                                "title": "The PaymentOptions schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "PaymentOptions",
+                                                                                "description": "Payment options.",
                                                                                 "default": {
                                                                                     "installmentOptions": [
                                                                                         {
@@ -2512,8 +2511,8 @@
                                                                                 "properties": {
                                                                                     "installmentOptions": {
                                                                                         "type": "array",
-                                                                                        "title": "The installmentOptions schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "title": "installmentOptions",
+                                                                                        "description": "installment options.",
                                                                                         "default": [
                                                                                             [
                                                                                                 {
@@ -2623,8 +2622,7 @@
                                                                                         ],
                                                                                         "items": {
                                                                                             "type": "object",
-                                                                                            "title": "The first anyOf schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "",
                                                                                             "default": {
                                                                                                 "paymentSystem": "2",
                                                                                                 "bin": null,

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -18,7 +18,7 @@
 				"tags": [
 					"CrossSelling"
 				],
-				"summary": "Get Product Search of *Who Saw Also Saw*",
+				"summary": "Get Product Search of Who Saw Also Saw",
 				"description": "Retrieves general information about other related products that the users also saw",
 				"operationId": "ProductSearchWhoSawAlsoSaw",
 				"parameters": [
@@ -3135,7 +3135,7 @@
 				"tags": [
 					"CrossSelling"
 				],
-				"summary": "ProductSearch Who Saw Also Bought",
+				"summary": "Get Product Search of Who Saw Also Bought",
 				"description": "Retrieves general information about other related products that the users saw and also bought.",
 				"operationId": "ProductSearchWhoSawAlsoBought",
 				"parameters": [
@@ -6252,7 +6252,7 @@
 				"tags": [
 					"CrossSelling"
 				],
-				"summary": "ProductSearch Who Bought Also Bought",
+				"summary": "Get Product Search of Who Bought Also Bought",
 				"description": "Retrieves general information about other related products that the user also bought.",
 				"operationId": "ProductSearchWhoBoughtAlsoBought",
 				"parameters": [
@@ -9369,7 +9369,7 @@
 				"tags": [
 					"CrossSelling"
 				],
-				"summary": "ProductSearch Accessories",
+				"summary": "Get Product Search of Accessories",
 				"description": "Retrieves general information about the product's accessories.",
 				"operationId": "ProductSearchAccessories",
 				"parameters": [
@@ -9450,7 +9450,7 @@
 				"tags": [
 					"CrossSelling"
 				],
-				"summary": "ProductSearch Similars",
+				"summary": "Get Product Search of Similars",
 				"description": "Retrieves general information about related product searches.",
 				"operationId": "ProductSearchSimilars",
 				"parameters": [
@@ -9531,7 +9531,7 @@
 				"tags": [
 					"CrossSelling"
 				],
-				"summary": "ProductSearch Suggestions",
+				"summary": "Get Product Search of Suggestions",
 				"description": "Retrieves general information about other product suggestions related to the product.",
 				"operationId": "ProductSearchSuggestions",
 				"parameters": [

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -20211,8 +20211,8 @@
 				"tags": [
 					"Autocomplete"
 				],
-				"summary": "AutoComplete",
-				"description": "",
+				"summary": "Product Search Autocomplete",
+				"description": "Retrieves product's information related to the searched string.",
 				"operationId": "AutoComplete",
 				"parameters": [
                     {
@@ -20235,253 +20235,240 @@
                             "default": "vtexcommercestable"
                         }
                     },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Type of the content being sent",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand ",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
 					{
 						"name": "productNameContains",
 						"in": "query",
-						"description": "",
+						"description": "Part of the string that will be searched.",
 						"required": true,
 						"style": "form",
 						"explode": true,
 						"schema": {
 							"type": "string",
-							"example": "{{searchString}}"
+							"example": "jeans"
 						}
 					}
 				],
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {
-							"Cache-Control": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "private"
-									}
-								}
-							},
-							"Connection": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "keep-alive"
-									}
-								}
-							},
-							"Content-Encoding": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "gzip"
-									}
-								}
-							},
-							"Content-Length": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "331"
-									}
-								}
-							},
-							"Date": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Fri, 10 Mar 2017 16:49:40 GMT"
-									}
-								}
-							},
-							"Server": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "nginx"
-									}
-								}
-							},
-							"Vary": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Accept-Encoding"
-									}
-								}
-							},
-							"X-CacheServer": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "janus-apicache-nginx17"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.3.9"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-Edge": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.35.3"
-									}
-								}
-							},
-							"X-Track": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "stable"
-									}
-								}
-							},
-							"X-VTEX-Cache-Status-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "MISS"
-									}
-								}
-							},
-							"X-VTEX-Janus-Router-Backend-App": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "portal-v1.4.698-stable+1225"
-									}
-								}
-							},
-							"X-vtex-processado-em": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": ": 00:00:00.5490219-c1:120"
-									}
-								}
-							},
-							"X-vtex-processed-at": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "10/03/2017 16:49:39"
-									}
-								}
-							},
-							"X-vtex-remote-cache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "true"
-									}
-								}
-							},
-							"no": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "-DINS692KJ1P"
-									}
-								}
-							},
-							"p3p": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "policyref=\"/w3c/p3p.xml\",CP=\"ADMa OUR NOR CNT NID DSP NOI COR\""
-									}
-								}
-							},
-							"powered": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "vtex"
-									}
-								}
-							}
-						},
 						"content": {
-							"application/json; charset=utf-8": {
+							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Example3"
-								},
+                                    "type": "object",
+                                    "title": "The root schema",
+                                    "description": "The root schema comprises the entire JSON document.",
+                                    "default": {
+                                        "itemsReturned": [
+                                            {
+                                                "items": [],
+                                                "thumb": "",
+                                                "thumbUrl": null,
+                                                "name": "Cacilds in Coronas",
+                                                "href": "https://merch.vtexcommercestable.com.br/coronas/Cacilds",
+                                                "criteria": "£Cacilds in Coronas¢/coronas/Cacilds"
+                                            },
+                                            {
+                                                "items": [
+                                                    {
+                                                        "productId": "3",
+                                                        "itemId": "5",
+                                                        "name": "Llf",
+                                                        "nameComplete": "Cacilds Llf",
+                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000"
+                                                    }
+                                                ],
+                                                "thumb": "<img src=\"https://merch.vteximg.com.br/arquivos/ids/155400-25-25/image-433ec3e72d7e4b94964481e843c9dd88.jpg?v=637172099619830000\" width=\"25\" height=\"25\" alt=\"image-433ec3e72d7e4b94964481e843c9dd88\" id=\"\" />",
+                                                "thumbUrl": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000",
+                                                "name": "cacilds - llf",
+                                                "href": "https://merch.vtexcommercestable.com.br/bay-max-3/p",
+                                                "criteria": null
+                                            }
+                                        ]
+                                    },
+                                    "required": [
+                                        "itemsReturned"
+                                    ],
+                                    "properties": {
+                                        "itemsReturned": {
+                                            "type": "array",
+                                            "title": "itemsReturned",
+                                            "description": "Autocomplete returned items.",
+                                            "default": [
+                                                {
+                                                    "items": [],
+                                                    "thumb": "",
+                                                    "thumbUrl": null,
+                                                    "name": "Cacilds in Coronas",
+                                                    "href": "https://merch.vtexcommercestable.com.br/coronas/Cacilds",
+                                                    "criteria": "£Cacilds in Coronas¢/coronas/Cacilds"
+                                                },
+                                                {
+                                                    "items": [
+                                                        {
+                                                            "productId": "3",
+                                                            "itemId": "5",
+                                                            "name": "Llf",
+                                                            "nameComplete": "Cacilds Llf",
+                                                            "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000"
+                                                        }
+                                                    ],
+                                                    "thumb": "<img src=\"https://merch.vteximg.com.br/arquivos/ids/155400-25-25/image-433ec3e72d7e4b94964481e843c9dd88.jpg?v=637172099619830000\" width=\"25\" height=\"25\" alt=\"image-433ec3e72d7e4b94964481e843c9dd88\" id=\"\" />",
+                                                    "thumbUrl": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000",
+                                                    "name": "cacilds - llf",
+                                                    "href": "https://merch.vtexcommercestable.com.br/bay-max-3/p",
+                                                    "criteria": null
+                                                }
+                                            ],
+                                            "items": {
+                                                "type": "object",
+                                                "default": {
+                                                    "items": [],
+                                                    "thumb": "",
+                                                    "thumbUrl": null,
+                                                    "name": "Cacilds in Coronas",
+                                                    "href": "https://merch.vtexcommercestable.com.br/coronas/Cacilds",
+                                                    "criteria": "£Cacilds in Coronas¢/coronas/Cacilds"
+                                                },
+                                                "required": [
+                                                    "items",
+                                                    "thumb",
+                                                    "thumbUrl",
+                                                    "name",
+                                                    "href",
+                                                    "criteria"
+                                                ],
+                                                "properties": {
+                                                    "items": {
+                                                        "type": "array",
+                                                        "title": "items",
+                                                        "description": "Array of products.",
+                                                        "default": [
+                                                            {
+                                                                "productId": "3",
+                                                                "itemId": "5",
+                                                                "name": "Llf",
+                                                                "nameComplete": "Cacilds Llf",
+                                                                "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000"
+                                                            }
+                                                        ],
+                                                        "properties": {
+                                                            "productId": {
+                                                                "type": "string",
+                                                                "title": "productId",
+                                                                "description": "Product ID.",
+                                                                "default": "1"
+                                                            },
+                                                            "itemId": {
+                                                                "type": "string",
+                                                                "title": "itemId",
+                                                                "description": "Item ID.",
+                                                                "default": "3"
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "title": "name",
+                                                                "description": "Product name.",
+                                                                "default": "Llf"
+                                                            },
+                                                            "nameComplete": {
+                                                                "type": "string",
+                                                                "title": "nameComplete",
+                                                                "description": "Complete product name.",
+                                                                "default": "Cacilds Llf"
+                                                            },
+                                                            "imageUrl": {
+                                                                "type": "string",
+                                                                "title": "imageUrl",
+                                                                "description": "Product image URL.",
+                                                                "default": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000"
+                                                            }
+                                                        }
+                                                    },
+                                                    "thumb": {
+                                                        "type": "string",
+                                                        "title": "thumb",
+                                                        "description": "Item thumbnail.",
+                                                        "default": "<img src=\"https://merch.vteximg.com.br/arquivos/ids/155400-25-25/image-433ec3e72d7e4b94964481e843c9dd88.jpg?v=637172099619830000\" width=\"25\" height=\"25\" alt=\"image-433ec3e72d7e4b94964481e843c9dd88\" id=\"\" />"
+                                                    },
+                                                    "thumbUrl": {
+                                                        "type": "string",
+                                                        "title": "thumbUrl",
+                                                        "description": "Item thumbnail URL.",
+                                                        "default": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000"
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "title": "name",
+                                                        "description": "Item name.",
+                                                        "default": "cacilds - llf"
+                                                    },
+                                                    "href": {
+                                                        "type": "string",
+                                                        "title": "href",
+                                                        "description": "Item URL.",
+                                                        "default":"https://merch.vtexcommercestable.com.br/bay-max-3/p"
+                                                    },
+                                                    "criteria": {
+                                                        "type": "string",
+                                                        "title": "criteria",
+                                                        "description": "Item criteria.",
+                                                        "default": "£Cacilds in Coronas¢/coronas/Cacilds"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
 								"example": {
-									"itemsReturned": [
-										{
-											"thumb": "",
-											"name": "geladeira em Departamento 8",
-											"href": "https://ambienteqa.vtexcommercestable.com.br/departamento-8/geladeira",
-											"criteria": "£geladeira em Departamento 8¢/departamento-8/geladeira"
-										},
-										{
-											"thumb": "",
-											"name": "geladeira em Eletrodoméstico",
-											"href": "https://ambienteqa.vtexcommercestable.com.br/eletrodomestico/geladeira",
-											"criteria": "£geladeira em Eletrodoméstico¢/eletrodomestico/geladeira"
-										},
-										{
-											"thumb": "<img src=\"https://ambienteqa.vteximg.com.br/arquivos/ids/168969-25-25/geladeira.jpg\" width=\"25\" height=\"25\" alt=\"geladeira\" id=\"\" />",
-											"name": "geladeira eli",
-											"href": "https://ambienteqa.vtexcommercestable.com.br/geladeiraeli/p",
-											"criteria": null
-										},
-										{
-											"thumb": "<img src=\"https://ambienteqa.vteximg.com.br/arquivos/ids/168964-25-25/gela.jpg\" width=\"25\" height=\"25\" alt=\"gela\" id=\"\" />",
-											"name": "pre venda geladeira",
-											"href": "https://ambienteqa.vtexcommercestable.com.br/prevendageladeira/p",
-											"criteria": null
-										},
-										{
-											"thumb": "<img src=\"https://ambienteqa.vteximg.com.br/arquivos/ids/168951-25-25/geladeira.jpg\" width=\"25\" height=\"25\" alt=\"geladeira\" id=\"\" />",
-											"name": "geladeira",
-											"href": "https://ambienteqa.vtexcommercestable.com.br/geladeira/p",
-											"criteria": null
-										}
-									]
-								}
+                                    "itemsReturned": [
+                                        {
+                                            "items": [],
+                                            "thumb": "",
+                                            "thumbUrl": null,
+                                            "name": "Cacilds in Coronas",
+                                            "href": "https://merch.vtexcommercestable.com.br/coronas/Cacilds",
+                                            "criteria": "£Cacilds in Coronas¢/coronas/Cacilds"
+                                        },
+                                        {
+                                            "items": [
+                                                {
+                                                    "productId": "3",
+                                                    "itemId": "5",
+                                                    "name": "Llf",
+                                                    "nameComplete": "Cacilds Llf",
+                                                    "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000"
+                                                }
+                                            ],
+                                            "thumb": "<img src=\"https://merch.vteximg.com.br/arquivos/ids/155400-25-25/image-433ec3e72d7e4b94964481e843c9dd88.jpg?v=637172099619830000\" width=\"25\" height=\"25\" alt=\"image-433ec3e72d7e4b94964481e843c9dd88\" id=\"\" />",
+                                            "thumbUrl": "https://merch.vteximg.com.br/arquivos/ids/172754-25-25/Diablo.jpg?v=637521970448770000",
+                                            "name": "cacilds - llf",
+                                            "href": "https://merch.vtexcommercestable.com.br/bay-max-3/p",
+                                            "criteria": null
+                                        }
+                                    ]
+                                }
 							}
 						}
 					}

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19199,13 +19199,13 @@
                 }
             }
         },
-		"/api/catalog_system/pub/facets/search/{category1}/{category2}": {
+		"/api/catalog_system/pub/facets/search/{term}": {
 			"get": {
 				"tags": [
 					"Facets"
 				],
-				"summary": "Search by Category Facets",
-				"description": "Search of ",
+				"summary": "Search by Store Facets",
+				"description": "Search of store facets that are ",
 				"operationId": "Facetscategory",
 				"parameters": [
                     {
@@ -19231,13 +19231,13 @@
 					{
 						"name": "map",
 						"in": "query",
-						"description": "",
+						"description": "Mapping of the term. It can be `c` for a category, `b` for a brand, or `specificationFilter_{specificationId}` for a specification.",
 						"required": true,
 						"style": "form",
 						"explode": true,
 						"schema": {
 							"type": "string",
-							"example": "c,c"
+							"example": "c"
 						}
 					},
 					{
@@ -19263,20 +19263,9 @@
 						}
 					},
 					{
-						"name": "category1",
+						"name": "term",
 						"in": "path",
-						"description": "",
-						"required": true,
-						"style": "simple",
-						"schema": {
-							"type": "string",
-                            "default": ""
-						}
-					},
-					{
-						"name": "category2",
-						"in": "path",
-						"description": "",
+						"description": "Term used for the facet's search. You can search for as much term as you want. The term can be: `categoryId`, `brandId`, `specificationId`.",
 						"required": true,
 						"style": "simple",
 						"schema": {
@@ -19284,6 +19273,7 @@
                             "default": ""
 						}
 					}
+
 				],
 				"responses": {
 					"200": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -9364,6 +9364,87 @@
 				]
 			}
 		},
+        "/api/catalog_system/pub/products/crossselling/showtogether/{productId}": {
+			"get": {
+				"tags": [
+					"CrossSelling"
+				],
+				"summary": "Get Product Search of Show Together",
+				"description": "Retrieves general information about the products that are show together with the product in question.",
+				"operationId": "ProductSearchAccessories",
+				"parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+					{
+						"name": "Accept",
+						"in": "header",
+						"description": "",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+					{
+						"name": "Content-Type",
+						"in": "header",
+						"description": "",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "required": true,
+                        "description": "Product's unique identifier",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"headers": {}
+					}
+				},
+				"deprecated": false,
+				"servers": [
+					{
+						"url": "https://entelperu.{environment}.com.br/api/catalog_system/pub/products/crossselling/accessories",
+						"variables": {
+							"environment": {
+								"default": "DefaultParameterValue"
+							}
+						}
+					}
+				]
+			}
+		},
 		"/api/catalog_system/pub/products/crossselling/accessories/{productId}": {
 			"get": {
 				"tags": [

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -1166,7 +1166,7 @@
                                                         "referenceId": {
                                                             "type": "array",
                                                             "title": "referenceId",
-                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "description": "Reference code ID.",
                                                             "default": [
                                                                     {
                                                                         "Key": "RefId",
@@ -1188,7 +1188,7 @@
                                                                     "Key": {
                                                                         "type": "string",
                                                                         "title": "Key",
-                                                                        "description": "Type of the key, in this case a Reference Code.",
+                                                                        "description": "Reference Code.",
                                                                         "default": [
                                                                             "RefId"
                                                                         ]

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -1842,7 +1842,7 @@
                                                                     "commertialOffer": {
                                                                         "type": "object",
                                                                         "title": "commertialOffer",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "description": "AKA Commertial Condition.",
                                                                         "default": {
                                                                             "DeliverySlaSamplesPerRegion": {
                                                                                 "0": {
@@ -2098,8 +2098,8 @@
                                                                                 "properties": {
                                                                                     "0": {
                                                                                         "type": "object",
-                                                                                        "title": "The 0 schema",
-                                                                                        "description": "0.",
+                                                                                        "title": "",
+                                                                                        "description": "Delivery SLA ID.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "DeliverySlaPerTypes": [],
@@ -2283,7 +2283,7 @@
                                                                             "AvailableQuantity": {
                                                                                 "type": "integer",
                                                                                 "title": "AvailableQuantity",
-                                                                                "description": "Available quantity of the product.",
+                                                                                "description": "Use the `IsAvailable` field instead.",
                                                                                 "default": 16
                                                                             },
                                                                             "IsAvailable": {
@@ -4959,7 +4959,7 @@
                                                                     "commertialOffer": {
                                                                         "type": "object",
                                                                         "title": "commertialOffer",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "description": "AKA Commertial Condition.",
                                                                         "default": {
                                                                             "DeliverySlaSamplesPerRegion": {
                                                                                 "0": {
@@ -5215,8 +5215,8 @@
                                                                                 "properties": {
                                                                                     "0": {
                                                                                         "type": "object",
-                                                                                        "title": "The 0 schema",
-                                                                                        "description": "0.",
+                                                                                        "title": "",
+                                                                                        "description": "Delivery SLA ID.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "DeliverySlaPerTypes": [],
@@ -5400,7 +5400,7 @@
                                                                             "AvailableQuantity": {
                                                                                 "type": "integer",
                                                                                 "title": "AvailableQuantity",
-                                                                                "description": "Available quantity of the product.",
+                                                                                "description": "Use the `IsAvailable` field instead.",
                                                                                 "default": 16
                                                                             },
                                                                             "IsAvailable": {
@@ -8076,7 +8076,7 @@
                                                                     "commertialOffer": {
                                                                         "type": "object",
                                                                         "title": "commertialOffer",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "description": "AKA Commertial Condition.",
                                                                         "default": {
                                                                             "DeliverySlaSamplesPerRegion": {
                                                                                 "0": {
@@ -8332,8 +8332,8 @@
                                                                                 "properties": {
                                                                                     "0": {
                                                                                         "type": "object",
-                                                                                        "title": "The 0 schema",
-                                                                                        "description": "0.",
+                                                                                        "title": "",
+                                                                                        "description": "Delivery SLA ID.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "DeliverySlaPerTypes": [],
@@ -8517,7 +8517,7 @@
                                                                             "AvailableQuantity": {
                                                                                 "type": "integer",
                                                                                 "title": "AvailableQuantity",
-                                                                                "description": "Available quantity of the product.",
+                                                                                "description": "Use the `IsAvailable` field instead.",
                                                                                 "default": 16
                                                                             },
                                                                             "IsAvailable": {
@@ -11517,7 +11517,7 @@
                                                                     "commertialOffer": {
                                                                         "type": "object",
                                                                         "title": "commertialOffer",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "description": "AKA Commertial Condition.",
                                                                         "default": {
                                                                             "DeliverySlaSamplesPerRegion": {
                                                                                 "0": {
@@ -11773,8 +11773,8 @@
                                                                                 "properties": {
                                                                                     "0": {
                                                                                         "type": "object",
-                                                                                        "title": "The 0 schema",
-                                                                                        "description": "0.",
+                                                                                        "title": "",
+                                                                                        "description": "Delivery SLA ID.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "DeliverySlaPerTypes": [],
@@ -11958,7 +11958,7 @@
                                                                             "AvailableQuantity": {
                                                                                 "type": "integer",
                                                                                 "title": "AvailableQuantity",
-                                                                                "description": "Available quantity of the product.",
+                                                                                "description": "Use the `IsAvailable` field instead.",
                                                                                 "default": 16
                                                                             },
                                                                             "IsAvailable": {
@@ -14678,7 +14678,7 @@
                                                                     "commertialOffer": {
                                                                         "type": "object",
                                                                         "title": "commertialOffer",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "description": "AKA Commertial Condition.",
                                                                         "default": {
                                                                             "DeliverySlaSamplesPerRegion": {
                                                                                 "0": {
@@ -14934,8 +14934,8 @@
                                                                                 "properties": {
                                                                                     "0": {
                                                                                         "type": "object",
-                                                                                        "title": "The 0 schema",
-                                                                                        "description": "0.",
+                                                                                        "title": "",
+                                                                                        "description": "Delivery SLA ID.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "DeliverySlaPerTypes": [],
@@ -15119,7 +15119,7 @@
                                                                             "AvailableQuantity": {
                                                                                 "type": "integer",
                                                                                 "title": "AvailableQuantity",
-                                                                                "description": "Available quantity of the product.",
+                                                                                "description": "Use the `IsAvailable` field instead.",
                                                                                 "default": 16
                                                                             },
                                                                             "IsAvailable": {
@@ -17795,7 +17795,7 @@
                                                                     "commertialOffer": {
                                                                         "type": "object",
                                                                         "title": "commertialOffer",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "description": "AKA Commertial Condition.",
                                                                         "default": {
                                                                             "DeliverySlaSamplesPerRegion": {
                                                                                 "0": {
@@ -18051,8 +18051,8 @@
                                                                                 "properties": {
                                                                                     "0": {
                                                                                         "type": "object",
-                                                                                        "title": "The 0 schema",
-                                                                                        "description": "0.",
+                                                                                        "title": "",
+                                                                                        "description": "Delivery SLA ID.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "DeliverySlaPerTypes": [],
@@ -18236,7 +18236,7 @@
                                                                             "AvailableQuantity": {
                                                                                 "type": "integer",
                                                                                 "title": "AvailableQuantity",
-                                                                                "description": "Available quantity of the product.",
+                                                                                "description": "Use the `IsAvailable` field instead.",
                                                                                 "default": 16
                                                                             },
                                                                             "IsAvailable": {
@@ -19421,7 +19421,7 @@
                                             "Offers": {
                                                 "type": "array",
                                                 "title": "Offers",
-                                                "description": "An explanation about the purpose of this instance.",
+                                                "description": "AKA Commertial Condition.",
                                                 "default": [
                                                     {
                                                         "SellerId": "1",
@@ -19952,7 +19952,7 @@
                                             "Offers": {
                                                 "type": "array",
                                                 "title": "Offers",
-                                                "description": "An explanation about the purpose of this instance.",
+                                                "description": "AKA Commertial Condition.",
                                                 "default": [
                                                     {
                                                         "SellerId": "1",

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -2088,7 +2088,7 @@
                                                                             "DeliverySlaSamplesPerRegion": {
                                                                                 "type": "object",
                                                                                 "title": "DeliverySlaSamplesPerRegion",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "description": "Delivery SLA samples per region.",
                                                                                 "default": {
                                                                                     "0": {
                                                                                         "DeliverySlaPerTypes": [],
@@ -2099,7 +2099,7 @@
                                                                                     "0": {
                                                                                         "type": "object",
                                                                                         "title": "The 0 schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "description": "0.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "DeliverySlaPerTypes": [],
@@ -2113,15 +2113,15 @@
                                                                                         "properties": {
                                                                                             "DeliverySlaPerTypes": {
                                                                                                 "type": "array",
-                                                                                                "title": "The DeliverySlaPerTypes schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "title": "DeliverySlaPerTypes",
+                                                                                                "description": "Delivery SLA per types.",
                                                                                                 "default": []
                                                                                             },
                                                                                             "Region": {
                                                                                                 "type": "string",
-                                                                                                "title": "The Region schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": null
+                                                                                                "title": "Region",
+                                                                                                "description": "Region.",
+                                                                                                "default": ""
                                                                                             }
                                                                                         }
                                                                                     }

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -9754,228 +9754,3042 @@
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {
-							"Cache-Control": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "no-cache"
-									}
-								}
-							},
-							"Connection": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "keep-alive"
-									}
-								}
-							},
-							"Content-Encoding": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "gzip"
-									}
-								}
-							},
-							"Content-Length": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "2534"
-									}
-								}
-							},
-							"Date": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Mon, 13 Feb 2017 16:03:56 GMT"
-									}
-								}
-							},
-							"Expires": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "-1"
-									}
-								}
-							},
-							"Pragma": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "no-cache"
-									}
-								}
-							},
-							"Server": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "nginx"
-									}
-								}
-							},
-							"Vary": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Accept-Encoding, resources"
-									}
-								}
-							},
-							"X-CacheServer": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "janus-apicache-nginx11"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.3.9"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-Edge": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.35.3"
-									}
-								}
-							},
-							"X-Track": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "stable"
-									}
-								}
-							},
-							"X-VTEX-Cache-Status-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "MISS"
-									}
-								}
-							},
-							"X-VTEX-Cache-Status-Janus-Edge": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "MISS"
-									}
-								}
-							},
-							"X-VTEX-Janus-Router-Backend-App": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "portal-v1.4.690-stable+1206"
-									}
-								}
-							},
-							"no": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "-DINS692KJ1P"
-									}
-								}
-							},
-							"p3p": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "policyref=\"/w3c/p3p.xml\",CP=\"ADMa OUR NOR CNT NID DSP NOI COR\""
-									}
-								}
-							},
-							"powered": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "vtex"
-									}
-								}
-							},
-							"resources": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "0-9/3"
-									}
-								}
-							},
-							"x-vtex-operation-id": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "f44463be-0cdf-4d8c-a83e-46019395dd0b"
-									}
-								}
-							}
-						},
-						"content": {
-							"application/json; charset=utf-8": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/Example"
-									}
-								}
-							}
-						}
+						"headers": {},
+                        "content": {
+                            "application/json":{
+                                "example":[{
+                                    "productId": "35",
+                                    "productName": "Kit de Hoegaarden",
+                                    "brand": "Hoegaarden",
+                                    "brandId": 2000004,
+                                    "brandImageUrl": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg",
+                                    "linkText": "kit-6-cerveja-hoegaarden",
+                                    "productReference": "000806",
+                                    "productReferenceCode": null,
+                                    "categoryId": "1",
+                                    "productTitle": "",
+                                    "metaTagDescription": "",
+                                    "releaseDate": "2020-10-07T00:00:00",
+                                    "clusterHighlights": {
+                                        "138": "teste2"
+                                    },
+                                    "productClusters": {
+                                        "138": "teste2",
+                                        "143": "NaoPesquisavel",
+                                        "146": "colecaotestesubcategoria",
+                                        "161": "merch_import_test1"
+                                    },
+                                    "searchableClusters": {
+                                        "138": "teste2"
+                                    },
+                                    "categories": [
+                                        "/Beers Beers Mesmo/"
+                                    ],
+                                    "categoriesIds": [
+                                        "/1/"
+                                    ],
+                                    "link": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p",
+                                    "Percentuals": [
+                                        "4,9"
+                                    ],
+                                    "Percentual": [
+                                        "4,9"
+                                    ],
+                                    "Total": [
+                                        "Percentuals",
+                                        "Percentual"
+                                    ],
+                                    "Teste de Api": [
+                                        "a"
+                                    ],
+                                    "Ale": [
+                                        "1"
+                                    ],
+                                    "Teste da Api2": [
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "Alcool": [
+                                        "Percentual"
+                                    ],
+                                    "allSpecifications": [
+                                        "Percentuals",
+                                        "Percentual",
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "allSpecificationsGroups": [
+                                        "Total",
+                                        "Teste da Api2"
+                                    ],
+                                    "description": "",
+                                    "items": [{
+                                        "itemId": "310118469",
+                                        "name": "Kit com 6",
+                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                        "complementName": "",
+                                        "ean": "",
+                                        "referenceId": [{
+                                            "Key": "RefId",
+                                            "Value": "000806"
+                                        }],
+                                        "measurementUnit": "un",
+                                        "unitMultiplier": 1.0000,
+                                        "modalType": null,
+                                        "isKit": true,
+                                        "kitItems": [{
+                                            "itemId": "310118466",
+                                            "amount": 6
+                                        }],
+                                        "images": [{
+                                            "imageId": "155489",
+                                            "imageLabel": "",
+                                            "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                            "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                            "imageText": "hoegaarden-kit",
+                                            "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                        }],
+                                        "sellers": [{
+                                            "sellerId": "1",
+                                            "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                            "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                            "sellerDefault": true,
+                                            "commertialOffer": {
+                                                "DeliverySlaSamplesPerRegion": {
+                                                    "0": {
+                                                        "DeliverySlaPerTypes": [],
+                                                        "Region": null
+                                                    }
+                                                },
+                                                "Installments": [{
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa à vista"
+                                                    },
+                                                    {
+                                                        "Value": 21.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 2,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 2 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 14.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 3,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 3 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 10.5,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 4,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 4 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Promissory",
+                                                        "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                        "Name": "Promissory à vista"
+                                                    }
+                                                ],
+                                                "DiscountHighLight": [],
+                                                "GiftSkuIds": [],
+                                                "Teasers": [],
+                                                "BuyTogether": [],
+                                                "ItemMetadataAttachment": [],
+                                                "Price": 42.0,
+                                                "ListPrice": 42.0,
+                                                "PriceWithoutDiscount": 42.0,
+                                                "RewardValue": 0.0,
+                                                "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                "AvailableQuantity": 16,
+                                                "IsAvailable": true,
+                                                "Tax": 0.0,
+                                                "SaleChannel": 0,
+                                                "DeliverySlaSamples": [{
+                                                    "DeliverySlaPerTypes": [],
+                                                    "Region": null
+                                                }],
+                                                "GetInfoErrorMessage": null,
+                                                "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                "PaymentOptions": {
+                                                    "installmentOptions": [{
+                                                            "paymentSystem": "2",
+                                                            "bin": null,
+                                                            "paymentName": "Visa",
+                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 1,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 4200,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 2,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 2100,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 2,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 2100,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 3,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1400,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 3,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1400,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 4,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1050,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 4,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1050,
+                                                                        "total": 4200
+                                                                    }]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "paymentSystem": "17",
+                                                            "bin": null,
+                                                            "paymentName": "Promissory",
+                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                "count": 1,
+                                                                "hasInterestRate": false,
+                                                                "interestRate": 0,
+                                                                "value": 4200,
+                                                                "total": 4200,
+                                                                "sellerMerchantInstallments": [{
+                                                                    "id": "MERCH",
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200
+                                                                }]
+                                                            }]
+                                                        }
+                                                    ],
+                                                    "paymentSystems": [{
+                                                            "id": 17,
+                                                            "name": "Promissory",
+                                                            "groupName": "promissoryPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "17",
+                                                            "template": "promissoryPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "name": "Visa",
+                                                            "groupName": "creditCardPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "2",
+                                                            "template": "creditCardPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        }
+                                                    ],
+                                                    "payments": [],
+                                                    "giftCards": [],
+                                                    "giftCardMessages": [],
+                                                    "availableAccounts": [],
+                                                    "availableTokens": []
+                                                }
+                                            }
+                                        }],
+                                        "Videos": [],
+                                        "estimatedDateArrival": null
+                                    }]
+                                }],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "",
+                                        "required": [
+                                            "productId",
+                                            "productName",
+                                            "brand",
+                                            "brandId",
+                                            "brandImageUrl",
+                                            "linkText",
+                                            "productReference",
+                                            "productReferenceCode",
+                                            "categoryId",
+                                            "productTitle",
+                                            "metaTagDescription",
+                                            "releaseDate",
+                                            "clusterHighlights",
+                                            "productClusters",
+                                            "searchableClusters",
+                                            "categories",
+                                            "categoriesIds",
+                                            "link",
+                                            "Percentuals",
+                                            "Percentual",
+                                            "Total",
+                                            "Teste de Api",
+                                            "Ale",
+                                            "Teste da Api2",
+                                            "Alcool",
+                                            "allSpecifications",
+                                            "allSpecificationsGroups",
+                                            "description",
+                                            "items"
+                                        ],
+                                        "properties": {
+                                            "productId": {
+                                                "type": "string",
+                                                "title": "productId",
+                                                "description": "Product unique identifier.",
+                                                "default": "35"
+                                            },
+                                            "productName": {
+                                                "type": "string",
+                                                "title": "productName",
+                                                "description": "Product name.",
+                                                "default": "Kit de Hoegaarden"
+                                            },
+                                            "brand": {
+                                                "type": "string",
+                                                "title": "brand",
+                                                "description": "Brand name.",
+                                                "default": "Hoegaarden"
+                                            },
+                                            "brandId": {
+                                                "type": "integer",
+                                                "title": "brandId",
+                                                "description": "Product brand ID.",
+                                                "default": 2000004
+                                            },
+                                            "brandImageUrl": {
+                                                "type": "string",
+                                                "title": "brandImageUrl",
+                                                "description": "Product's brand image URL.",
+                                                "default": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg"
+                                            },
+                                            "linkText": {
+                                                "type": "string",
+                                                "title": "linkText",
+                                                "description": "Product URL.",
+                                                "default": "kit-6-cerveja-hoegaarden"
+                                            },
+                                            "productReference": {
+                                                "type": "string",
+                                                "title": "productReference",
+                                                "description": "Product reference.",
+                                                "default": "000806"
+                                            },
+                                            "productReferenceCode": {
+                                                "type": "integer",
+                                                "title": "productReferenceCode",
+                                                "description": "Product reference ID.",
+                                                "default": 1234
+                                            },
+                                            "categoryId": {
+                                                "type": "string",
+                                                "title": "categoryId",
+                                                "description": "Product category ID.",
+                                                "default": "1"
+                                            },
+                                            "productTitle": {
+                                                "type": "string",
+                                                "title": "productTitle",
+                                                "description": "Text that is in the browser tab and corresponds to the title of the product page. This field is important for SEO.",
+                                                "default": "Kit 6 cerveja Hoegaarden"
+                                            },
+                                            "metaTagDescription": {
+                                                "type": "string",
+                                                "title": "metaTagDescription",
+                                                "description": "Brief description of the category. It's recommended that you don't exceed 150 characters so that the search engines can display it correctly in the results page.",
+                                                "default": "Category for Beers"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "title": "releaseDate",
+                                                "description": "Product release date.",
+                                                "default": "2020-10-07T00:00:00"
+                                            },
+                                            "clusterHighlights": {
+                                                "type": "object",
+                                                "title": "clusterHighlights",
+                                                "description": "Cluster highlight ID and name.",
+                                                "default": {
+                                                        "138": "teste2"
+                                                    }
+                                            },
+                                            "productClusters": {
+                                                "type": "object",
+                                                "title": "productClusters",
+                                                "description": "Product clusters' IDs and names.",
+                                                "default": {
+                                                        "138": "teste2",
+                                                        "143": "NaoPesquisavel",
+                                                        "146": "colecaotestesubcategoria",
+                                                        "161": "merch_import_test1"
+                                                }
+                                            },
+                                            "searchableClusters": {
+                                                "type": "object",
+                                                "title": "searchableClusters",
+                                                "description": "Searchable clusters IDs and names",
+                                                "default": {
+                                                    "138": "teste2"
+                                                }
+                                            },
+                                            "categories": {
+                                                "type": "array",
+                                                "title": "categories",
+                                                "description": "Array of the product's categories URLs.",
+                                                "default": [
+                                                    "/Beers Beers Mesmo/"
+                                                ]
+                                            },
+                                            "categoriesIds": {
+                                                "type": "array",
+                                                "title": "categoriesIds",
+                                                "description": "Array of the product's categories IDs.",
+                                                "default": [
+                                                    "/1/"
+                                                ]
+                                            },
+                                            "link": {
+                                                "type": "string",
+                                                "title": "link",
+                                                "description": "Product URL.",
+                                                "default": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p"
+                                            },
+                                            "allSpecifications": {
+                                                "type": "array",
+                                                "title": "allSpecifications",
+                                                "description": "Array of the product's specifications.",
+                                                "default": [
+                                                    "Percentuals",
+                                                    "Percentual"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification.",
+                                                    "default": "Percentual"
+                                                }
+                                            },
+                                            "allSpecificationsGroups": {
+                                                "type": "array",
+                                                "title": "allSpecificationsGroups",
+                                                "description": "Array of the product's specifications groups.",
+                                                "default": [
+                                                    "Total",
+                                                    "Teste da Api2"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification group",
+                                                    "default": "Teste da Api2"
+                                                }
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "title": "description",
+                                                "description": "Description of the main information related to the product. A simple and easy to understand summary for the customer.",
+                                                "default": "Description example"
+                                            },
+                                            "items": {
+                                                "type": "array",
+                                                "title": "items",
+                                                "description": "Array containing the product SKU general information.",
+                                                "default": [
+                                                    {
+                                                        "itemId": "310118469",
+                                                        "name": "Kit com 6",
+                                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                        "complementName": "",
+                                                        "ean": "",
+                                                        "referenceId": [
+                                                            {
+                                                                "Key": "RefId",
+                                                                "Value": "000806"
+                                                            }
+                                                        ],
+                                                        "measurementUnit": "un",
+                                                        "unitMultiplier": 1.0,
+                                                        "modalType": null,
+                                                        "isKit": true,
+                                                        "kitItems": [
+                                                            {
+                                                                "itemId": "310118466",
+                                                                "amount": 6
+                                                            }
+                                                        ],
+                                                        "images": [
+                                                            {
+                                                                "imageId": "155489",
+                                                                "imageLabel": "",
+                                                                "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                "imageText": "hoegaarden-kit",
+                                                                "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                            }
+                                                        ],
+                                                        "sellers": [
+                                                            {
+                                                                "sellerId": "1",
+                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                "sellerDefault": true,
+                                                                "commertialOffer": {
+                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                        "0": {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    },
+                                                                    "Installments": [
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa à vista"
+                                                                        },
+                                                                        {
+                                                                            "Value": 21.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 2,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 14.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 3,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 3 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 10.5,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 4,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 4 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Promissory",
+                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                            "Name": "Promissory à vista"
+                                                                        }
+                                                                    ],
+                                                                    "DiscountHighLight": [],
+                                                                    "GiftSkuIds": [],
+                                                                    "Teasers": [],
+                                                                    "BuyTogether": [],
+                                                                    "ItemMetadataAttachment": [],
+                                                                    "Price": 42.0,
+                                                                    "ListPrice": 42.0,
+                                                                    "PriceWithoutDiscount": 42.0,
+                                                                    "RewardValue": 0.0,
+                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                    "AvailableQuantity": 16,
+                                                                    "IsAvailable": true,
+                                                                    "Tax": 0.0,
+                                                                    "SaleChannel": 0,
+                                                                    "DeliverySlaSamples": [
+                                                                        {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    ],
+                                                                    "GetInfoErrorMessage": null,
+                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                    "PaymentOptions": {
+                                                                        "installmentOptions": [
+                                                                            {
+                                                                                "paymentSystem": "2",
+                                                                                "bin": null,
+                                                                                "paymentName": "Visa",
+                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 2,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 2100,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 3,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1400,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 4,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1050,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "paymentSystem": "17",
+                                                                                "bin": null,
+                                                                                "paymentName": "Promissory",
+                                                                                "paymentGroupName": "promissoryPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "paymentSystems": [
+                                                                            {
+                                                                                "id": 17,
+                                                                                "name": "Promissory",
+                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "17",
+                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            },
+                                                                            {
+                                                                                "id": 2,
+                                                                                "name": "Visa",
+                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "2",
+                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            }
+                                                                        ],
+                                                                        "payments": [],
+                                                                        "giftCards": [],
+                                                                        "giftCardMessages": [],
+                                                                        "availableAccounts": [],
+                                                                        "availableTokens": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "Videos": [],
+                                                        "estimatedDateArrival": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": [
+                                                        {
+                                                            "itemId": "310118469",
+                                                            "name": "Kit com 6",
+                                                            "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                            "complementName": "",
+                                                            "ean": "",
+                                                            "referenceId": [
+                                                                {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                }
+                                                            ],
+                                                            "measurementUnit": "un",
+                                                            "unitMultiplier": 1.0,
+                                                            "modalType": null,
+                                                            "isKit": true,
+                                                            "kitItems": [
+                                                                {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                }
+                                                            ],
+                                                            "images": [
+                                                                {
+                                                                    "imageId": "155489",
+                                                                    "imageLabel": "",
+                                                                    "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                    "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                    "imageText": "hoegaarden-kit",
+                                                                    "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                }
+                                                            ],
+                                                            "sellers": [
+                                                                {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Videos": [],
+                                                            "estimatedDateArrival": null
+                                                        }
+                                                    ],
+                                                    "required": [
+                                                        "itemId",
+                                                        "name",
+                                                        "nameComplete",
+                                                        "complementName",
+                                                        "ean",
+                                                        "referenceId",
+                                                        "measurementUnit",
+                                                        "unitMultiplier",
+                                                        "modalType",
+                                                        "isKit",
+                                                        "kitItems",
+                                                        "images",
+                                                        "sellers",
+                                                        "Videos",
+                                                        "estimatedDateArrival"
+                                                    ],
+                                                    "properties": {
+                                                        "itemId": {
+                                                            "type": "string",
+                                                            "title": "itemId",
+                                                            "description": "SKU ID.",
+                                                            "default": "310118469"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "title": "name",
+                                                            "description": "SKU name.",
+                                                            "default": "Kit com 6"
+                                                        },
+                                                        "nameComplete": {
+                                                            "type": "string",
+                                                            "title": "nameComplete",
+                                                            "description": "SKU complete name.",
+                                                            "default": "Kit de Hoegaarden Kit com 6"
+                                                        },
+                                                        "complementName": {
+                                                            "type": "string",
+                                                            "title": "complementName",
+                                                            "description": "SKU complement name.",
+                                                            "default": "Complement name"
+                                                        },
+                                                        "ean": {
+                                                            "type": "string",
+                                                            "title": "ean",
+                                                            "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                            "default": "12345567"
+                                                        },
+                                                        "referenceId": {
+                                                            "type": "array",
+                                                            "title": "referenceId",
+                                                            "description": "Reference code ID.",
+                                                            "default": [
+                                                                    {
+                                                                        "Key": "RefId",
+                                                                        "Value": "000806"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                },
+                                                                "required": [
+                                                                    "Key",
+                                                                    "Value"
+                                                                ],
+                                                                "properties": {
+                                                                    "Key": {
+                                                                        "type": "string",
+                                                                        "title": "Key",
+                                                                        "description": "Reference Code.",
+                                                                        "default": [
+                                                                            "RefId"
+                                                                        ]
+                                                                    },
+                                                                    "Value": {
+                                                                        "type": "string",
+                                                                        "title": "Value",
+                                                                        "description": "Unique reference code used internally for organizational purposes.",
+                                                                        "default": [
+                                                                            "000806"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "measurementUnit": {
+                                                            "type": "string",
+                                                            "title": "measurementUnit",
+                                                            "description": "Used only in cases when you need to convert the unit of measure for sale. In common cases, use 'un'.",
+                                                            "default": [
+                                                                "un"
+                                                            ]
+                                                        },
+                                                        "unitMultiplier": {
+                                                            "type": "number",
+                                                            "title": "unitMultiplier",
+                                                            "description": "numerical unit that multiplies the selected quantity of the product when it is inserted in the cart.",
+                                                            "default": 1.0
+                                                        },
+                                                        "modalType": {
+                                                            "type": "string",
+                                                            "title": "modalType",
+                                                            "description": "Modal Type.",
+                                                            "default": "Modal Type test"
+                                                        },
+                                                        "isKit": {
+                                                            "type": "boolean",
+                                                            "title": "isKit",
+                                                            "description": "If the SKU is part of a kit.",
+                                                            "default": true
+                                                        },
+                                                        "kitItems": {
+                                                            "type": "array",
+                                                            "title": "kitItems",
+                                                            "description": "Array with information of SKUs components from a Kit.",
+                                                            "default": [
+                                                                    {
+                                                                        "itemId": "310118466",
+                                                                        "amount": 6
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                },
+                                                                "required": [
+                                                                    "itemId",
+                                                                    "amount"
+                                                                ],
+                                                                "properties": {
+                                                                    "itemId": {
+                                                                        "type": "string",
+                                                                        "title": "itemId",
+                                                                        "description": "SKU kit component ID.",
+                                                                        "default": [
+                                                                            "310118466"
+                                                                        ]
+                                                                    },
+                                                                    "amount": {
+                                                                        "type": "integer",
+                                                                        "title": "amount",
+                                                                        "description": "Amount of the SKU component in the kit.",
+                                                                        "default": 6
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "title": "images",
+                                                            "description": "Array of information about the SKU image.",
+                                                            "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                                "required": [
+                                                                    "imageId",
+                                                                    "imageLabel",
+                                                                    "imageTag",
+                                                                    "imageUrl",
+                                                                    "imageText",
+                                                                    "imageLastModified"
+                                                                ],
+                                                                "properties": {
+                                                                    "imageId": {
+                                                                        "type": "string",
+                                                                        "title": "imageId",
+                                                                        "description": "Image ID.",
+                                                                        "default": [
+                                                                            "155489"
+                                                                        ]
+                                                                    },
+                                                                    "imageLabel": {
+                                                                        "type": "string",
+                                                                        "title": "imageLabel",
+                                                                        "description": "Image label.",
+                                                                        "default": "Label test"
+                                                                    },
+                                                                    "imageTag": {
+                                                                        "type": "string",
+                                                                        "title": "imageTag",
+                                                                        "description": "Image tag.",
+                                                                        "default": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
+                                                                    },
+                                                                    "imageUrl": {
+                                                                        "type": "string",
+                                                                        "title": "imageUrl",
+                                                                        "description": "Image URL.",
+                                                                        "default": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
+                                                                    },
+                                                                    "imageText": {
+                                                                        "type": "string",
+                                                                        "title": "imageText",
+                                                                        "description": "Image text.",
+                                                                        "default": "hoegaarden-kit"
+                                                                    },
+                                                                    "imageLastModified": {
+                                                                        "type": "string",
+                                                                        "title": "imageLastModified",
+                                                                        "description": "Date and time of the last update of the image.",
+                                                                        "default": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "sellers": {
+                                                            "type": "array",
+                                                            "title": "sellers",
+                                                            "description": "Array of SKU sellers.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "sellerId": "1",
+                                                                        "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                        "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                        "sellerDefault": true,
+                                                                        "commertialOffer": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "sellerId",
+                                                                    "sellerName",
+                                                                    "addToCartLink",
+                                                                    "sellerDefault",
+                                                                    "commertialOffer"
+                                                                ],
+                                                                "properties": {
+                                                                    "sellerId": {
+                                                                        "type": "string",
+                                                                        "title": "sellerId",
+                                                                        "description": "SKU seller ID.",
+                                                                        "default": "1"
+                                                                    },
+                                                                    "sellerName": {
+                                                                        "type": "string",
+                                                                        "title": "sellerName",
+                                                                        "description": "SKU seller name.",
+                                                                        "default": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
+                                                                    },
+                                                                    "addToCartLink": {
+                                                                        "type": "string",
+                                                                        "title": "addToCartLink",
+                                                                        "description": "URL to add the product to the cart.",
+                                                                        "default": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
+                                                                    },
+                                                                    "sellerDefault": {
+                                                                        "type": "boolean",
+                                                                        "title": "sellerDefault",
+                                                                        "description": "If the seller is default or not.",
+                                                                        "default": true
+                                                                    },
+                                                                    "commertialOffer": {
+                                                                        "type": "object",
+                                                                        "title": "commertialOffer",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "DeliverySlaSamplesPerRegion",
+                                                                            "Installments",
+                                                                            "DiscountHighLight",
+                                                                            "GiftSkuIds",
+                                                                            "Teasers",
+                                                                            "BuyTogether",
+                                                                            "ItemMetadataAttachment",
+                                                                            "Price",
+                                                                            "ListPrice",
+                                                                            "PriceWithoutDiscount",
+                                                                            "RewardValue",
+                                                                            "PriceValidUntil",
+                                                                            "AvailableQuantity",
+                                                                            "IsAvailable",
+                                                                            "Tax",
+                                                                            "SaleChannel",
+                                                                            "DeliverySlaSamples",
+                                                                            "GetInfoErrorMessage",
+                                                                            "CacheVersionUsedToCallCheckout",
+                                                                            "PaymentOptions"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "type": "object",
+                                                                                "title": "DeliverySlaSamplesPerRegion",
+                                                                                "description": "Delivery SLA samples per region.",
+                                                                                "default": {
+                                                                                    "0": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": "null"
+                                                                                    }
+                                                                                },
+                                                                                "properties": {
+                                                                                    "0": {
+                                                                                        "type": "object",
+                                                                                        "title": "The 0 schema",
+                                                                                        "description": "0.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "required": [
+                                                                                            "DeliverySlaPerTypes",
+                                                                                            "Region"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "DeliverySlaPerTypes": {
+                                                                                                "type": "array",
+                                                                                                "title": "DeliverySlaPerTypes",
+                                                                                                "description": "Delivery SLA per types.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "Region": {
+                                                                                                "type": "string",
+                                                                                                "title": "Region",
+                                                                                                "description": "Region.",
+                                                                                                "default": ""
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "Installments": {
+                                                                                "type": "array",
+                                                                                "title": "Installments",
+                                                                                "description": "Installments options.",
+                                                                                "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 21.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 2,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                                        }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        }
+                                                                                    ],
+                                                                                    "required": [
+                                                                                        "Value",
+                                                                                        "InterestRate",
+                                                                                        "TotalValuePlusInterestRate",
+                                                                                        "NumberOfInstallments",
+                                                                                        "PaymentSystemName",
+                                                                                        "PaymentSystemGroupName",
+                                                                                        "Name"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "Value": {
+                                                                                            "type": "number",
+                                                                                            "title": "Value",
+                                                                                            "description": "Value of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "InterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "InterestRate",
+                                                                                            "description": "Interest rate of the installment.",
+                                                                                            "default": 0.0
+                                                                                        },
+                                                                                        "TotalValuePlusInterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "TotalValuePlusInterestRate",
+                                                                                            "description": "Total value plus interest rate of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "NumberOfInstallments": {
+                                                                                            "type": "integer",
+                                                                                            "title": "NumberOfInstallments",
+                                                                                            "description": "Number of the installment.",
+                                                                                            "default": 1
+                                                                                        },
+                                                                                        "PaymentSystemName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemName",
+                                                                                            "description": "Payment system name of the installment.",
+                                                                                            "default": "Visa"
+                                                                                        },
+                                                                                        "PaymentSystemGroupName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemGroupName",
+                                                                                            "description": "Payment system group name of the installment.",
+                                                                                            "default": "creditCardPaymentGroup"
+                                                                                        },
+                                                                                        "Name": {
+                                                                                            "type": "string",
+                                                                                            "title": "Name",
+                                                                                            "description": "Name of the installment.",
+                                                                                            "default": "Visa à vista"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "DiscountHighLight": {
+                                                                                "type": "array",
+                                                                                "title": "DiscountHighLight",
+                                                                                "description": "Discount hightlight.",
+                                                                                "default": []
+                                                                            },
+                                                                            "GiftSkuIds": {
+                                                                                "type": "array",
+                                                                                "title": "GiftSkuIds",
+                                                                                "description": "Array of SKU gifts IDs.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Teasers": {
+                                                                                "type": "array",
+                                                                                "title": "Teasers",
+                                                                                "description": "Teasers.",
+                                                                                "default": []
+                                                                            },
+                                                                            "BuyTogether": {
+                                                                                "type": "array",
+                                                                                "title": "BuyTogether",
+                                                                                "description": "Array of other products that can be bought together with the product in question.",
+                                                                                "default": []
+                                                                            },
+                                                                            "ItemMetadataAttachment": {
+                                                                                "type": "array",
+                                                                                "title": "ItemMetadataAttachment",
+                                                                                "description": "Item metadata attachment.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Price": {
+                                                                                "type": "number",
+                                                                                "title": "Price",
+                                                                                "description": "Price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "ListPrice": {
+                                                                                "type": "number",
+                                                                                "title": "ListPrice",
+                                                                                "description": "List price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "PriceWithoutDiscount": {
+                                                                                "type": "number",
+                                                                                "title": "PriceWithoutDiscount",
+                                                                                "description": "Price of the product without discount.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "RewardValue": {
+                                                                                "type": "number",
+                                                                                "title": "RewardValue",
+                                                                                "description": "Reward value of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "PriceValidUntil": {
+                                                                                "type": "string",
+                                                                                "title": "PriceValidUntil",
+                                                                                "description": "Price of the product valid until a certain date.",
+                                                                                "default": "4000-01-01T03:00:00Z"
+                                                                            },
+                                                                            "AvailableQuantity": {
+                                                                                "type": "integer",
+                                                                                "title": "AvailableQuantity",
+                                                                                "description": "Available quantity of the product.",
+                                                                                "default": 16
+                                                                            },
+                                                                            "IsAvailable": {
+                                                                                "type": "boolean",
+                                                                                "title": "IsAvailable",
+                                                                                "description": "If the product is available or not.",
+                                                                                "default": true
+                                                                            },
+                                                                            "Tax": {
+                                                                                "type": "number",
+                                                                                "title": "Tax",
+                                                                                "description": "Tax of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "SaleChannel": {
+                                                                                "type": "integer",
+                                                                                "title": "SaleChannel",
+                                                                                "description": "Trade policy which the product is contained.",
+                                                                                "default": 0
+                                                                            },
+                                                                            "DeliverySlaSamples": {
+                                                                                "type": "array",
+                                                                                "title": "DeliverySlaSamples",
+                                                                                "description": "Delivery SLA samples.",
+                                                                                "default": [
+                                                                                    {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "DeliverySlaPerTypes",
+                                                                                        "Region"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "DeliverySlaPerTypes": {
+                                                                                            "type": "array",
+                                                                                            "title": "DeliverySlaPerTypes",
+                                                                                            "description": "Delivery SLA per types.",
+                                                                                            "default": []
+                                                                                        },
+                                                                                        "Region": {
+                                                                                            "type": "string",
+                                                                                            "title": "Region",
+                                                                                            "description": "Region.",
+                                                                                            "default": null
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "GetInfoErrorMessage": {
+                                                                                "type": "string",
+                                                                                "title": "GetInfoErrorMessage",
+                                                                                "description": "Get info error message.",
+                                                                                "default": null
+                                                                            },
+                                                                            "CacheVersionUsedToCallCheckout": {
+                                                                                "type": "string",
+                                                                                "title": "CacheVersionUsedToCallCheckout",
+                                                                                "description": "Cache version used to call checkout.",
+                                                                                "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                            },
+                                                                            "PaymentOptions": {
+                                                                                "type": "object",
+                                                                                "title": "PaymentOptions",
+                                                                                "description": "Payment options.",
+                                                                                "default": {
+                                                                                    "installmentOptions": [
+                                                                                        {
+                                                                                            "paymentSystem": "2",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Visa",
+                                                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "paymentSystem": "17",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Promissory",
+                                                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ],
+                                                                                    "paymentSystems": [
+                                                                                        {
+                                                                                            "id": 17,
+                                                                                            "name": "Promissory",
+                                                                                            "groupName": "promissoryPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "17",
+                                                                                            "template": "promissoryPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        },
+                                                                                        {
+                                                                                            "id": 2,
+                                                                                            "name": "Visa",
+                                                                                            "groupName": "creditCardPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "2",
+                                                                                            "template": "creditCardPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        }
+                                                                                    ],
+                                                                                    "payments": [],
+                                                                                    "giftCards": [],
+                                                                                    "giftCardMessages": [],
+                                                                                    "availableAccounts": [],
+                                                                                    "availableTokens": []
+                                                                                },
+                                                                                "required": [
+                                                                                    "installmentOptions",
+                                                                                    "paymentSystems",
+                                                                                    "payments",
+                                                                                    "giftCards",
+                                                                                    "giftCardMessages",
+                                                                                    "availableAccounts",
+                                                                                    "availableTokens"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "installmentOptions": {
+                                                                                        "type": "array",
+                                                                                        "title": "installmentOptions",
+                                                                                        "description": "installment options.",
+                                                                                        "default": [
+                                                                                            [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "paymentSystem": "2",
+                                                                                                "bin": null,
+                                                                                                "paymentName": "Visa",
+                                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                "value": 4200,
+                                                                                                "installments": [
+                                                                                                    {
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 2,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 2100,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 3,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1400,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 4,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1050,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "paymentSystem",
+                                                                                                "bin",
+                                                                                                "paymentName",
+                                                                                                "paymentGroupName",
+                                                                                                "value",
+                                                                                                "installments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "paymentSystem": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentSystem",
+                                                                                                    "description": "Payment system.",
+                                                                                                    "default": "2"
+                                                                                                },
+                                                                                                "bin": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "bin",
+                                                                                                    "description": "Bin.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "paymentName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentName",
+                                                                                                    "description": "Payment name.",
+                                                                                                    "default": "Visa"
+                                                                                                },
+                                                                                                "paymentGroupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentGroupName",
+                                                                                                    "description": "Payment group name.",
+                                                                                                    "default": "creditCardPaymentGroup"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "value",
+                                                                                                    "description": "Value.",
+                                                                                                    "default": 4200
+                                                                                                },
+                                                                                                "installments": {
+                                                                                                    "type": "array",
+                                                                                                    "title": "installments",
+                                                                                                    "description": "Installments.",
+                                                                                                    "default": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ],
+                                                                                                    "items": {
+                                                                                                        "type": "object",
+                                                                                                        "title": "",
+                                                                                                        "default": {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "required": [
+                                                                                                            "count",
+                                                                                                            "hasInterestRate",
+                                                                                                            "interestRate",
+                                                                                                            "value",
+                                                                                                            "total",
+                                                                                                            "sellerMerchantInstallments"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                            "count": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "count",
+                                                                                                                "description": "Count.",
+                                                                                                                "default": 1
+                                                                                                            },
+                                                                                                            "hasInterestRate": {
+                                                                                                                "type": "boolean",
+                                                                                                                "title": "hasInterestRate",
+                                                                                                                "description": "Has interest rate.",
+                                                                                                                "default": false
+                                                                                                            },
+                                                                                                            "interestRate": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "interestRate",
+                                                                                                                "description": "Interest rate.",
+                                                                                                                "default": 0
+                                                                                                            },
+                                                                                                            "value": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "value",
+                                                                                                                "description": "Value.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "total": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "total",
+                                                                                                                "description": "Total.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "sellerMerchantInstallments": {
+                                                                                                                "type": "array",
+                                                                                                                "title": "sellerMerchantInstallments",
+                                                                                                                "description": "Seller merchant installments.",
+                                                                                                                "default": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "items": {
+                                                                                                                    "type": "object",
+                                                                                                                    "title": "",
+                                                                                                                    "default": {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                        "id",
+                                                                                                                        "count",
+                                                                                                                        "hasInterestRate",
+                                                                                                                        "interestRate",
+                                                                                                                        "value",
+                                                                                                                        "total"
+                                                                                                                    ],
+                                                                                                                    "properties": {
+                                                                                                                        "id": {
+                                                                                                                            "type": "string",
+                                                                                                                            "title": "id",
+                                                                                                                            "description": "ID.",
+                                                                                                                            "default": "MERCH"
+                                                                                                                        },
+                                                                                                                        "count": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "count",
+                                                                                                                            "description": "Count.",
+                                                                                                                            "default": 1
+                                                                                                                        },
+                                                                                                                        "hasInterestRate": {
+                                                                                                                            "type": "boolean",
+                                                                                                                            "title": "hasInterestRate",
+                                                                                                                            "description": "Has interest rate.",
+                                                                                                                            "default": false
+                                                                                                                        },
+                                                                                                                        "interestRate": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "interestRate",
+                                                                                                                            "description": "Interest rate.",
+                                                                                                                            "default": 0
+                                                                                                                        },
+                                                                                                                        "value": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "value",
+                                                                                                                            "description": "Value.",
+                                                                                                                            "default": 4200
+                                                                                                                        },
+                                                                                                                        "total": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "total",
+                                                                                                                            "description": "Total.",
+                                                                                                                            "default": 4200
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "paymentSystems": {
+                                                                                        "type": "array",
+                                                                                        "title": "paymentSystems",
+                                                                                        "description": "Payment systems.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            {
+                                                                                                "id": 2,
+                                                                                                "name": "Visa",
+                                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "2",
+                                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "id",
+                                                                                                "name",
+                                                                                                "groupName",
+                                                                                                "validator",
+                                                                                                "stringId",
+                                                                                                "template",
+                                                                                                "requiresDocument",
+                                                                                                "isCustom",
+                                                                                                "description",
+                                                                                                "requiresAuthentication",
+                                                                                                "dueDate",
+                                                                                                "availablePayments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "id": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "id",
+                                                                                                    "description": "ID.",
+                                                                                                    "default": 17
+                                                                                                },
+                                                                                                "name": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "name",
+                                                                                                    "description": "Name.",
+                                                                                                    "default": "Promissory"
+                                                                                                },
+                                                                                                "groupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "groupName",
+                                                                                                    "description": "Group name.",
+                                                                                                    "default": "promissoryPaymentGroup"
+                                                                                                },
+                                                                                                "validator": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "validator",
+                                                                                                    "description": "Validator.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "stringId": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "stringId",
+                                                                                                    "description": "String ID.",
+                                                                                                    "default": "17"
+                                                                                                },
+                                                                                                "template": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "template",
+                                                                                                    "description": "Template.",
+                                                                                                    "default": "promissoryPaymentGroup-template"
+                                                                                                },
+                                                                                                "requiresDocument": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresDocument",
+                                                                                                    "description": "If requires document or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "isCustom": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "isCustom",
+                                                                                                    "description": "If is custom or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "description": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "description",
+                                                                                                    "description": "Description.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "requiresAuthentication": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresAuthentication",
+                                                                                                    "description": "If requires authentication.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "dueDate": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "dueDate",
+                                                                                                    "description": "Due date.",
+                                                                                                    "default": "2021-07-01T18:43:00.0264384Z"
+                                                                                                },
+                                                                                                "availablePayments": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "availablePayments",
+                                                                                                    "description": "Available payments.",
+                                                                                                    "default": ""
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "payments": {
+                                                                                        "type": "array",
+                                                                                        "title": "payments",
+                                                                                        "description": "Payments.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCards": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCards",
+                                                                                        "description": "GiftCards.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCardMessages": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCardMessages",
+                                                                                        "description": "GiftCardMessages.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableAccounts": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableAccounts",
+                                                                                        "description": "Available accounts.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableTokens": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableTokens",
+                                                                                        "description": "Available tokens.",
+                                                                                        "default": []
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "Videos": {
+                                                            "type": "array",
+                                                            "title": "Videos",
+                                                            "description": "Videos.",
+                                                            "default": []
+                                                        },
+                                                        "estimatedDateArrival": {
+                                                            "type": "string",
+                                                            "title": "estimatedDateArrival",
+                                                            "description": "Estimated date arrival.",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
 					}
 				},
 				"deprecated": false,

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -2711,38 +2711,38 @@
                                                                                             "properties": {
                                                                                                 "paymentSystem": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The paymentSystem schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "paymentSystem",
+                                                                                                    "description": "Payment system.",
                                                                                                     "default": "2"
                                                                                                 },
                                                                                                 "bin": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The bin schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "bin",
+                                                                                                    "description": "Bin.",
                                                                                                     "default": null
                                                                                                 },
                                                                                                 "paymentName": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The paymentName schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "paymentName",
+                                                                                                    "description": "Payment name.",
                                                                                                     "default": "Visa"
                                                                                                 },
                                                                                                 "paymentGroupName": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The paymentGroupName schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "paymentGroupName",
+                                                                                                    "description": "Payment group name.",
                                                                                                     "default": "creditCardPaymentGroup"
                                                                                                 },
                                                                                                 "value": {
                                                                                                     "type": "integer",
-                                                                                                    "title": "The value schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "value",
+                                                                                                    "description": "Value.",
                                                                                                     "default": 4200
                                                                                                 },
                                                                                                 "installments": {
                                                                                                     "type": "array",
-                                                                                                    "title": "The installments schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "installments",
+                                                                                                    "description": "Installments.",
                                                                                                     "default": [
                                                                                                         {
                                                                                                             "count": 1,
@@ -2781,8 +2781,7 @@
                                                                                                     ],
                                                                                                     "items": {
                                                                                                         "type": "object",
-                                                                                                        "title": "The first anyOf schema",
-                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                        "title": "",
                                                                                                         "default": {
                                                                                                             "count": 1,
                                                                                                             "hasInterestRate": false,
@@ -2811,38 +2810,38 @@
                                                                                                         "properties": {
                                                                                                             "count": {
                                                                                                                 "type": "integer",
-                                                                                                                "title": "The count schema",
-                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "title": "count",
+                                                                                                                "description": "Count.",
                                                                                                                 "default": 1
                                                                                                             },
                                                                                                             "hasInterestRate": {
                                                                                                                 "type": "boolean",
-                                                                                                                "title": "The hasInterestRate schema",
-                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "title": "hasInterestRate",
+                                                                                                                "description": "Has interest rate.",
                                                                                                                 "default": false
                                                                                                             },
                                                                                                             "interestRate": {
                                                                                                                 "type": "integer",
-                                                                                                                "title": "The interestRate schema",
-                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "title": "interestRate",
+                                                                                                                "description": "Interest rate.",
                                                                                                                 "default": 0
                                                                                                             },
                                                                                                             "value": {
                                                                                                                 "type": "integer",
-                                                                                                                "title": "The value schema",
-                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "title": "value",
+                                                                                                                "description": "Value.",
                                                                                                                 "default": 4200
                                                                                                             },
                                                                                                             "total": {
                                                                                                                 "type": "integer",
-                                                                                                                "title": "The total schema",
-                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "title": "total",
+                                                                                                                "description": "Total.",
                                                                                                                 "default": 4200
                                                                                                             },
                                                                                                             "sellerMerchantInstallments": {
                                                                                                                 "type": "array",
-                                                                                                                "title": "The sellerMerchantInstallments schema",
-                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "title": "sellerMerchantInstallments",
+                                                                                                                "description": "Seller merchant installments.",
                                                                                                                 "default": [
                                                                                                                     {
                                                                                                                         "id": "MERCH",
@@ -2855,8 +2854,7 @@
                                                                                                                 ],
                                                                                                                 "items": {
                                                                                                                     "type": "object",
-                                                                                                                    "title": "The first anyOf schema",
-                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                    "title": "",
                                                                                                                     "default": {
                                                                                                                         "id": "MERCH",
                                                                                                                         "count": 1,
@@ -2876,38 +2874,38 @@
                                                                                                                     "properties": {
                                                                                                                         "id": {
                                                                                                                             "type": "string",
-                                                                                                                            "title": "The id schema",
-                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "title": "id",
+                                                                                                                            "description": "ID.",
                                                                                                                             "default": "MERCH"
                                                                                                                         },
                                                                                                                         "count": {
                                                                                                                             "type": "integer",
-                                                                                                                            "title": "The count schema",
-                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "title": "count",
+                                                                                                                            "description": "Count.",
                                                                                                                             "default": 1
                                                                                                                         },
                                                                                                                         "hasInterestRate": {
                                                                                                                             "type": "boolean",
-                                                                                                                            "title": "The hasInterestRate schema",
-                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "title": "hasInterestRate",
+                                                                                                                            "description": "Has interest rate.",
                                                                                                                             "default": false
                                                                                                                         },
                                                                                                                         "interestRate": {
                                                                                                                             "type": "integer",
-                                                                                                                            "title": "The interestRate schema",
-                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "title": "interestRate",
+                                                                                                                            "description": "Interest rate.",
                                                                                                                             "default": 0
                                                                                                                         },
                                                                                                                         "value": {
                                                                                                                             "type": "integer",
-                                                                                                                            "title": "The value schema",
-                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "title": "value",
+                                                                                                                            "description": "Value.",
                                                                                                                             "default": 4200
                                                                                                                         },
                                                                                                                         "total": {
                                                                                                                             "type": "integer",
-                                                                                                                            "title": "The total schema",
-                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "title": "total",
+                                                                                                                            "description": "Total.",
                                                                                                                             "default": 4200
                                                                                                                         }
                                                                                                                     }
@@ -2921,8 +2919,8 @@
                                                                                     },
                                                                                     "paymentSystems": {
                                                                                         "type": "array",
-                                                                                        "title": "The paymentSystems schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "title": "paymentSystems",
+                                                                                        "description": "Payment systems.",
                                                                                         "default": [
                                                                                             {
                                                                                                 "id": 17,
@@ -2955,8 +2953,7 @@
                                                                                         ],
                                                                                         "items": {
                                                                                             "type": "object",
-                                                                                            "title": "The first anyOf schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "",
                                                                                             "default": {
                                                                                                 "id": 17,
                                                                                                 "name": "Promissory",
@@ -2988,107 +2985,107 @@
                                                                                             "properties": {
                                                                                                 "id": {
                                                                                                     "type": "integer",
-                                                                                                    "title": "The id schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "id",
+                                                                                                    "description": "ID.",
                                                                                                     "default": 17
                                                                                                 },
                                                                                                 "name": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The name schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "name",
+                                                                                                    "description": "Name.",
                                                                                                     "default": "Promissory"
                                                                                                 },
                                                                                                 "groupName": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The groupName schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "groupName",
+                                                                                                    "description": "Group name.",
                                                                                                     "default": "promissoryPaymentGroup"
                                                                                                 },
                                                                                                 "validator": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The validator schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": null
+                                                                                                    "title": "validator",
+                                                                                                    "description": "Validator.",
+                                                                                                    "default": ""
                                                                                                 },
                                                                                                 "stringId": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The stringId schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "stringId",
+                                                                                                    "description": "String ID.",
                                                                                                     "default": "17"
                                                                                                 },
                                                                                                 "template": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The template schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "template",
+                                                                                                    "description": "Template.",
                                                                                                     "default": "promissoryPaymentGroup-template"
                                                                                                 },
                                                                                                 "requiresDocument": {
                                                                                                     "type": "boolean",
-                                                                                                    "title": "The requiresDocument schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "requiresDocument",
+                                                                                                    "description": "If requires document or not.",
                                                                                                     "default": false
                                                                                                 },
                                                                                                 "isCustom": {
                                                                                                     "type": "boolean",
-                                                                                                    "title": "The isCustom schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "isCustom",
+                                                                                                    "description": "If is custom or not.",
                                                                                                     "default": false
                                                                                                 },
                                                                                                 "description": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The description schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": null
+                                                                                                    "title": "description",
+                                                                                                    "description": "Description.",
+                                                                                                    "default": ""
                                                                                                 },
                                                                                                 "requiresAuthentication": {
                                                                                                     "type": "boolean",
-                                                                                                    "title": "The requiresAuthentication schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "requiresAuthentication",
+                                                                                                    "description": "If requires authentication.",
                                                                                                     "default": false
                                                                                                 },
                                                                                                 "dueDate": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The dueDate schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "title": "dueDate",
+                                                                                                    "description": "Due date.",
                                                                                                     "default": "2021-07-01T18:43:00.0264384Z"
                                                                                                 },
                                                                                                 "availablePayments": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The availablePayments schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": null
+                                                                                                    "title": "availablePayments",
+                                                                                                    "description": "Available payments.",
+                                                                                                    "default": ""
                                                                                                 }
                                                                                             }
                                                                                         }
                                                                                     },
                                                                                     "payments": {
                                                                                         "type": "array",
-                                                                                        "title": "The payments schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "title": "payments",
+                                                                                        "description": "Payments.",
                                                                                         "default": []
                                                                                     },
                                                                                     "giftCards": {
                                                                                         "type": "array",
-                                                                                        "title": "The giftCards schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "title": "giftCards",
+                                                                                        "description": "GiftCards.",
                                                                                         "default": []
                                                                                     },
                                                                                     "giftCardMessages": {
                                                                                         "type": "array",
-                                                                                        "title": "The giftCardMessages schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "title": "giftCardMessages",
+                                                                                        "description": "GiftCardMessages.",
                                                                                         "default": []
                                                                                     },
                                                                                     "availableAccounts": {
                                                                                         "type": "array",
-                                                                                        "title": "The availableAccounts schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "title": "availableAccounts",
+                                                                                        "description": "Available accounts.",
                                                                                         "default": []
                                                                                     },
                                                                                     "availableTokens": {
                                                                                         "type": "array",
-                                                                                        "title": "The availableTokens schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "title": "availableTokens",
+                                                                                        "description": "Available tokens.",
                                                                                         "default": []
                                                                                     }
                                                                                 }
@@ -3100,15 +3097,15 @@
                                                         },
                                                         "Videos": {
                                                             "type": "array",
-                                                            "title": "The Videos schema",
-                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "title": "Videos",
+                                                            "description": "Videos.",
                                                             "default": []
                                                         },
                                                         "estimatedDateArrival": {
                                                             "type": "string",
-                                                            "title": "The estimatedDateArrival schema",
-                                                            "description": "An explanation about the purpose of this instance.",
-                                                            "default": null
+                                                            "title": "estimatedDateArrival",
+                                                            "description": "Estimated date arrival.",
+                                                            "default": ""
                                                         }
                                                     }
                                                 }

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -15970,8 +15970,8 @@
 				"tags": [
 					"Search"
 				],
-				"summary": "Search by product URL",
-				"description": "",
+				"summary": "Search Product by Product URL",
+				"description": "Retrieves general information about the product of the URL you searched for",
 				"operationId": "Searchbyproducturl",
 				"parameters": [
                     {
@@ -16019,18 +16019,3054 @@
 					{
 						"name": "product-text-link",
 						"in": "path",
-						"description": "",
+						"description": "Product URL",
 						"required": true,
 						"style": "simple",
 						"schema": {
-							"type": "string"
+                            "type": "string",
+                            "default": "blue-shirt"
 						}
 					}
 				],
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {}
+						"headers": {},
+                        "content": {
+                            "application/json":{
+                                "example":[{
+                                    "productId": "35",
+                                    "productName": "Kit de Hoegaarden",
+                                    "brand": "Hoegaarden",
+                                    "brandId": 2000004,
+                                    "brandImageUrl": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg",
+                                    "linkText": "kit-6-cerveja-hoegaarden",
+                                    "productReference": "000806",
+                                    "productReferenceCode": null,
+                                    "categoryId": "1",
+                                    "productTitle": "",
+                                    "metaTagDescription": "",
+                                    "releaseDate": "2020-10-07T00:00:00",
+                                    "clusterHighlights": {
+                                        "138": "teste2"
+                                    },
+                                    "productClusters": {
+                                        "138": "teste2",
+                                        "143": "NaoPesquisavel",
+                                        "146": "colecaotestesubcategoria",
+                                        "161": "merch_import_test1"
+                                    },
+                                    "searchableClusters": {
+                                        "138": "teste2"
+                                    },
+                                    "categories": [
+                                        "/Beers Beers Mesmo/"
+                                    ],
+                                    "categoriesIds": [
+                                        "/1/"
+                                    ],
+                                    "link": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p",
+                                    "Percentuals": [
+                                        "4,9"
+                                    ],
+                                    "Percentual": [
+                                        "4,9"
+                                    ],
+                                    "Total": [
+                                        "Percentuals",
+                                        "Percentual"
+                                    ],
+                                    "Teste de Api": [
+                                        "a"
+                                    ],
+                                    "Ale": [
+                                        "1"
+                                    ],
+                                    "Teste da Api2": [
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "Alcool": [
+                                        "Percentual"
+                                    ],
+                                    "allSpecifications": [
+                                        "Percentuals",
+                                        "Percentual",
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "allSpecificationsGroups": [
+                                        "Total",
+                                        "Teste da Api2"
+                                    ],
+                                    "description": "",
+                                    "items": [{
+                                        "itemId": "310118469",
+                                        "name": "Kit com 6",
+                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                        "complementName": "",
+                                        "ean": "",
+                                        "referenceId": [{
+                                            "Key": "RefId",
+                                            "Value": "000806"
+                                        }],
+                                        "measurementUnit": "un",
+                                        "unitMultiplier": 1.0000,
+                                        "modalType": null,
+                                        "isKit": true,
+                                        "kitItems": [{
+                                            "itemId": "310118466",
+                                            "amount": 6
+                                        }],
+                                        "images": [{
+                                            "imageId": "155489",
+                                            "imageLabel": "",
+                                            "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                            "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                            "imageText": "hoegaarden-kit",
+                                            "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                        }],
+                                        "sellers": [{
+                                            "sellerId": "1",
+                                            "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                            "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                            "sellerDefault": true,
+                                            "commertialOffer": {
+                                                "DeliverySlaSamplesPerRegion": {
+                                                    "0": {
+                                                        "DeliverySlaPerTypes": [],
+                                                        "Region": null
+                                                    }
+                                                },
+                                                "Installments": [{
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa à vista"
+                                                    },
+                                                    {
+                                                        "Value": 21.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 2,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 2 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 14.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 3,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 3 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 10.5,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 4,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 4 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Promissory",
+                                                        "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                        "Name": "Promissory à vista"
+                                                    }
+                                                ],
+                                                "DiscountHighLight": [],
+                                                "GiftSkuIds": [],
+                                                "Teasers": [],
+                                                "BuyTogether": [],
+                                                "ItemMetadataAttachment": [],
+                                                "Price": 42.0,
+                                                "ListPrice": 42.0,
+                                                "PriceWithoutDiscount": 42.0,
+                                                "RewardValue": 0.0,
+                                                "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                "AvailableQuantity": 16,
+                                                "IsAvailable": true,
+                                                "Tax": 0.0,
+                                                "SaleChannel": 0,
+                                                "DeliverySlaSamples": [{
+                                                    "DeliverySlaPerTypes": [],
+                                                    "Region": null
+                                                }],
+                                                "GetInfoErrorMessage": null,
+                                                "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                "PaymentOptions": {
+                                                    "installmentOptions": [{
+                                                            "paymentSystem": "2",
+                                                            "bin": null,
+                                                            "paymentName": "Visa",
+                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 1,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 4200,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 2,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 2100,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 2,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 2100,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 3,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1400,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 3,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1400,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 4,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1050,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 4,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1050,
+                                                                        "total": 4200
+                                                                    }]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "paymentSystem": "17",
+                                                            "bin": null,
+                                                            "paymentName": "Promissory",
+                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                "count": 1,
+                                                                "hasInterestRate": false,
+                                                                "interestRate": 0,
+                                                                "value": 4200,
+                                                                "total": 4200,
+                                                                "sellerMerchantInstallments": [{
+                                                                    "id": "MERCH",
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200
+                                                                }]
+                                                            }]
+                                                        }
+                                                    ],
+                                                    "paymentSystems": [{
+                                                            "id": 17,
+                                                            "name": "Promissory",
+                                                            "groupName": "promissoryPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "17",
+                                                            "template": "promissoryPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "name": "Visa",
+                                                            "groupName": "creditCardPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "2",
+                                                            "template": "creditCardPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        }
+                                                    ],
+                                                    "payments": [],
+                                                    "giftCards": [],
+                                                    "giftCardMessages": [],
+                                                    "availableAccounts": [],
+                                                    "availableTokens": []
+                                                }
+                                            }
+                                        }],
+                                        "Videos": [],
+                                        "estimatedDateArrival": null
+                                    }]
+                                }],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "",
+                                        "required": [
+                                            "productId",
+                                            "productName",
+                                            "brand",
+                                            "brandId",
+                                            "brandImageUrl",
+                                            "linkText",
+                                            "productReference",
+                                            "productReferenceCode",
+                                            "categoryId",
+                                            "productTitle",
+                                            "metaTagDescription",
+                                            "releaseDate",
+                                            "clusterHighlights",
+                                            "productClusters",
+                                            "searchableClusters",
+                                            "categories",
+                                            "categoriesIds",
+                                            "link",
+                                            "Percentuals",
+                                            "Percentual",
+                                            "Total",
+                                            "Teste de Api",
+                                            "Ale",
+                                            "Teste da Api2",
+                                            "Alcool",
+                                            "allSpecifications",
+                                            "allSpecificationsGroups",
+                                            "description",
+                                            "items"
+                                        ],
+                                        "properties": {
+                                            "productId": {
+                                                "type": "string",
+                                                "title": "productId",
+                                                "description": "Product unique identifier.",
+                                                "default": "35"
+                                            },
+                                            "productName": {
+                                                "type": "string",
+                                                "title": "productName",
+                                                "description": "Product name.",
+                                                "default": "Kit de Hoegaarden"
+                                            },
+                                            "brand": {
+                                                "type": "string",
+                                                "title": "brand",
+                                                "description": "Brand name.",
+                                                "default": "Hoegaarden"
+                                            },
+                                            "brandId": {
+                                                "type": "integer",
+                                                "title": "brandId",
+                                                "description": "Product brand ID.",
+                                                "default": 2000004
+                                            },
+                                            "brandImageUrl": {
+                                                "type": "string",
+                                                "title": "brandImageUrl",
+                                                "description": "Product's brand image URL.",
+                                                "default": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg"
+                                            },
+                                            "linkText": {
+                                                "type": "string",
+                                                "title": "linkText",
+                                                "description": "Product URL.",
+                                                "default": "kit-6-cerveja-hoegaarden"
+                                            },
+                                            "productReference": {
+                                                "type": "string",
+                                                "title": "productReference",
+                                                "description": "Product reference.",
+                                                "default": "000806"
+                                            },
+                                            "productReferenceCode": {
+                                                "type": "integer",
+                                                "title": "productReferenceCode",
+                                                "description": "Product reference ID.",
+                                                "default": 1234
+                                            },
+                                            "categoryId": {
+                                                "type": "string",
+                                                "title": "categoryId",
+                                                "description": "Product category ID.",
+                                                "default": "1"
+                                            },
+                                            "productTitle": {
+                                                "type": "string",
+                                                "title": "productTitle",
+                                                "description": "Text that is in the browser tab and corresponds to the title of the product page. This field is important for SEO.",
+                                                "default": "Kit 6 cerveja Hoegaarden"
+                                            },
+                                            "metaTagDescription": {
+                                                "type": "string",
+                                                "title": "metaTagDescription",
+                                                "description": "Brief description of the category. It's recommended that you don't exceed 150 characters so that the search engines can display it correctly in the results page.",
+                                                "default": "Category for Beers"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "title": "releaseDate",
+                                                "description": "Product release date.",
+                                                "default": "2020-10-07T00:00:00"
+                                            },
+                                            "clusterHighlights": {
+                                                "type": "object",
+                                                "title": "clusterHighlights",
+                                                "description": "Cluster highlight ID and name.",
+                                                "default": {
+                                                        "138": "teste2"
+                                                    }
+                                            },
+                                            "productClusters": {
+                                                "type": "object",
+                                                "title": "productClusters",
+                                                "description": "Product clusters' IDs and names.",
+                                                "default": {
+                                                        "138": "teste2",
+                                                        "143": "NaoPesquisavel",
+                                                        "146": "colecaotestesubcategoria",
+                                                        "161": "merch_import_test1"
+                                                }
+                                            },
+                                            "searchableClusters": {
+                                                "type": "object",
+                                                "title": "searchableClusters",
+                                                "description": "Searchable clusters IDs and names",
+                                                "default": {
+                                                    "138": "teste2"
+                                                }
+                                            },
+                                            "categories": {
+                                                "type": "array",
+                                                "title": "categories",
+                                                "description": "Array of the product's categories URLs.",
+                                                "default": [
+                                                    "/Beers Beers Mesmo/"
+                                                ]
+                                            },
+                                            "categoriesIds": {
+                                                "type": "array",
+                                                "title": "categoriesIds",
+                                                "description": "Array of the product's categories IDs.",
+                                                "default": [
+                                                    "/1/"
+                                                ]
+                                            },
+                                            "link": {
+                                                "type": "string",
+                                                "title": "link",
+                                                "description": "Product URL.",
+                                                "default": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p"
+                                            },
+                                            "allSpecifications": {
+                                                "type": "array",
+                                                "title": "allSpecifications",
+                                                "description": "Array of the product's specifications.",
+                                                "default": [
+                                                    "Percentuals",
+                                                    "Percentual"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification.",
+                                                    "default": "Percentual"
+                                                }
+                                            },
+                                            "allSpecificationsGroups": {
+                                                "type": "array",
+                                                "title": "allSpecificationsGroups",
+                                                "description": "Array of the product's specifications groups.",
+                                                "default": [
+                                                    "Total",
+                                                    "Teste da Api2"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification group",
+                                                    "default": "Teste da Api2"
+                                                }
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "title": "description",
+                                                "description": "Description of the main information related to the product. A simple and easy to understand summary for the customer.",
+                                                "default": "Description example"
+                                            },
+                                            "items": {
+                                                "type": "array",
+                                                "title": "items",
+                                                "description": "Array containing the product SKU general information.",
+                                                "default": [
+                                                    {
+                                                        "itemId": "310118469",
+                                                        "name": "Kit com 6",
+                                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                        "complementName": "",
+                                                        "ean": "",
+                                                        "referenceId": [
+                                                            {
+                                                                "Key": "RefId",
+                                                                "Value": "000806"
+                                                            }
+                                                        ],
+                                                        "measurementUnit": "un",
+                                                        "unitMultiplier": 1.0,
+                                                        "modalType": null,
+                                                        "isKit": true,
+                                                        "kitItems": [
+                                                            {
+                                                                "itemId": "310118466",
+                                                                "amount": 6
+                                                            }
+                                                        ],
+                                                        "images": [
+                                                            {
+                                                                "imageId": "155489",
+                                                                "imageLabel": "",
+                                                                "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                "imageText": "hoegaarden-kit",
+                                                                "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                            }
+                                                        ],
+                                                        "sellers": [
+                                                            {
+                                                                "sellerId": "1",
+                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                "sellerDefault": true,
+                                                                "commertialOffer": {
+                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                        "0": {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    },
+                                                                    "Installments": [
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa à vista"
+                                                                        },
+                                                                        {
+                                                                            "Value": 21.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 2,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 14.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 3,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 3 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 10.5,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 4,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 4 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Promissory",
+                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                            "Name": "Promissory à vista"
+                                                                        }
+                                                                    ],
+                                                                    "DiscountHighLight": [],
+                                                                    "GiftSkuIds": [],
+                                                                    "Teasers": [],
+                                                                    "BuyTogether": [],
+                                                                    "ItemMetadataAttachment": [],
+                                                                    "Price": 42.0,
+                                                                    "ListPrice": 42.0,
+                                                                    "PriceWithoutDiscount": 42.0,
+                                                                    "RewardValue": 0.0,
+                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                    "AvailableQuantity": 16,
+                                                                    "IsAvailable": true,
+                                                                    "Tax": 0.0,
+                                                                    "SaleChannel": 0,
+                                                                    "DeliverySlaSamples": [
+                                                                        {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    ],
+                                                                    "GetInfoErrorMessage": null,
+                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                    "PaymentOptions": {
+                                                                        "installmentOptions": [
+                                                                            {
+                                                                                "paymentSystem": "2",
+                                                                                "bin": null,
+                                                                                "paymentName": "Visa",
+                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 2,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 2100,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 3,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1400,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 4,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1050,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "paymentSystem": "17",
+                                                                                "bin": null,
+                                                                                "paymentName": "Promissory",
+                                                                                "paymentGroupName": "promissoryPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "paymentSystems": [
+                                                                            {
+                                                                                "id": 17,
+                                                                                "name": "Promissory",
+                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "17",
+                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            },
+                                                                            {
+                                                                                "id": 2,
+                                                                                "name": "Visa",
+                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "2",
+                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            }
+                                                                        ],
+                                                                        "payments": [],
+                                                                        "giftCards": [],
+                                                                        "giftCardMessages": [],
+                                                                        "availableAccounts": [],
+                                                                        "availableTokens": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "Videos": [],
+                                                        "estimatedDateArrival": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": [
+                                                        {
+                                                            "itemId": "310118469",
+                                                            "name": "Kit com 6",
+                                                            "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                            "complementName": "",
+                                                            "ean": "",
+                                                            "referenceId": [
+                                                                {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                }
+                                                            ],
+                                                            "measurementUnit": "un",
+                                                            "unitMultiplier": 1.0,
+                                                            "modalType": null,
+                                                            "isKit": true,
+                                                            "kitItems": [
+                                                                {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                }
+                                                            ],
+                                                            "images": [
+                                                                {
+                                                                    "imageId": "155489",
+                                                                    "imageLabel": "",
+                                                                    "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                    "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                    "imageText": "hoegaarden-kit",
+                                                                    "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                }
+                                                            ],
+                                                            "sellers": [
+                                                                {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Videos": [],
+                                                            "estimatedDateArrival": null
+                                                        }
+                                                    ],
+                                                    "required": [
+                                                        "itemId",
+                                                        "name",
+                                                        "nameComplete",
+                                                        "complementName",
+                                                        "ean",
+                                                        "referenceId",
+                                                        "measurementUnit",
+                                                        "unitMultiplier",
+                                                        "modalType",
+                                                        "isKit",
+                                                        "kitItems",
+                                                        "images",
+                                                        "sellers",
+                                                        "Videos",
+                                                        "estimatedDateArrival"
+                                                    ],
+                                                    "properties": {
+                                                        "itemId": {
+                                                            "type": "string",
+                                                            "title": "itemId",
+                                                            "description": "SKU ID.",
+                                                            "default": "310118469"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "title": "name",
+                                                            "description": "SKU name.",
+                                                            "default": "Kit com 6"
+                                                        },
+                                                        "nameComplete": {
+                                                            "type": "string",
+                                                            "title": "nameComplete",
+                                                            "description": "SKU complete name.",
+                                                            "default": "Kit de Hoegaarden Kit com 6"
+                                                        },
+                                                        "complementName": {
+                                                            "type": "string",
+                                                            "title": "complementName",
+                                                            "description": "SKU complement name.",
+                                                            "default": "Complement name"
+                                                        },
+                                                        "ean": {
+                                                            "type": "string",
+                                                            "title": "ean",
+                                                            "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                            "default": "12345567"
+                                                        },
+                                                        "referenceId": {
+                                                            "type": "array",
+                                                            "title": "referenceId",
+                                                            "description": "Reference code ID.",
+                                                            "default": [
+                                                                    {
+                                                                        "Key": "RefId",
+                                                                        "Value": "000806"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                },
+                                                                "required": [
+                                                                    "Key",
+                                                                    "Value"
+                                                                ],
+                                                                "properties": {
+                                                                    "Key": {
+                                                                        "type": "string",
+                                                                        "title": "Key",
+                                                                        "description": "Reference Code.",
+                                                                        "default": [
+                                                                            "RefId"
+                                                                        ]
+                                                                    },
+                                                                    "Value": {
+                                                                        "type": "string",
+                                                                        "title": "Value",
+                                                                        "description": "Unique reference code used internally for organizational purposes.",
+                                                                        "default": [
+                                                                            "000806"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "measurementUnit": {
+                                                            "type": "string",
+                                                            "title": "measurementUnit",
+                                                            "description": "Used only in cases when you need to convert the unit of measure for sale. In common cases, use 'un'.",
+                                                            "default": [
+                                                                "un"
+                                                            ]
+                                                        },
+                                                        "unitMultiplier": {
+                                                            "type": "number",
+                                                            "title": "unitMultiplier",
+                                                            "description": "numerical unit that multiplies the selected quantity of the product when it is inserted in the cart.",
+                                                            "default": 1.0
+                                                        },
+                                                        "modalType": {
+                                                            "type": "string",
+                                                            "title": "modalType",
+                                                            "description": "Modal Type.",
+                                                            "default": "Modal Type test"
+                                                        },
+                                                        "isKit": {
+                                                            "type": "boolean",
+                                                            "title": "isKit",
+                                                            "description": "If the SKU is part of a kit.",
+                                                            "default": true
+                                                        },
+                                                        "kitItems": {
+                                                            "type": "array",
+                                                            "title": "kitItems",
+                                                            "description": "Array with information of SKUs components from a Kit.",
+                                                            "default": [
+                                                                    {
+                                                                        "itemId": "310118466",
+                                                                        "amount": 6
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                },
+                                                                "required": [
+                                                                    "itemId",
+                                                                    "amount"
+                                                                ],
+                                                                "properties": {
+                                                                    "itemId": {
+                                                                        "type": "string",
+                                                                        "title": "itemId",
+                                                                        "description": "SKU kit component ID.",
+                                                                        "default": [
+                                                                            "310118466"
+                                                                        ]
+                                                                    },
+                                                                    "amount": {
+                                                                        "type": "integer",
+                                                                        "title": "amount",
+                                                                        "description": "Amount of the SKU component in the kit.",
+                                                                        "default": 6
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "title": "images",
+                                                            "description": "Array of information about the SKU image.",
+                                                            "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                                "required": [
+                                                                    "imageId",
+                                                                    "imageLabel",
+                                                                    "imageTag",
+                                                                    "imageUrl",
+                                                                    "imageText",
+                                                                    "imageLastModified"
+                                                                ],
+                                                                "properties": {
+                                                                    "imageId": {
+                                                                        "type": "string",
+                                                                        "title": "imageId",
+                                                                        "description": "Image ID.",
+                                                                        "default": [
+                                                                            "155489"
+                                                                        ]
+                                                                    },
+                                                                    "imageLabel": {
+                                                                        "type": "string",
+                                                                        "title": "imageLabel",
+                                                                        "description": "Image label.",
+                                                                        "default": "Label test"
+                                                                    },
+                                                                    "imageTag": {
+                                                                        "type": "string",
+                                                                        "title": "imageTag",
+                                                                        "description": "Image tag.",
+                                                                        "default": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
+                                                                    },
+                                                                    "imageUrl": {
+                                                                        "type": "string",
+                                                                        "title": "imageUrl",
+                                                                        "description": "Image URL.",
+                                                                        "default": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
+                                                                    },
+                                                                    "imageText": {
+                                                                        "type": "string",
+                                                                        "title": "imageText",
+                                                                        "description": "Image text.",
+                                                                        "default": "hoegaarden-kit"
+                                                                    },
+                                                                    "imageLastModified": {
+                                                                        "type": "string",
+                                                                        "title": "imageLastModified",
+                                                                        "description": "Date and time of the last update of the image.",
+                                                                        "default": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "sellers": {
+                                                            "type": "array",
+                                                            "title": "sellers",
+                                                            "description": "Array of SKU sellers.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "sellerId": "1",
+                                                                        "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                        "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                        "sellerDefault": true,
+                                                                        "commertialOffer": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "sellerId",
+                                                                    "sellerName",
+                                                                    "addToCartLink",
+                                                                    "sellerDefault",
+                                                                    "commertialOffer"
+                                                                ],
+                                                                "properties": {
+                                                                    "sellerId": {
+                                                                        "type": "string",
+                                                                        "title": "sellerId",
+                                                                        "description": "SKU seller ID.",
+                                                                        "default": "1"
+                                                                    },
+                                                                    "sellerName": {
+                                                                        "type": "string",
+                                                                        "title": "sellerName",
+                                                                        "description": "SKU seller name.",
+                                                                        "default": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
+                                                                    },
+                                                                    "addToCartLink": {
+                                                                        "type": "string",
+                                                                        "title": "addToCartLink",
+                                                                        "description": "URL to add the product to the cart.",
+                                                                        "default": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
+                                                                    },
+                                                                    "sellerDefault": {
+                                                                        "type": "boolean",
+                                                                        "title": "sellerDefault",
+                                                                        "description": "If the seller is default or not.",
+                                                                        "default": true
+                                                                    },
+                                                                    "commertialOffer": {
+                                                                        "type": "object",
+                                                                        "title": "commertialOffer",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "DeliverySlaSamplesPerRegion",
+                                                                            "Installments",
+                                                                            "DiscountHighLight",
+                                                                            "GiftSkuIds",
+                                                                            "Teasers",
+                                                                            "BuyTogether",
+                                                                            "ItemMetadataAttachment",
+                                                                            "Price",
+                                                                            "ListPrice",
+                                                                            "PriceWithoutDiscount",
+                                                                            "RewardValue",
+                                                                            "PriceValidUntil",
+                                                                            "AvailableQuantity",
+                                                                            "IsAvailable",
+                                                                            "Tax",
+                                                                            "SaleChannel",
+                                                                            "DeliverySlaSamples",
+                                                                            "GetInfoErrorMessage",
+                                                                            "CacheVersionUsedToCallCheckout",
+                                                                            "PaymentOptions"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "type": "object",
+                                                                                "title": "DeliverySlaSamplesPerRegion",
+                                                                                "description": "Delivery SLA samples per region.",
+                                                                                "default": {
+                                                                                    "0": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": "null"
+                                                                                    }
+                                                                                },
+                                                                                "properties": {
+                                                                                    "0": {
+                                                                                        "type": "object",
+                                                                                        "title": "The 0 schema",
+                                                                                        "description": "0.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "required": [
+                                                                                            "DeliverySlaPerTypes",
+                                                                                            "Region"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "DeliverySlaPerTypes": {
+                                                                                                "type": "array",
+                                                                                                "title": "DeliverySlaPerTypes",
+                                                                                                "description": "Delivery SLA per types.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "Region": {
+                                                                                                "type": "string",
+                                                                                                "title": "Region",
+                                                                                                "description": "Region.",
+                                                                                                "default": ""
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "Installments": {
+                                                                                "type": "array",
+                                                                                "title": "Installments",
+                                                                                "description": "Installments options.",
+                                                                                "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 21.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 2,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                                        }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        }
+                                                                                    ],
+                                                                                    "required": [
+                                                                                        "Value",
+                                                                                        "InterestRate",
+                                                                                        "TotalValuePlusInterestRate",
+                                                                                        "NumberOfInstallments",
+                                                                                        "PaymentSystemName",
+                                                                                        "PaymentSystemGroupName",
+                                                                                        "Name"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "Value": {
+                                                                                            "type": "number",
+                                                                                            "title": "Value",
+                                                                                            "description": "Value of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "InterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "InterestRate",
+                                                                                            "description": "Interest rate of the installment.",
+                                                                                            "default": 0.0
+                                                                                        },
+                                                                                        "TotalValuePlusInterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "TotalValuePlusInterestRate",
+                                                                                            "description": "Total value plus interest rate of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "NumberOfInstallments": {
+                                                                                            "type": "integer",
+                                                                                            "title": "NumberOfInstallments",
+                                                                                            "description": "Number of the installment.",
+                                                                                            "default": 1
+                                                                                        },
+                                                                                        "PaymentSystemName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemName",
+                                                                                            "description": "Payment system name of the installment.",
+                                                                                            "default": "Visa"
+                                                                                        },
+                                                                                        "PaymentSystemGroupName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemGroupName",
+                                                                                            "description": "Payment system group name of the installment.",
+                                                                                            "default": "creditCardPaymentGroup"
+                                                                                        },
+                                                                                        "Name": {
+                                                                                            "type": "string",
+                                                                                            "title": "Name",
+                                                                                            "description": "Name of the installment.",
+                                                                                            "default": "Visa à vista"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "DiscountHighLight": {
+                                                                                "type": "array",
+                                                                                "title": "DiscountHighLight",
+                                                                                "description": "Discount hightlight.",
+                                                                                "default": []
+                                                                            },
+                                                                            "GiftSkuIds": {
+                                                                                "type": "array",
+                                                                                "title": "GiftSkuIds",
+                                                                                "description": "Array of SKU gifts IDs.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Teasers": {
+                                                                                "type": "array",
+                                                                                "title": "Teasers",
+                                                                                "description": "Teasers.",
+                                                                                "default": []
+                                                                            },
+                                                                            "BuyTogether": {
+                                                                                "type": "array",
+                                                                                "title": "BuyTogether",
+                                                                                "description": "Array of other products that can be bought together with the product in question.",
+                                                                                "default": []
+                                                                            },
+                                                                            "ItemMetadataAttachment": {
+                                                                                "type": "array",
+                                                                                "title": "ItemMetadataAttachment",
+                                                                                "description": "Item metadata attachment.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Price": {
+                                                                                "type": "number",
+                                                                                "title": "Price",
+                                                                                "description": "Price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "ListPrice": {
+                                                                                "type": "number",
+                                                                                "title": "ListPrice",
+                                                                                "description": "List price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "PriceWithoutDiscount": {
+                                                                                "type": "number",
+                                                                                "title": "PriceWithoutDiscount",
+                                                                                "description": "Price of the product without discount.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "RewardValue": {
+                                                                                "type": "number",
+                                                                                "title": "RewardValue",
+                                                                                "description": "Reward value of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "PriceValidUntil": {
+                                                                                "type": "string",
+                                                                                "title": "PriceValidUntil",
+                                                                                "description": "Price of the product valid until a certain date.",
+                                                                                "default": "4000-01-01T03:00:00Z"
+                                                                            },
+                                                                            "AvailableQuantity": {
+                                                                                "type": "integer",
+                                                                                "title": "AvailableQuantity",
+                                                                                "description": "Available quantity of the product.",
+                                                                                "default": 16
+                                                                            },
+                                                                            "IsAvailable": {
+                                                                                "type": "boolean",
+                                                                                "title": "IsAvailable",
+                                                                                "description": "If the product is available or not.",
+                                                                                "default": true
+                                                                            },
+                                                                            "Tax": {
+                                                                                "type": "number",
+                                                                                "title": "Tax",
+                                                                                "description": "Tax of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "SaleChannel": {
+                                                                                "type": "integer",
+                                                                                "title": "SaleChannel",
+                                                                                "description": "Trade policy which the product is contained.",
+                                                                                "default": 0
+                                                                            },
+                                                                            "DeliverySlaSamples": {
+                                                                                "type": "array",
+                                                                                "title": "DeliverySlaSamples",
+                                                                                "description": "Delivery SLA samples.",
+                                                                                "default": [
+                                                                                    {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "DeliverySlaPerTypes",
+                                                                                        "Region"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "DeliverySlaPerTypes": {
+                                                                                            "type": "array",
+                                                                                            "title": "DeliverySlaPerTypes",
+                                                                                            "description": "Delivery SLA per types.",
+                                                                                            "default": []
+                                                                                        },
+                                                                                        "Region": {
+                                                                                            "type": "string",
+                                                                                            "title": "Region",
+                                                                                            "description": "Region.",
+                                                                                            "default": null
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "GetInfoErrorMessage": {
+                                                                                "type": "string",
+                                                                                "title": "GetInfoErrorMessage",
+                                                                                "description": "Get info error message.",
+                                                                                "default": null
+                                                                            },
+                                                                            "CacheVersionUsedToCallCheckout": {
+                                                                                "type": "string",
+                                                                                "title": "CacheVersionUsedToCallCheckout",
+                                                                                "description": "Cache version used to call checkout.",
+                                                                                "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                            },
+                                                                            "PaymentOptions": {
+                                                                                "type": "object",
+                                                                                "title": "PaymentOptions",
+                                                                                "description": "Payment options.",
+                                                                                "default": {
+                                                                                    "installmentOptions": [
+                                                                                        {
+                                                                                            "paymentSystem": "2",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Visa",
+                                                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "paymentSystem": "17",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Promissory",
+                                                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ],
+                                                                                    "paymentSystems": [
+                                                                                        {
+                                                                                            "id": 17,
+                                                                                            "name": "Promissory",
+                                                                                            "groupName": "promissoryPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "17",
+                                                                                            "template": "promissoryPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        },
+                                                                                        {
+                                                                                            "id": 2,
+                                                                                            "name": "Visa",
+                                                                                            "groupName": "creditCardPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "2",
+                                                                                            "template": "creditCardPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        }
+                                                                                    ],
+                                                                                    "payments": [],
+                                                                                    "giftCards": [],
+                                                                                    "giftCardMessages": [],
+                                                                                    "availableAccounts": [],
+                                                                                    "availableTokens": []
+                                                                                },
+                                                                                "required": [
+                                                                                    "installmentOptions",
+                                                                                    "paymentSystems",
+                                                                                    "payments",
+                                                                                    "giftCards",
+                                                                                    "giftCardMessages",
+                                                                                    "availableAccounts",
+                                                                                    "availableTokens"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "installmentOptions": {
+                                                                                        "type": "array",
+                                                                                        "title": "installmentOptions",
+                                                                                        "description": "installment options.",
+                                                                                        "default": [
+                                                                                            [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "paymentSystem": "2",
+                                                                                                "bin": null,
+                                                                                                "paymentName": "Visa",
+                                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                "value": 4200,
+                                                                                                "installments": [
+                                                                                                    {
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 2,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 2100,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 3,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1400,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 4,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1050,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "paymentSystem",
+                                                                                                "bin",
+                                                                                                "paymentName",
+                                                                                                "paymentGroupName",
+                                                                                                "value",
+                                                                                                "installments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "paymentSystem": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentSystem",
+                                                                                                    "description": "Payment system.",
+                                                                                                    "default": "2"
+                                                                                                },
+                                                                                                "bin": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "bin",
+                                                                                                    "description": "Bin.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "paymentName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentName",
+                                                                                                    "description": "Payment name.",
+                                                                                                    "default": "Visa"
+                                                                                                },
+                                                                                                "paymentGroupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentGroupName",
+                                                                                                    "description": "Payment group name.",
+                                                                                                    "default": "creditCardPaymentGroup"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "value",
+                                                                                                    "description": "Value.",
+                                                                                                    "default": 4200
+                                                                                                },
+                                                                                                "installments": {
+                                                                                                    "type": "array",
+                                                                                                    "title": "installments",
+                                                                                                    "description": "Installments.",
+                                                                                                    "default": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ],
+                                                                                                    "items": {
+                                                                                                        "type": "object",
+                                                                                                        "title": "",
+                                                                                                        "default": {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "required": [
+                                                                                                            "count",
+                                                                                                            "hasInterestRate",
+                                                                                                            "interestRate",
+                                                                                                            "value",
+                                                                                                            "total",
+                                                                                                            "sellerMerchantInstallments"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                            "count": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "count",
+                                                                                                                "description": "Count.",
+                                                                                                                "default": 1
+                                                                                                            },
+                                                                                                            "hasInterestRate": {
+                                                                                                                "type": "boolean",
+                                                                                                                "title": "hasInterestRate",
+                                                                                                                "description": "Has interest rate.",
+                                                                                                                "default": false
+                                                                                                            },
+                                                                                                            "interestRate": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "interestRate",
+                                                                                                                "description": "Interest rate.",
+                                                                                                                "default": 0
+                                                                                                            },
+                                                                                                            "value": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "value",
+                                                                                                                "description": "Value.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "total": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "total",
+                                                                                                                "description": "Total.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "sellerMerchantInstallments": {
+                                                                                                                "type": "array",
+                                                                                                                "title": "sellerMerchantInstallments",
+                                                                                                                "description": "Seller merchant installments.",
+                                                                                                                "default": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "items": {
+                                                                                                                    "type": "object",
+                                                                                                                    "title": "",
+                                                                                                                    "default": {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                        "id",
+                                                                                                                        "count",
+                                                                                                                        "hasInterestRate",
+                                                                                                                        "interestRate",
+                                                                                                                        "value",
+                                                                                                                        "total"
+                                                                                                                    ],
+                                                                                                                    "properties": {
+                                                                                                                        "id": {
+                                                                                                                            "type": "string",
+                                                                                                                            "title": "id",
+                                                                                                                            "description": "ID.",
+                                                                                                                            "default": "MERCH"
+                                                                                                                        },
+                                                                                                                        "count": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "count",
+                                                                                                                            "description": "Count.",
+                                                                                                                            "default": 1
+                                                                                                                        },
+                                                                                                                        "hasInterestRate": {
+                                                                                                                            "type": "boolean",
+                                                                                                                            "title": "hasInterestRate",
+                                                                                                                            "description": "Has interest rate.",
+                                                                                                                            "default": false
+                                                                                                                        },
+                                                                                                                        "interestRate": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "interestRate",
+                                                                                                                            "description": "Interest rate.",
+                                                                                                                            "default": 0
+                                                                                                                        },
+                                                                                                                        "value": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "value",
+                                                                                                                            "description": "Value.",
+                                                                                                                            "default": 4200
+                                                                                                                        },
+                                                                                                                        "total": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "total",
+                                                                                                                            "description": "Total.",
+                                                                                                                            "default": 4200
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "paymentSystems": {
+                                                                                        "type": "array",
+                                                                                        "title": "paymentSystems",
+                                                                                        "description": "Payment systems.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            {
+                                                                                                "id": 2,
+                                                                                                "name": "Visa",
+                                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "2",
+                                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "id",
+                                                                                                "name",
+                                                                                                "groupName",
+                                                                                                "validator",
+                                                                                                "stringId",
+                                                                                                "template",
+                                                                                                "requiresDocument",
+                                                                                                "isCustom",
+                                                                                                "description",
+                                                                                                "requiresAuthentication",
+                                                                                                "dueDate",
+                                                                                                "availablePayments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "id": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "id",
+                                                                                                    "description": "ID.",
+                                                                                                    "default": 17
+                                                                                                },
+                                                                                                "name": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "name",
+                                                                                                    "description": "Name.",
+                                                                                                    "default": "Promissory"
+                                                                                                },
+                                                                                                "groupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "groupName",
+                                                                                                    "description": "Group name.",
+                                                                                                    "default": "promissoryPaymentGroup"
+                                                                                                },
+                                                                                                "validator": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "validator",
+                                                                                                    "description": "Validator.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "stringId": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "stringId",
+                                                                                                    "description": "String ID.",
+                                                                                                    "default": "17"
+                                                                                                },
+                                                                                                "template": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "template",
+                                                                                                    "description": "Template.",
+                                                                                                    "default": "promissoryPaymentGroup-template"
+                                                                                                },
+                                                                                                "requiresDocument": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresDocument",
+                                                                                                    "description": "If requires document or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "isCustom": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "isCustom",
+                                                                                                    "description": "If is custom or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "description": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "description",
+                                                                                                    "description": "Description.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "requiresAuthentication": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresAuthentication",
+                                                                                                    "description": "If requires authentication.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "dueDate": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "dueDate",
+                                                                                                    "description": "Due date.",
+                                                                                                    "default": "2021-07-01T18:43:00.0264384Z"
+                                                                                                },
+                                                                                                "availablePayments": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "availablePayments",
+                                                                                                    "description": "Available payments.",
+                                                                                                    "default": ""
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "payments": {
+                                                                                        "type": "array",
+                                                                                        "title": "payments",
+                                                                                        "description": "Payments.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCards": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCards",
+                                                                                        "description": "GiftCards.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCardMessages": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCardMessages",
+                                                                                        "description": "GiftCardMessages.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableAccounts": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableAccounts",
+                                                                                        "description": "Available accounts.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableTokens": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableTokens",
+                                                                                        "description": "Available tokens.",
+                                                                                        "default": []
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "Videos": {
+                                                            "type": "array",
+                                                            "title": "Videos",
+                                                            "description": "Videos.",
+                                                            "default": []
+                                                        },
+                                                        "estimatedDateArrival": {
+                                                            "type": "string",
+                                                            "title": "estimatedDateArrival",
+                                                            "description": "Estimated date arrival.",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
 					}
 				},
 				"deprecated": false,

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19,7 +19,7 @@
 					"CrossSelling"
 				],
 				"summary": "ProductSearch Who Saw Also Saw",
-				"description": "",
+				"description": "Retrieves general information about other related products that the users also saw",
 				"operationId": "ProductSearchWhoSawAlsoSaw",
 				"parameters": [
                     {
@@ -67,18 +67,3098 @@
 					{
 						"name": "productId",
 						"in": "path",
-						"description": "",
+						"description": "Product unique identifier",
 						"required": true,
 						"style": "simple",
 						"schema": {
-							"type": "string"
+							"type": "integer",
+                            "default": 1
 						}
 					}
 				],
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {}
+						"headers": {},
+                        "content": {
+                            "application/json":{
+                                "example":[{
+                                    "productId": "35",
+                                    "productName": "Kit de Hoegaarden",
+                                    "brand": "Hoegaarden",
+                                    "brandId": 2000004,
+                                    "brandImageUrl": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg",
+                                    "linkText": "kit-6-cerveja-hoegaarden",
+                                    "productReference": "000806",
+                                    "productReferenceCode": null,
+                                    "categoryId": "1",
+                                    "productTitle": "",
+                                    "metaTagDescription": "",
+                                    "releaseDate": "2020-10-07T00:00:00",
+                                    "clusterHighlights": {
+                                        "138": "teste2"
+                                    },
+                                    "productClusters": {
+                                        "138": "teste2",
+                                        "143": "NaoPesquisavel",
+                                        "146": "colecaotestesubcategoria",
+                                        "161": "merch_import_test1"
+                                    },
+                                    "searchableClusters": {
+                                        "138": "teste2"
+                                    },
+                                    "categories": [
+                                        "/Beers Beers Mesmo/"
+                                    ],
+                                    "categoriesIds": [
+                                        "/1/"
+                                    ],
+                                    "link": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p",
+                                    "Percentuals": [
+                                        "4,9"
+                                    ],
+                                    "Percentual": [
+                                        "4,9"
+                                    ],
+                                    "Total": [
+                                        "Percentuals",
+                                        "Percentual"
+                                    ],
+                                    "Teste de Api": [
+                                        "a"
+                                    ],
+                                    "Ale": [
+                                        "1"
+                                    ],
+                                    "Teste da Api2": [
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "Alcool": [
+                                        "Percentual"
+                                    ],
+                                    "allSpecifications": [
+                                        "Percentuals",
+                                        "Percentual",
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "allSpecificationsGroups": [
+                                        "Total",
+                                        "Teste da Api2"
+                                    ],
+                                    "description": "",
+                                    "items": [{
+                                        "itemId": "310118469",
+                                        "name": "Kit com 6",
+                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                        "complementName": "",
+                                        "ean": "",
+                                        "referenceId": [{
+                                            "Key": "RefId",
+                                            "Value": "000806"
+                                        }],
+                                        "measurementUnit": "un",
+                                        "unitMultiplier": 1.0000,
+                                        "modalType": null,
+                                        "isKit": true,
+                                        "kitItems": [{
+                                            "itemId": "310118466",
+                                            "amount": 6
+                                        }],
+                                        "images": [{
+                                            "imageId": "155489",
+                                            "imageLabel": "",
+                                            "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                            "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                            "imageText": "hoegaarden-kit",
+                                            "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                        }],
+                                        "sellers": [{
+                                            "sellerId": "1",
+                                            "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                            "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                            "sellerDefault": true,
+                                            "commertialOffer": {
+                                                "DeliverySlaSamplesPerRegion": {
+                                                    "0": {
+                                                        "DeliverySlaPerTypes": [],
+                                                        "Region": null
+                                                    }
+                                                },
+                                                "Installments": [{
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa à vista"
+                                                    },
+                                                    {
+                                                        "Value": 21.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 2,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 2 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 14.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 3,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 3 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 10.5,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 4,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 4 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Promissory",
+                                                        "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                        "Name": "Promissory à vista"
+                                                    }
+                                                ],
+                                                "DiscountHighLight": [],
+                                                "GiftSkuIds": [],
+                                                "Teasers": [],
+                                                "BuyTogether": [],
+                                                "ItemMetadataAttachment": [],
+                                                "Price": 42.0,
+                                                "ListPrice": 42.0,
+                                                "PriceWithoutDiscount": 42.0,
+                                                "RewardValue": 0.0,
+                                                "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                "AvailableQuantity": 16,
+                                                "IsAvailable": true,
+                                                "Tax": 0.0,
+                                                "SaleChannel": 0,
+                                                "DeliverySlaSamples": [{
+                                                    "DeliverySlaPerTypes": [],
+                                                    "Region": null
+                                                }],
+                                                "GetInfoErrorMessage": null,
+                                                "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                "PaymentOptions": {
+                                                    "installmentOptions": [{
+                                                            "paymentSystem": "2",
+                                                            "bin": null,
+                                                            "paymentName": "Visa",
+                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 1,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 4200,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 2,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 2100,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 2,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 2100,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 3,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1400,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 3,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1400,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 4,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1050,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 4,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1050,
+                                                                        "total": 4200
+                                                                    }]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "paymentSystem": "17",
+                                                            "bin": null,
+                                                            "paymentName": "Promissory",
+                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                "count": 1,
+                                                                "hasInterestRate": false,
+                                                                "interestRate": 0,
+                                                                "value": 4200,
+                                                                "total": 4200,
+                                                                "sellerMerchantInstallments": [{
+                                                                    "id": "MERCH",
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200
+                                                                }]
+                                                            }]
+                                                        }
+                                                    ],
+                                                    "paymentSystems": [{
+                                                            "id": 17,
+                                                            "name": "Promissory",
+                                                            "groupName": "promissoryPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "17",
+                                                            "template": "promissoryPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "name": "Visa",
+                                                            "groupName": "creditCardPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "2",
+                                                            "template": "creditCardPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        }
+                                                    ],
+                                                    "payments": [],
+                                                    "giftCards": [],
+                                                    "giftCardMessages": [],
+                                                    "availableAccounts": [],
+                                                    "availableTokens": []
+                                                }
+                                            }
+                                        }],
+                                        "Videos": [],
+                                        "estimatedDateArrival": null
+                                    }]
+                                }],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "",
+                                        "required": [
+                                            "productId",
+                                            "productName",
+                                            "brand",
+                                            "brandId",
+                                            "brandImageUrl",
+                                            "linkText",
+                                            "productReference",
+                                            "productReferenceCode",
+                                            "categoryId",
+                                            "productTitle",
+                                            "metaTagDescription",
+                                            "releaseDate",
+                                            "clusterHighlights",
+                                            "productClusters",
+                                            "searchableClusters",
+                                            "categories",
+                                            "categoriesIds",
+                                            "link",
+                                            "Percentuals",
+                                            "Percentual",
+                                            "Total",
+                                            "Teste de Api",
+                                            "Ale",
+                                            "Teste da Api2",
+                                            "Alcool",
+                                            "allSpecifications",
+                                            "allSpecificationsGroups",
+                                            "description",
+                                            "items"
+                                        ],
+                                        "properties": {
+                                            "productId": {
+                                                "type": "string",
+                                                "title": "productId",
+                                                "description": "Product unique identifier.",
+                                                "default": "35"
+                                            },
+                                            "productName": {
+                                                "type": "string",
+                                                "title": "productName",
+                                                "description": "Product name.",
+                                                "default": "Kit de Hoegaarden"
+                                            },
+                                            "brand": {
+                                                "type": "string",
+                                                "title": "brand",
+                                                "description": "Brand name.",
+                                                "default": "Hoegaarden"
+                                            },
+                                            "brandId": {
+                                                "type": "integer",
+                                                "title": "brandId",
+                                                "description": "Product brand ID.",
+                                                "default": 2000004
+                                            },
+                                            "brandImageUrl": {
+                                                "type": "string",
+                                                "title": "brandImageUrl",
+                                                "description": "Product's brand image URL.",
+                                                "default": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg"
+                                            },
+                                            "linkText": {
+                                                "type": "string",
+                                                "title": "linkText",
+                                                "description": "Product URL.",
+                                                "default": "kit-6-cerveja-hoegaarden"
+                                            },
+                                            "productReference": {
+                                                "type": "string",
+                                                "title": "productReference",
+                                                "description": "Product reference.",
+                                                "default": "000806"
+                                            },
+                                            "productReferenceCode": {
+                                                "type": "integer",
+                                                "title": "productReferenceCode",
+                                                "description": "Product reference ID.",
+                                                "default": 1234
+                                            },
+                                            "categoryId": {
+                                                "type": "string",
+                                                "title": "categoryId",
+                                                "description": "Product category ID.",
+                                                "default": "1"
+                                            },
+                                            "productTitle": {
+                                                "type": "string",
+                                                "title": "productTitle",
+                                                "description": "Text that is in the browser tab and corresponds to the title of the product page. This field is important for SEO.",
+                                                "default": "Kit 6 cerveja Hoegaarden"
+                                            },
+                                            "metaTagDescription": {
+                                                "type": "string",
+                                                "title": "metaTagDescription",
+                                                "description": "Brief description of the category. It's recommended that you don't exceed 150 characters so that the search engines can display it correctly in the results page.",
+                                                "default": "Category for Beers"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "title": "releaseDate",
+                                                "description": "Product release date.",
+                                                "default": "2020-10-07T00:00:00"
+                                            },
+                                            "clusterHighlights": {
+                                                "type": "object",
+                                                "title": "clusterHighlights",
+                                                "description": "Cluster highlight ID and name.",
+                                                "default": {
+                                                        "138": "teste2"
+                                                    }
+                                            },
+                                            "productClusters": {
+                                                "type": "object",
+                                                "title": "productClusters",
+                                                "description": "Product clusters' IDs and names.",
+                                                "default": {
+                                                        "138": "teste2",
+                                                        "143": "NaoPesquisavel",
+                                                        "146": "colecaotestesubcategoria",
+                                                        "161": "merch_import_test1"
+                                                    }
+                                            },
+                                            "searchableClusters": {
+                                                "type": "object",
+                                                "title": "searchableClusters",
+                                                "description": "Searchable clusters IDs and names",
+                                                "default": {
+                                                    "138": "teste2"
+                                                }
+                                            },
+                                            "categories": {
+                                                "type": "array",
+                                                "title": "categories",
+                                                "description": "Array of the product's categories URLs.",
+                                                "default": [
+                                                    "/Beers Beers Mesmo/"
+                                                ]
+                                            },
+                                            "categoriesIds": {
+                                                "type": "array",
+                                                "title": "categoriesIds",
+                                                "description": "Array of the product's categories IDs.",
+                                                "default": [
+                                                    "/1/"
+                                                ]
+                                            },
+                                            "link": {
+                                                "type": "string",
+                                                "title": "link",
+                                                "description": "Product URL.",
+                                                "default": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p"
+                                            },
+                                            "allSpecifications": {
+                                                "type": "array",
+                                                "title": "allSpecifications",
+                                                "description": "Array of the product's specifications.",
+                                                "default": [
+                                                    "Percentuals",
+                                                    "Percentual"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification.",
+                                                    "default": "Percentual"
+                                                }
+                                            },
+                                            "allSpecificationsGroups": {
+                                                "type": "array",
+                                                "title": "allSpecificationsGroups",
+                                                "description": "Array of the product's specifications groups.",
+                                                "default": [
+                                                    "Total",
+                                                    "Teste da Api2"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification group",
+                                                    "default": "Teste da Api2"
+                                                }
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "title": "description",
+                                                "description": "Description of the main information related to the product. A simple and easy to understand summary for the customer.",
+                                                "default": "Description example"
+                                            },
+                                            "items": {
+                                                "type": "array",
+                                                "title": "items",
+                                                "description": "Array containing the product SKU general information.",
+                                                "default": [
+                                                    {
+                                                        "itemId": "310118469",
+                                                        "name": "Kit com 6",
+                                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                        "complementName": "",
+                                                        "ean": "",
+                                                        "referenceId": [
+                                                            {
+                                                                "Key": "RefId",
+                                                                "Value": "000806"
+                                                            }
+                                                        ],
+                                                        "measurementUnit": "un",
+                                                        "unitMultiplier": 1.0,
+                                                        "modalType": null,
+                                                        "isKit": true,
+                                                        "kitItems": [
+                                                            {
+                                                                "itemId": "310118466",
+                                                                "amount": 6
+                                                            }
+                                                        ],
+                                                        "images": [
+                                                            {
+                                                                "imageId": "155489",
+                                                                "imageLabel": "",
+                                                                "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                "imageText": "hoegaarden-kit",
+                                                                "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                            }
+                                                        ],
+                                                        "sellers": [
+                                                            {
+                                                                "sellerId": "1",
+                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                "sellerDefault": true,
+                                                                "commertialOffer": {
+                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                        "0": {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    },
+                                                                    "Installments": [
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa à vista"
+                                                                        },
+                                                                        {
+                                                                            "Value": 21.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 2,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 14.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 3,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 3 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 10.5,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 4,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 4 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Promissory",
+                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                            "Name": "Promissory à vista"
+                                                                        }
+                                                                    ],
+                                                                    "DiscountHighLight": [],
+                                                                    "GiftSkuIds": [],
+                                                                    "Teasers": [],
+                                                                    "BuyTogether": [],
+                                                                    "ItemMetadataAttachment": [],
+                                                                    "Price": 42.0,
+                                                                    "ListPrice": 42.0,
+                                                                    "PriceWithoutDiscount": 42.0,
+                                                                    "RewardValue": 0.0,
+                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                    "AvailableQuantity": 16,
+                                                                    "IsAvailable": true,
+                                                                    "Tax": 0.0,
+                                                                    "SaleChannel": 0,
+                                                                    "DeliverySlaSamples": [
+                                                                        {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    ],
+                                                                    "GetInfoErrorMessage": null,
+                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                    "PaymentOptions": {
+                                                                        "installmentOptions": [
+                                                                            {
+                                                                                "paymentSystem": "2",
+                                                                                "bin": null,
+                                                                                "paymentName": "Visa",
+                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 2,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 2100,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 3,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1400,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 4,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1050,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "paymentSystem": "17",
+                                                                                "bin": null,
+                                                                                "paymentName": "Promissory",
+                                                                                "paymentGroupName": "promissoryPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "paymentSystems": [
+                                                                            {
+                                                                                "id": 17,
+                                                                                "name": "Promissory",
+                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "17",
+                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            },
+                                                                            {
+                                                                                "id": 2,
+                                                                                "name": "Visa",
+                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "2",
+                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            }
+                                                                        ],
+                                                                        "payments": [],
+                                                                        "giftCards": [],
+                                                                        "giftCardMessages": [],
+                                                                        "availableAccounts": [],
+                                                                        "availableTokens": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "Videos": [],
+                                                        "estimatedDateArrival": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": [
+                                                        {
+                                                            "itemId": "310118469",
+                                                            "name": "Kit com 6",
+                                                            "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                            "complementName": "",
+                                                            "ean": "",
+                                                            "referenceId": [
+                                                                {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                }
+                                                            ],
+                                                            "measurementUnit": "un",
+                                                            "unitMultiplier": 1.0,
+                                                            "modalType": null,
+                                                            "isKit": true,
+                                                            "kitItems": [
+                                                                {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                }
+                                                            ],
+                                                            "images": [
+                                                                {
+                                                                    "imageId": "155489",
+                                                                    "imageLabel": "",
+                                                                    "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                    "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                    "imageText": "hoegaarden-kit",
+                                                                    "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                }
+                                                            ],
+                                                            "sellers": [
+                                                                {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Videos": [],
+                                                            "estimatedDateArrival": null
+                                                        }
+                                                    ],
+                                                    "required": [
+                                                        "itemId",
+                                                        "name",
+                                                        "nameComplete",
+                                                        "complementName",
+                                                        "ean",
+                                                        "referenceId",
+                                                        "measurementUnit",
+                                                        "unitMultiplier",
+                                                        "modalType",
+                                                        "isKit",
+                                                        "kitItems",
+                                                        "images",
+                                                        "sellers",
+                                                        "Videos",
+                                                        "estimatedDateArrival"
+                                                    ],
+                                                    "properties": {
+                                                        "itemId": {
+                                                            "type": "string",
+                                                            "title": "itemId",
+                                                            "description": "SKU ID.",
+                                                            "default": "310118469"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "title": "name",
+                                                            "description": "SKU name.",
+                                                            "default": "Kit com 6"
+                                                        },
+                                                        "nameComplete": {
+                                                            "type": "string",
+                                                            "title": "nameComplete",
+                                                            "description": "SKU complete name.",
+                                                            "default": "Kit de Hoegaarden Kit com 6"
+                                                        },
+                                                        "complementName": {
+                                                            "type": "string",
+                                                            "title": "complementName",
+                                                            "description": "SKU complement name.",
+                                                            "default": "Complement name"
+                                                        },
+                                                        "ean": {
+                                                            "type": "string",
+                                                            "title": "ean",
+                                                            "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                            "default": "12345567"
+                                                        },
+                                                        "referenceId": {
+                                                            "type": "array",
+                                                            "title": "referenceId",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": [
+                                                                    {
+                                                                        "Key": "RefId",
+                                                                        "Value": "000806"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                },
+                                                                "required": [
+                                                                    "Key",
+                                                                    "Value"
+                                                                ],
+                                                                "properties": {
+                                                                    "Key": {
+                                                                        "type": "string",
+                                                                        "title": "Key",
+                                                                        "description": "Type of the key, in this case a Reference Code.",
+                                                                        "default": [
+                                                                            "RefId"
+                                                                        ]
+                                                                    },
+                                                                    "Value": {
+                                                                        "type": "string",
+                                                                        "title": "Value",
+                                                                        "description": "Unique reference code used internally for organizational purposes.",
+                                                                        "default": [
+                                                                            "000806"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "measurementUnit": {
+                                                            "type": "string",
+                                                            "title": "measurementUnit",
+                                                            "description": "Used only in cases when you need to convert the unit of measure for sale. In common cases, use 'un'.",
+                                                            "default": [
+                                                                "un"
+                                                            ]
+                                                        },
+                                                        "unitMultiplier": {
+                                                            "type": "number",
+                                                            "title": "The unitMultiplier schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": [
+                                                                1.0
+                                                            ]
+                                                        },
+                                                        "modalType": {
+                                                            "type": "string",
+                                                            "title": "The modalType schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": ""
+                                                        },
+                                                        "isKit": {
+                                                            "type": "boolean",
+                                                            "title": "The isKit schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": true
+                                                        },
+                                                        "kitItems": {
+                                                            "type": "array",
+                                                            "title": "The kitItems schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "itemId": "310118466",
+                                                                        "amount": 6
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "The first anyOf schema",
+                                                                "description": "An explanation about the purpose of this instance.",
+                                                                "default": {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                },
+                                                                "required": [
+                                                                    "itemId",
+                                                                    "amount"
+                                                                ],
+                                                                "properties": {
+                                                                    "itemId": {
+                                                                        "type": "string",
+                                                                        "title": "The itemId schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            "310118466"
+                                                                        ]
+                                                                    },
+                                                                    "amount": {
+                                                                        "type": "integer",
+                                                                        "title": "The amount schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            6
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "title": "The images schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "The first anyOf schema",
+                                                                "description": "An explanation about the purpose of this instance.",
+                                                                "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                                "required": [
+                                                                    "imageId",
+                                                                    "imageLabel",
+                                                                    "imageTag",
+                                                                    "imageUrl",
+                                                                    "imageText",
+                                                                    "imageLastModified"
+                                                                ],
+                                                                "properties": {
+                                                                    "imageId": {
+                                                                        "type": "string",
+                                                                        "title": "The imageId schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            "155489"
+                                                                        ]
+                                                                    },
+                                                                    "imageLabel": {
+                                                                        "type": "string",
+                                                                        "title": "The imageLabel schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": ""
+                                                                    },
+                                                                    "imageTag": {
+                                                                        "type": "string",
+                                                                        "title": "The imageTag schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
+                                                                        ]
+                                                                    },
+                                                                    "imageUrl": {
+                                                                        "type": "string",
+                                                                        "title": "The imageUrl schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
+                                                                        ]
+                                                                    },
+                                                                    "imageText": {
+                                                                        "type": "string",
+                                                                        "title": "The imageText schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            "hoegaarden-kit"
+                                                                        ]
+                                                                    },
+                                                                    "imageLastModified": {
+                                                                        "type": "string",
+                                                                        "title": "The imageLastModified schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            "2020-10-07T12:49:27.5800000Z"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "sellers": {
+                                                            "type": "array",
+                                                            "title": "The sellers schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "sellerId": "1",
+                                                                        "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                        "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                        "sellerDefault": true,
+                                                                        "commertialOffer": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "title": "The first anyOf schema",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": [
+                                                                            {
+                                                                                "sellerId": "1",
+                                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                                "sellerDefault": true,
+                                                                                "commertialOffer": {
+                                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                                        "0": {
+                                                                                            "DeliverySlaPerTypes": [],
+                                                                                            "Region": null
+                                                                                        }
+                                                                                    },
+                                                                                    "Installments": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 21.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 2,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 14.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 3,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 3 vezes sem juros"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 10.5,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 4,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 4 vezes sem juros"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Promissory",
+                                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                            "Name": "Promissory à vista"
+                                                                                        }
+                                                                                    ],
+                                                                                    "DiscountHighLight": [],
+                                                                                    "GiftSkuIds": [],
+                                                                                    "Teasers": [],
+                                                                                    "BuyTogether": [],
+                                                                                    "ItemMetadataAttachment": [],
+                                                                                    "Price": 42.0,
+                                                                                    "ListPrice": 42.0,
+                                                                                    "PriceWithoutDiscount": 42.0,
+                                                                                    "RewardValue": 0.0,
+                                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                                    "AvailableQuantity": 16,
+                                                                                    "IsAvailable": true,
+                                                                                    "Tax": 0.0,
+                                                                                    "SaleChannel": 0,
+                                                                                    "DeliverySlaSamples": [
+                                                                                        {
+                                                                                            "DeliverySlaPerTypes": [],
+                                                                                            "Region": null
+                                                                                        }
+                                                                                    ],
+                                                                                    "GetInfoErrorMessage": null,
+                                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                                    "PaymentOptions": {
+                                                                                        "installmentOptions": [
+                                                                                            {
+                                                                                                "paymentSystem": "2",
+                                                                                                "bin": null,
+                                                                                                "paymentName": "Visa",
+                                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                "value": 4200,
+                                                                                                "installments": [
+                                                                                                    {
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 2,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 2100,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 3,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1400,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 4,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1050,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "paymentSystem": "17",
+                                                                                                "bin": null,
+                                                                                                "paymentName": "Promissory",
+                                                                                                "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                "value": 4200,
+                                                                                                "installments": [
+                                                                                                    {
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ],
+                                                                                        "paymentSystems": [
+                                                                                            {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            {
+                                                                                                "id": 2,
+                                                                                                "name": "Visa",
+                                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "2",
+                                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "payments": [],
+                                                                                        "giftCards": [],
+                                                                                        "giftCardMessages": [],
+                                                                                        "availableAccounts": [],
+                                                                                        "availableTokens": []
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "required": [
+                                                                            "sellerId",
+                                                                            "sellerName",
+                                                                            "addToCartLink",
+                                                                            "sellerDefault",
+                                                                            "commertialOffer"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "sellerId": {
+                                                                                "type": "string",
+                                                                                "title": "The sellerId schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": "1"
+                                                                            },
+                                                                            "sellerName": {
+                                                                                "type": "string",
+                                                                                "title": "The sellerName schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": [
+                                                                                    "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
+                                                                                ]
+                                                                            },
+                                                                            "addToCartLink": {
+                                                                                "type": "string",
+                                                                                "title": "The addToCartLink schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": [
+                                                                                    "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
+                                                                                ]
+                                                                            },
+                                                                            "sellerDefault": {
+                                                                                "type": "boolean",
+                                                                                "title": "The sellerDefault schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": true
+                                                                            },
+                                                                            "commertialOffer": {
+                                                                                "type": "object",
+                                                                                "title": "The commertialOffer schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": [
+                                                                                    {
+                                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                                            "0": {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        },
+                                                                                        "Installments": [
+                                                                                            {
+                                                                                                "Value": 42.0,
+                                                                                                "InterestRate": 0.0,
+                                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                                "NumberOfInstallments": 1,
+                                                                                                "PaymentSystemName": "Visa",
+                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                                "Name": "Visa à vista"
+                                                                                            },
+                                                                                            {
+                                                                                                "Value": 21.0,
+                                                                                                "InterestRate": 0.0,
+                                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                                "NumberOfInstallments": 2,
+                                                                                                "PaymentSystemName": "Visa",
+                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                                            },
+                                                                                            {
+                                                                                                "Value": 14.0,
+                                                                                                "InterestRate": 0.0,
+                                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                                "NumberOfInstallments": 3,
+                                                                                                "PaymentSystemName": "Visa",
+                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                                            },
+                                                                                            {
+                                                                                                "Value": 10.5,
+                                                                                                "InterestRate": 0.0,
+                                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                                "NumberOfInstallments": 4,
+                                                                                                "PaymentSystemName": "Visa",
+                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                                            },
+                                                                                            {
+                                                                                                "Value": 42.0,
+                                                                                                "InterestRate": 0.0,
+                                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                                "NumberOfInstallments": 1,
+                                                                                                "PaymentSystemName": "Promissory",
+                                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                                "Name": "Promissory à vista"
+                                                                                            }
+                                                                                        ],
+                                                                                        "DiscountHighLight": [],
+                                                                                        "GiftSkuIds": [],
+                                                                                        "Teasers": [],
+                                                                                        "BuyTogether": [],
+                                                                                        "ItemMetadataAttachment": [],
+                                                                                        "Price": 42.0,
+                                                                                        "ListPrice": 42.0,
+                                                                                        "PriceWithoutDiscount": 42.0,
+                                                                                        "RewardValue": 0.0,
+                                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                                        "AvailableQuantity": 16,
+                                                                                        "IsAvailable": true,
+                                                                                        "Tax": 0.0,
+                                                                                        "SaleChannel": 0,
+                                                                                        "DeliverySlaSamples": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "GetInfoErrorMessage": null,
+                                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                                        "PaymentOptions": {
+                                                                                            "installmentOptions": [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ],
+                                                                                            "paymentSystems": [
+                                                                                                {
+                                                                                                    "id": 17,
+                                                                                                    "name": "Promissory",
+                                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                                    "validator": null,
+                                                                                                    "stringId": "17",
+                                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                                    "requiresDocument": false,
+                                                                                                    "isCustom": false,
+                                                                                                    "description": null,
+                                                                                                    "requiresAuthentication": false,
+                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                    "availablePayments": null
+                                                                                                },
+                                                                                                {
+                                                                                                    "id": 2,
+                                                                                                    "name": "Visa",
+                                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                                    "validator": null,
+                                                                                                    "stringId": "2",
+                                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                                    "requiresDocument": false,
+                                                                                                    "isCustom": false,
+                                                                                                    "description": null,
+                                                                                                    "requiresAuthentication": false,
+                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                    "availablePayments": null
+                                                                                                }
+                                                                                            ],
+                                                                                            "payments": [],
+                                                                                            "giftCards": [],
+                                                                                            "giftCardMessages": [],
+                                                                                            "availableAccounts": [],
+                                                                                            "availableTokens": []
+                                                                                        }
+                                                                                    }
+                                                                                ],
+                                                                                "required": [
+                                                                                    "DeliverySlaSamplesPerRegion",
+                                                                                    "Installments",
+                                                                                    "DiscountHighLight",
+                                                                                    "GiftSkuIds",
+                                                                                    "Teasers",
+                                                                                    "BuyTogether",
+                                                                                    "ItemMetadataAttachment",
+                                                                                    "Price",
+                                                                                    "ListPrice",
+                                                                                    "PriceWithoutDiscount",
+                                                                                    "RewardValue",
+                                                                                    "PriceValidUntil",
+                                                                                    "AvailableQuantity",
+                                                                                    "IsAvailable",
+                                                                                    "Tax",
+                                                                                    "SaleChannel",
+                                                                                    "DeliverySlaSamples",
+                                                                                    "GetInfoErrorMessage",
+                                                                                    "CacheVersionUsedToCallCheckout",
+                                                                                    "PaymentOptions"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                                        "type": "object",
+                                                                                        "title": "The DeliverySlaSamplesPerRegion schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "0": {
+                                                                                                    "DeliverySlaPerTypes": [],
+                                                                                                    "Region": null
+                                                                                                }
+                                                                                            }
+                                                                                        ],
+                                                                                        "required": [
+                                                                                            "0"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "0": {
+                                                                                                "type": "object",
+                                                                                                "title": "The 0 schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": [
+                                                                                                    {
+                                                                                                        "DeliverySlaPerTypes": [],
+                                                                                                        "Region": null
+                                                                                                    }
+                                                                                                ],
+                                                                                                "required": [
+                                                                                                    "DeliverySlaPerTypes",
+                                                                                                    "Region"
+                                                                                                ],
+                                                                                                "properties": {
+                                                                                                    "DeliverySlaPerTypes": {
+                                                                                                        "type": "array",
+                                                                                                        "title": "The DeliverySlaPerTypes schema",
+                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                        "default": []
+                                                                                                    },
+                                                                                                    "Region": {
+                                                                                                        "type": "string",
+                                                                                                        "title": "The Region schema",
+                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                        "default": null
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "Installments": {
+                                                                                        "type": "array",
+                                                                                        "title": "The Installments schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": [
+                                                                                            [
+                                                                                                {
+                                                                                                    "Value": 42.0,
+                                                                                                    "InterestRate": 0.0,
+                                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                                    "NumberOfInstallments": 1,
+                                                                                                    "PaymentSystemName": "Visa",
+                                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                                    "Name": "Visa à vista"
+                                                                                                },
+                                                                                                {
+                                                                                                    "Value": 21.0,
+                                                                                                    "InterestRate": 0.0,
+                                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                                    "NumberOfInstallments": 2,
+                                                                                                    "PaymentSystemName": "Visa",
+                                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                                }
+                                                                                            ]
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "The first anyOf schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": [
+                                                                                                {
+                                                                                                    "Value": 42.0,
+                                                                                                    "InterestRate": 0.0,
+                                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                                    "NumberOfInstallments": 1,
+                                                                                                    "PaymentSystemName": "Visa",
+                                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                                    "Name": "Visa à vista"
+                                                                                                }
+                                                                                            ],
+                                                                                            "required": [
+                                                                                                "Value",
+                                                                                                "InterestRate",
+                                                                                                "TotalValuePlusInterestRate",
+                                                                                                "NumberOfInstallments",
+                                                                                                "PaymentSystemName",
+                                                                                                "PaymentSystemGroupName",
+                                                                                                "Name"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "Value": {
+                                                                                                    "type": "number",
+                                                                                                    "title": "The Value schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": 42.0
+                                                                                                },
+                                                                                                "InterestRate": {
+                                                                                                    "type": "number",
+                                                                                                    "title": "The InterestRate schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": 0.0
+                                                                                                },
+                                                                                                "TotalValuePlusInterestRate": {
+                                                                                                    "type": "number",
+                                                                                                    "title": "The TotalValuePlusInterestRate schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": 42.0
+                                                                                                },
+                                                                                                "NumberOfInstallments": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "The NumberOfInstallments schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": 1
+                                                                                                },
+                                                                                                "PaymentSystemName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The PaymentSystemName schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "Visa"
+                                                                                                },
+                                                                                                "PaymentSystemGroupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The PaymentSystemGroupName schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "creditCardPaymentGroup"
+                                                                                                },
+                                                                                                "Name": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The Name schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "Visa à vista"
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "DiscountHighLight": {
+                                                                                        "type": "array",
+                                                                                        "title": "The DiscountHighLight schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "GiftSkuIds": {
+                                                                                        "type": "array",
+                                                                                        "title": "The GiftSkuIds schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "Teasers": {
+                                                                                        "type": "array",
+                                                                                        "title": "The Teasers schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "BuyTogether": {
+                                                                                        "type": "array",
+                                                                                        "title": "The BuyTogether schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "ItemMetadataAttachment": {
+                                                                                        "type": "array",
+                                                                                        "title": "The ItemMetadataAttachment schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "Price": {
+                                                                                        "type": "number",
+                                                                                        "title": "The Price schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": 42.0
+                                                                                    },
+                                                                                    "ListPrice": {
+                                                                                        "type": "number",
+                                                                                        "title": "The ListPrice schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": 42.0
+                                                                                    },
+                                                                                    "PriceWithoutDiscount": {
+                                                                                        "type": "number",
+                                                                                        "title": "The PriceWithoutDiscount schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": 42.0
+                                                                                    },
+                                                                                    "RewardValue": {
+                                                                                        "type": "number",
+                                                                                        "title": "The RewardValue schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": 0.0
+                                                                                    },
+                                                                                    "PriceValidUntil": {
+                                                                                        "type": "string",
+                                                                                        "title": "The PriceValidUntil schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": "4000-01-01T03:00:00Z"
+                                                                                    },
+                                                                                    "AvailableQuantity": {
+                                                                                        "type": "integer",
+                                                                                        "title": "The AvailableQuantity schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": 16
+                                                                                    },
+                                                                                    "IsAvailable": {
+                                                                                        "type": "boolean",
+                                                                                        "title": "The IsAvailable schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": true
+                                                                                    },
+                                                                                    "Tax": {
+                                                                                        "type": "number",
+                                                                                        "title": "The Tax schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": 0.0
+                                                                                    },
+                                                                                    "SaleChannel": {
+                                                                                        "type": "integer",
+                                                                                        "title": "The SaleChannel schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": 0
+                                                                                    },
+                                                                                    "DeliverySlaSamples": {
+                                                                                        "type": "array",
+                                                                                        "title": "The DeliverySlaSamples schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "The first anyOf schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "DeliverySlaPerTypes",
+                                                                                                "Region"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "DeliverySlaPerTypes": {
+                                                                                                    "type": "array",
+                                                                                                    "title": "The DeliverySlaPerTypes schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": []
+                                                                                                },
+                                                                                                "Region": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The Region schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": null
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "GetInfoErrorMessage": {
+                                                                                        "type": "string",
+                                                                                        "title": "The GetInfoErrorMessage schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": null
+                                                                                    },
+                                                                                    "CacheVersionUsedToCallCheckout": {
+                                                                                        "type": "string",
+                                                                                        "title": "The CacheVersionUsedToCallCheckout schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                                    },
+                                                                                    "PaymentOptions": {
+                                                                                        "type": "object",
+                                                                                        "title": "The PaymentOptions schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": {
+                                                                                            "installmentOptions": [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ],
+                                                                                            "paymentSystems": [
+                                                                                                {
+                                                                                                    "id": 17,
+                                                                                                    "name": "Promissory",
+                                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                                    "validator": null,
+                                                                                                    "stringId": "17",
+                                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                                    "requiresDocument": false,
+                                                                                                    "isCustom": false,
+                                                                                                    "description": null,
+                                                                                                    "requiresAuthentication": false,
+                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                    "availablePayments": null
+                                                                                                },
+                                                                                                {
+                                                                                                    "id": 2,
+                                                                                                    "name": "Visa",
+                                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                                    "validator": null,
+                                                                                                    "stringId": "2",
+                                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                                    "requiresDocument": false,
+                                                                                                    "isCustom": false,
+                                                                                                    "description": null,
+                                                                                                    "requiresAuthentication": false,
+                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                    "availablePayments": null
+                                                                                                }
+                                                                                            ],
+                                                                                            "payments": [],
+                                                                                            "giftCards": [],
+                                                                                            "giftCardMessages": [],
+                                                                                            "availableAccounts": [],
+                                                                                            "availableTokens": []
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "installmentOptions",
+                                                                                            "paymentSystems",
+                                                                                            "payments",
+                                                                                            "giftCards",
+                                                                                            "giftCardMessages",
+                                                                                            "availableAccounts",
+                                                                                            "availableTokens"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "installmentOptions": {
+                                                                                                "type": "array",
+                                                                                                "title": "The installmentOptions schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": [
+                                                                                                    [
+                                                                                                        {
+                                                                                                            "paymentSystem": "2",
+                                                                                                            "bin": null,
+                                                                                                            "paymentName": "Visa",
+                                                                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                            "value": 4200,
+                                                                                                            "installments": [
+                                                                                                                {
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 1,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 4200,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 2,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 2100,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 3,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 1400,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 4,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 1050,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "paymentSystem": "17",
+                                                                                                            "bin": null,
+                                                                                                            "paymentName": "Promissory",
+                                                                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                            "value": 4200,
+                                                                                                            "installments": [
+                                                                                                                {
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 1,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 4200,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                ],
+                                                                                                "items": {
+                                                                                                    "type": "object",
+                                                                                                    "title": "The first anyOf schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": {
+                                                                                                        "paymentSystem": "2",
+                                                                                                        "bin": null,
+                                                                                                        "paymentName": "Visa",
+                                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                        "value": 4200,
+                                                                                                        "installments": [
+                                                                                                            {
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200,
+                                                                                                                "sellerMerchantInstallments": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "count": 2,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 2100,
+                                                                                                                "total": 4200,
+                                                                                                                "sellerMerchantInstallments": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 2,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 2100,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "count": 3,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1400,
+                                                                                                                "total": 4200,
+                                                                                                                "sellerMerchantInstallments": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 3,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 1400,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "count": 4,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1050,
+                                                                                                                "total": 4200,
+                                                                                                                "sellerMerchantInstallments": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 4,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 1050,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "required": [
+                                                                                                        "paymentSystem",
+                                                                                                        "bin",
+                                                                                                        "paymentName",
+                                                                                                        "paymentGroupName",
+                                                                                                        "value",
+                                                                                                        "installments"
+                                                                                                    ],
+                                                                                                    "properties": {
+                                                                                                        "paymentSystem": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The paymentSystem schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "2"
+                                                                                                        },
+                                                                                                        "bin": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The bin schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": null
+                                                                                                        },
+                                                                                                        "paymentName": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The paymentName schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "Visa"
+                                                                                                        },
+                                                                                                        "paymentGroupName": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The paymentGroupName schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "creditCardPaymentGroup"
+                                                                                                        },
+                                                                                                        "value": {
+                                                                                                            "type": "integer",
+                                                                                                            "title": "The value schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": 4200
+                                                                                                        },
+                                                                                                        "installments": {
+                                                                                                            "type": "array",
+                                                                                                            "title": "The installments schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": [
+                                                                                                                {
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 1,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 4200,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 2,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 2100,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            ],
+                                                                                                            "items": {
+                                                                                                                "type": "object",
+                                                                                                                "title": "The first anyOf schema",
+                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "default": {
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200,
+                                                                                                                    "sellerMerchantInstallments": [
+                                                                                                                        {
+                                                                                                                            "id": "MERCH",
+                                                                                                                            "count": 1,
+                                                                                                                            "hasInterestRate": false,
+                                                                                                                            "interestRate": 0,
+                                                                                                                            "value": 4200,
+                                                                                                                            "total": 4200
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                                "required": [
+                                                                                                                    "count",
+                                                                                                                    "hasInterestRate",
+                                                                                                                    "interestRate",
+                                                                                                                    "value",
+                                                                                                                    "total",
+                                                                                                                    "sellerMerchantInstallments"
+                                                                                                                ],
+                                                                                                                "properties": {
+                                                                                                                    "count": {
+                                                                                                                        "type": "integer",
+                                                                                                                        "title": "The count schema",
+                                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                                        "default": 1
+                                                                                                                    },
+                                                                                                                    "hasInterestRate": {
+                                                                                                                        "type": "boolean",
+                                                                                                                        "title": "The hasInterestRate schema",
+                                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                                        "default": false
+                                                                                                                    },
+                                                                                                                    "interestRate": {
+                                                                                                                        "type": "integer",
+                                                                                                                        "title": "The interestRate schema",
+                                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                                        "default": 0
+                                                                                                                    },
+                                                                                                                    "value": {
+                                                                                                                        "type": "integer",
+                                                                                                                        "title": "The value schema",
+                                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                                        "default": 4200
+                                                                                                                    },
+                                                                                                                    "total": {
+                                                                                                                        "type": "integer",
+                                                                                                                        "title": "The total schema",
+                                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                                        "default": 4200
+                                                                                                                    },
+                                                                                                                    "sellerMerchantInstallments": {
+                                                                                                                        "type": "array",
+                                                                                                                        "title": "The sellerMerchantInstallments schema",
+                                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                                        "default": [
+                                                                                                                            {
+                                                                                                                                "id": "MERCH",
+                                                                                                                                "count": 1,
+                                                                                                                                "hasInterestRate": false,
+                                                                                                                                "interestRate": 0,
+                                                                                                                                "value": 4200,
+                                                                                                                                "total": 4200
+                                                                                                                            }
+                                                                                                                        ],
+                                                                                                                        "items": {
+                                                                                                                            "type": "object",
+                                                                                                                            "title": "The first anyOf schema",
+                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "default": {
+                                                                                                                                "id": "MERCH",
+                                                                                                                                "count": 1,
+                                                                                                                                "hasInterestRate": false,
+                                                                                                                                "interestRate": 0,
+                                                                                                                                "value": 4200,
+                                                                                                                                "total": 4200
+                                                                                                                            },
+                                                                                                                            "required": [
+                                                                                                                                "id",
+                                                                                                                                "count",
+                                                                                                                                "hasInterestRate",
+                                                                                                                                "interestRate",
+                                                                                                                                "value",
+                                                                                                                                "total"
+                                                                                                                            ],
+                                                                                                                            "properties": {
+                                                                                                                                "id": {
+                                                                                                                                    "type": "string",
+                                                                                                                                    "title": "The id schema",
+                                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                                    "default": "MERCH"
+                                                                                                                                },
+                                                                                                                                "count": {
+                                                                                                                                    "type": "integer",
+                                                                                                                                    "title": "The count schema",
+                                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                                    "default": 1
+                                                                                                                                },
+                                                                                                                                "hasInterestRate": {
+                                                                                                                                    "type": "boolean",
+                                                                                                                                    "title": "The hasInterestRate schema",
+                                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                                    "default": false
+                                                                                                                                },
+                                                                                                                                "interestRate": {
+                                                                                                                                    "type": "integer",
+                                                                                                                                    "title": "The interestRate schema",
+                                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                                    "default": 0
+                                                                                                                                },
+                                                                                                                                "value": {
+                                                                                                                                    "type": "integer",
+                                                                                                                                    "title": "The value schema",
+                                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                                    "default": 4200
+                                                                                                                                },
+                                                                                                                                "total": {
+                                                                                                                                    "type": "integer",
+                                                                                                                                    "title": "The total schema",
+                                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                                    "default": 4200
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "paymentSystems": {
+                                                                                                "type": "array",
+                                                                                                "title": "The paymentSystems schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": [
+                                                                                                    {
+                                                                                                        "id": 17,
+                                                                                                        "name": "Promissory",
+                                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                                        "validator": null,
+                                                                                                        "stringId": "17",
+                                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                                        "requiresDocument": false,
+                                                                                                        "isCustom": false,
+                                                                                                        "description": null,
+                                                                                                        "requiresAuthentication": false,
+                                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                        "availablePayments": null
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": 2,
+                                                                                                        "name": "Visa",
+                                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                                        "validator": null,
+                                                                                                        "stringId": "2",
+                                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                                        "requiresDocument": false,
+                                                                                                        "isCustom": false,
+                                                                                                        "description": null,
+                                                                                                        "requiresAuthentication": false,
+                                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                        "availablePayments": null
+                                                                                                    }
+                                                                                                ],
+                                                                                                "items": {
+                                                                                                    "type": "object",
+                                                                                                    "title": "The first anyOf schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": {
+                                                                                                        "id": 17,
+                                                                                                        "name": "Promissory",
+                                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                                        "validator": null,
+                                                                                                        "stringId": "17",
+                                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                                        "requiresDocument": false,
+                                                                                                        "isCustom": false,
+                                                                                                        "description": null,
+                                                                                                        "requiresAuthentication": false,
+                                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                        "availablePayments": null
+                                                                                                    },
+                                                                                                    "required": [
+                                                                                                        "id",
+                                                                                                        "name",
+                                                                                                        "groupName",
+                                                                                                        "validator",
+                                                                                                        "stringId",
+                                                                                                        "template",
+                                                                                                        "requiresDocument",
+                                                                                                        "isCustom",
+                                                                                                        "description",
+                                                                                                        "requiresAuthentication",
+                                                                                                        "dueDate",
+                                                                                                        "availablePayments"
+                                                                                                    ],
+                                                                                                    "properties": {
+                                                                                                        "id": {
+                                                                                                            "type": "integer",
+                                                                                                            "title": "The id schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": 17
+                                                                                                        },
+                                                                                                        "name": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The name schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "Promissory"
+                                                                                                        },
+                                                                                                        "groupName": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The groupName schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "promissoryPaymentGroup"
+                                                                                                        },
+                                                                                                        "validator": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The validator schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": null
+                                                                                                        },
+                                                                                                        "stringId": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The stringId schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "17"
+                                                                                                        },
+                                                                                                        "template": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The template schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "promissoryPaymentGroup-template"
+                                                                                                        },
+                                                                                                        "requiresDocument": {
+                                                                                                            "type": "boolean",
+                                                                                                            "title": "The requiresDocument schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": false
+                                                                                                        },
+                                                                                                        "isCustom": {
+                                                                                                            "type": "boolean",
+                                                                                                            "title": "The isCustom schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": false
+                                                                                                        },
+                                                                                                        "description": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The description schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": null
+                                                                                                        },
+                                                                                                        "requiresAuthentication": {
+                                                                                                            "type": "boolean",
+                                                                                                            "title": "The requiresAuthentication schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": false
+                                                                                                        },
+                                                                                                        "dueDate": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The dueDate schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": "2021-07-01T18:43:00.0264384Z"
+                                                                                                        },
+                                                                                                        "availablePayments": {
+                                                                                                            "type": "string",
+                                                                                                            "title": "The availablePayments schema",
+                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                            "default": null
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "payments": {
+                                                                                                "type": "array",
+                                                                                                "title": "The payments schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "giftCards": {
+                                                                                                "type": "array",
+                                                                                                "title": "The giftCards schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "giftCardMessages": {
+                                                                                                "type": "array",
+                                                                                                "title": "The giftCardMessages schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "availableAccounts": {
+                                                                                                "type": "array",
+                                                                                                "title": "The availableAccounts schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "availableTokens": {
+                                                                                                "type": "array",
+                                                                                                "title": "The availableTokens schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": []
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "Videos": {
+                                                            "type": "array",
+                                                            "title": "The Videos schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": []
+                                                        },
+                                                        "estimatedDateArrival": {
+                                                            "type": "string",
+                                                            "title": "The estimatedDateArrival schema",
+                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "default": null
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
 					}
 				},
 				"deprecated": false,

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19083,6 +19083,526 @@
 				]
 			}
 		},
+        "/api/catalog_system/pub/products/offers/{productId}": {
+            "get": {
+                "tags": [
+					"Offers"
+				],
+                "summary": "Search Product offers",
+                "description": "Retrieves existing offers of a specific product.",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+					{
+						"name": "Accept",
+						"in": "header",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+					{
+						"name": "Content-Type",
+						"in": "header",
+						"description": "Describes the type of the content being sent",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+					{
+						"name": "productId",
+						"in": "path",
+						"description": "Product unique number identifier.",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+                            "default": "3"
+						}
+					}
+				],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json":{
+                                "example": [
+                                    {
+                                        "SkuId": "5",
+                                        "EanId": "272727",
+                                        "RefId": "BIGHEROBML",
+                                        "Name": "Llf",
+                                        "NameComplete": "Cacilds Llf",
+                                        "IsActive": true,
+                                        "MainImage": {
+                                            "ImageId": "172754",
+                                            "ImageLabel": null,
+                                            "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                            "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                            "IsMain": true,
+                                            "IsZoomSize": false,
+                                            "ImageText": null,
+                                            "LastModified": "2021-03-24T15:37:24.877"
+                                        },
+                                        "Offers": [
+                                            {
+                                                "SellerId": "1",
+                                                "SellerSkuId": "5",
+                                                "OffersPerSalesChannel": [
+                                                    {
+                                                        "AvailableQuantity": 0,
+                                                        "SaleChannel": 1,
+                                                        "Price": 200.0,
+                                                        "ListPrice": 200.0,
+                                                        "PriceWithoutDiscount": 200.0,
+                                                        "IsAvailable": false
+                                                    },
+                                                    {
+                                                        "AvailableQuantity": 0,
+                                                        "SaleChannel": 2,
+                                                        "Price": 200.0,
+                                                        "ListPrice": 200.0,
+                                                        "PriceWithoutDiscount": 200.0,
+                                                        "IsAvailable": false
+                                                    }
+                                                ],
+                                                "AvailableSalesChannels": null
+                                            }
+                                        ],
+                                        "LastModified": "2021-07-06T19:13:45.831483",
+                                        "ProductId": "3"
+                                    }
+                                ],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "default": [
+                                        {
+                                            "SkuId": "5",
+                                            "EanId": "272727",
+                                            "RefId": "BIGHEROBML",
+                                            "Name": "Llf",
+                                            "NameComplete": "Cacilds Llf",
+                                            "IsActive": true,
+                                            "MainImage": {
+                                                "ImageId": "172754",
+                                                "ImageLabel": null,
+                                                "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                                "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                                "IsMain": true,
+                                                "IsZoomSize": false,
+                                                "ImageText": null,
+                                                "LastModified": "2021-03-24T15:37:24.877"
+                                            },
+                                            "Offers": [
+                                                {
+                                                    "SellerId": "1",
+                                                    "SellerSkuId": "5",
+                                                    "OffersPerSalesChannel": [
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 1,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        },
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 2,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        }
+                                                    ],
+                                                    "AvailableSalesChannels": null
+                                                }
+                                            ],
+                                            "LastModified": "2021-07-06T19:13:45.831483",
+                                            "ProductId": "3"
+                                        }
+                                    ],
+                                    "items": {
+                                        "type": "object",
+                                        "default": {
+                                            "SkuId": "5",
+                                            "EanId": "272727",
+                                            "RefId": "BIGHEROBML",
+                                            "Name": "Llf",
+                                            "NameComplete": "Cacilds Llf",
+                                            "IsActive": true,
+                                            "MainImage": {
+                                                "ImageId": "172754",
+                                                "ImageLabel": null,
+                                                "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                                "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                                "IsMain": true,
+                                                "IsZoomSize": false,
+                                                "ImageText": null,
+                                                "LastModified": "2021-03-24T15:37:24.877"
+                                            },
+                                            "Offers": [
+                                                {
+                                                    "SellerId": "1",
+                                                    "SellerSkuId": "5",
+                                                    "OffersPerSalesChannel": [
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 1,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        },
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 2,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        }
+                                                    ],
+                                                    "AvailableSalesChannels": null
+                                                }
+                                            ],
+                                            "LastModified": "2021-07-06T19:13:45.831483",
+                                            "ProductId": "3"
+                                        },
+                                        "required": [
+                                            "SkuId",
+                                            "EanId",
+                                            "RefId",
+                                            "Name",
+                                            "NameComplete",
+                                            "IsActive",
+                                            "MainImage",
+                                            "Offers",
+                                            "LastModified",
+                                            "ProductId"
+                                        ],
+                                        "properties": {
+                                            "SkuId": {
+                                                "type": "string",
+                                                "title": "SkuId",
+                                                "description": "SKU ID.",
+                                                "default": "5"
+                                            },
+                                            "EanId": {
+                                                "type": "string",
+                                                "title": "EanId",
+                                                "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                "default": "272727"
+                                            },
+                                            "RefId": {
+                                                "type": "string",
+                                                "title": "RefId",
+                                                "description": "Unique reference code used internally for organizational purposes.",
+                                                "default": "BIGHEROBML"
+                                            },
+                                            "Name": {
+                                                "type": "string",
+                                                "title": "Name",
+                                                "description": "SKU name.",
+                                                "default": "Llf"
+                                            },
+                                            "NameComplete": {
+                                                "type": "string",
+                                                "title": "NameComplete",
+                                                "description": "SKU complete name.",
+                                                "default": "Cacilds Llf"
+                                            },
+                                            "IsActive": {
+                                                "type": "boolean",
+                                                "title": "IsActive",
+                                                "description": "If the SKU is active or not.",
+                                                "default": true
+                                            },
+                                            "MainImage": {
+                                                "type": "object",
+                                                "title": "MainImage",
+                                                "description": "General information of the main image of the SKU.",
+                                                "default": {
+                                                    "ImageId": "172754",
+                                                    "ImageLabel": null,
+                                                    "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                                    "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                                    "IsMain": true,
+                                                    "IsZoomSize": false,
+                                                    "ImageText": null,
+                                                    "LastModified": "2021-03-24T15:37:24.877"
+                                                },
+                                                "required": [
+                                                    "ImageId",
+                                                    "ImageLabel",
+                                                    "ImageTag",
+                                                    "ImagePath",
+                                                    "IsMain",
+                                                    "IsZoomSize",
+                                                    "ImageText",
+                                                    "LastModified"
+                                                ],
+                                                "properties": {
+                                                    "ImageId": {
+                                                        "type": "string",
+                                                        "title": "ImageId",
+                                                        "description": "Unique identifier of the association of the Image to the SKU.",
+                                                        "default": "172754"
+                                                    },
+                                                    "ImageLabel": {
+                                                        "type": "string",
+                                                        "title": "ImageLabel",
+                                                        "description": "Image Label.",
+                                                        "default": ""
+                                                    },
+                                                    "ImageTag": {
+                                                        "type": "string",
+                                                        "title": "ImageTag",
+                                                        "description": "Image HTML tag.",
+                                                        "default": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />"
+                                                    },
+                                                    "ImagePath": {
+                                                        "type": "string",
+                                                        "title": "ImagePath",
+                                                        "description": "Image file path.",
+                                                        "default": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg"
+                                                    },
+                                                    "IsMain": {
+                                                        "type": "boolean",
+                                                        "title": "IsMain",
+                                                        "description": "If the image is the main image of the SKU or not.",
+                                                        "default": true
+                                                    },
+                                                    "IsZoomSize": {
+                                                        "type": "boolean",
+                                                        "title": "IsZoomSize",
+                                                        "description": "If the image has zoom applied.",
+                                                        "default": false
+                                                    },
+                                                    "ImageText": {
+                                                        "type": "string",
+                                                        "title": "ImageText",
+                                                        "description": "General text of the image.",
+                                                        "default": ""
+                                                    },
+                                                    "LastModified": {
+                                                        "type": "string",
+                                                        "title": "LastModified",
+                                                        "description": "Time that the image was last modified.",
+                                                        "default": "2021-03-24T15:37:24.877"
+                                                    }
+                                                }
+                                            },
+                                            "Offers": {
+                                                "type": "array",
+                                                "title": "Offers",
+                                                "description": "An explanation about the purpose of this instance.",
+                                                "default": [
+                                                    {
+                                                        "SellerId": "1",
+                                                        "SellerSkuId": "5",
+                                                        "OffersPerSalesChannel": [
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 1,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            },
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 2,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            }
+                                                        ],
+                                                        "AvailableSalesChannels": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": {
+                                                        "SellerId": "1",
+                                                        "SellerSkuId": "5",
+                                                        "OffersPerSalesChannel": [
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 1,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            },
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 2,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            }
+                                                        ],
+                                                        "AvailableSalesChannels": null
+                                                    },
+                                                    "required": [
+                                                        "SellerId",
+                                                        "SellerSkuId",
+                                                        "OffersPerSalesChannel",
+                                                        "AvailableSalesChannels"
+                                                    ],
+                                                    "properties": {
+                                                        "SellerId": {
+                                                            "type": "string",
+                                                            "title": "SellerId",
+                                                            "description": "Seller ID.",
+                                                            "default": "1"
+                                                        },
+                                                        "SellerSkuId": {
+                                                            "type": "string",
+                                                            "title": "SellerSkuId",
+                                                            "description": "ID of the association of the SKU with the seller.",
+                                                            "default": "5"
+                                                        },
+                                                        "OffersPerSalesChannel": {
+                                                            "type": "array",
+                                                            "title": "OffersPerSalesChannel",
+                                                            "description": "Offers per trade policy.",
+                                                            "default": [
+                                                                {
+                                                                    "AvailableQuantity": 0,
+                                                                    "SaleChannel": 1,
+                                                                    "Price": 200.0,
+                                                                    "ListPrice": 200.0,
+                                                                    "PriceWithoutDiscount": 200.0,
+                                                                    "IsAvailable": false
+                                                                },
+                                                                {
+                                                                    "AvailableQuantity": 0,
+                                                                    "SaleChannel": 2,
+                                                                    "Price": 200.0,
+                                                                    "ListPrice": 200.0,
+                                                                    "PriceWithoutDiscount": 200.0,
+                                                                    "IsAvailable": false
+                                                                }
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "AvailableQuantity": 0,
+                                                                    "SaleChannel": 1,
+                                                                    "Price": 200.0,
+                                                                    "ListPrice": 200.0,
+                                                                    "PriceWithoutDiscount": 200.0,
+                                                                    "IsAvailable": false
+                                                                },
+                                                                "required": [
+                                                                    "AvailableQuantity",
+                                                                    "SaleChannel",
+                                                                    "Price",
+                                                                    "ListPrice",
+                                                                    "PriceWithoutDiscount",
+                                                                    "IsAvailable"
+                                                                ],
+                                                                "properties": {
+                                                                    "AvailableQuantity": {
+                                                                        "type": "integer",
+                                                                        "title": "AvailableQuantity",
+                                                                        "description": "SKU available quantity.",
+                                                                        "default": 50
+                                                                    },
+                                                                    "SaleChannel": {
+                                                                        "type": "integer",
+                                                                        "title": "SaleChannel",
+                                                                        "description": "SKU trade policy.",
+                                                                        "default": 1
+                                                                    },
+                                                                    "Price": {
+                                                                        "type": "number",
+                                                                        "title": "Price",
+                                                                        "description": "SKU price.",
+                                                                        "default": 200.0
+                                                                    },
+                                                                    "ListPrice": {
+                                                                        "type": "number",
+                                                                        "title": "ListPrice",
+                                                                        "description": "SKU list price.",
+                                                                        "default": 200.0
+                                                                    },
+                                                                    "PriceWithoutDiscount": {
+                                                                        "type": "number",
+                                                                        "title": "PriceWithoutDiscount",
+                                                                        "description": "SKU precie without discount.",
+                                                                        "default": 200.0
+                                                                    },
+                                                                    "IsAvailable": {
+                                                                        "type": "boolean",
+                                                                        "title": "IsAvailable",
+                                                                        "description": "If the SKU is available or not.",
+                                                                        "default": true
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "AvailableSalesChannels": {
+                                                            "type": "string",
+                                                            "title": "AvailableSalesChannels",
+                                                            "description": "Trade policy that the SKU in contained.",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "LastModified": {
+                                                "type": "string",
+                                                "title": "LastModified",
+                                                "description": "Time that the offer was last modified.",
+                                                "default": "2021-07-06T19:13:45.831483"
+                                            },
+                                            "ProductId": {
+                                                "type": "string",
+                                                "title": "ProductId",
+                                                "description": "Product ID.",
+                                                "default": "3"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/catalog_system/pub/products/offers/{productId}/sku/{skuId}": {
             "get": {
                 "tags": [

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19083,6 +19083,537 @@
 				]
 			}
 		},
+        "/api/catalog_system/pub/products/offers/{productId}/sku/{skuId}": {
+            "get": {
+                "tags": [
+					"Offers"
+				],
+                "summary": "Search SKU offers",
+                "description": "Retrieves existing offers of a specific SKU.",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+					{
+						"name": "Accept",
+						"in": "header",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+					{
+						"name": "Content-Type",
+						"in": "header",
+						"description": "Describes the type of the content being sent",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+					{
+						"name": "productId",
+						"in": "path",
+						"description": "Product unique number identifier.",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+                            "default": "1"
+						}
+					},
+                    {
+						"name": "skuId",
+						"in": "path",
+						"description": "Product unique number identifier.",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+                            "default": "5"
+						}
+					}
+				],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json":{
+                                "example": [
+                                    {
+                                        "SkuId": "5",
+                                        "EanId": "272727",
+                                        "RefId": "BIGHEROBML",
+                                        "Name": "Llf",
+                                        "NameComplete": "Cacilds Llf",
+                                        "IsActive": true,
+                                        "MainImage": {
+                                            "ImageId": "172754",
+                                            "ImageLabel": null,
+                                            "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                            "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                            "IsMain": true,
+                                            "IsZoomSize": false,
+                                            "ImageText": null,
+                                            "LastModified": "2021-03-24T15:37:24.877"
+                                        },
+                                        "Offers": [
+                                            {
+                                                "SellerId": "1",
+                                                "SellerSkuId": "5",
+                                                "OffersPerSalesChannel": [
+                                                    {
+                                                        "AvailableQuantity": 0,
+                                                        "SaleChannel": 1,
+                                                        "Price": 200.0,
+                                                        "ListPrice": 200.0,
+                                                        "PriceWithoutDiscount": 200.0,
+                                                        "IsAvailable": false
+                                                    },
+                                                    {
+                                                        "AvailableQuantity": 0,
+                                                        "SaleChannel": 2,
+                                                        "Price": 200.0,
+                                                        "ListPrice": 200.0,
+                                                        "PriceWithoutDiscount": 200.0,
+                                                        "IsAvailable": false
+                                                    }
+                                                ],
+                                                "AvailableSalesChannels": null
+                                            }
+                                        ],
+                                        "LastModified": "2021-07-06T19:13:45.831483",
+                                        "ProductId": "3"
+                                    }
+                                ],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "default": [
+                                        {
+                                            "SkuId": "5",
+                                            "EanId": "272727",
+                                            "RefId": "BIGHEROBML",
+                                            "Name": "Llf",
+                                            "NameComplete": "Cacilds Llf",
+                                            "IsActive": true,
+                                            "MainImage": {
+                                                "ImageId": "172754",
+                                                "ImageLabel": null,
+                                                "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                                "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                                "IsMain": true,
+                                                "IsZoomSize": false,
+                                                "ImageText": null,
+                                                "LastModified": "2021-03-24T15:37:24.877"
+                                            },
+                                            "Offers": [
+                                                {
+                                                    "SellerId": "1",
+                                                    "SellerSkuId": "5",
+                                                    "OffersPerSalesChannel": [
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 1,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        },
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 2,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        }
+                                                    ],
+                                                    "AvailableSalesChannels": null
+                                                }
+                                            ],
+                                            "LastModified": "2021-07-06T19:13:45.831483",
+                                            "ProductId": "3"
+                                        }
+                                    ],
+                                    "items": {
+                                        "type": "object",
+                                        "default": {
+                                            "SkuId": "5",
+                                            "EanId": "272727",
+                                            "RefId": "BIGHEROBML",
+                                            "Name": "Llf",
+                                            "NameComplete": "Cacilds Llf",
+                                            "IsActive": true,
+                                            "MainImage": {
+                                                "ImageId": "172754",
+                                                "ImageLabel": null,
+                                                "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                                "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                                "IsMain": true,
+                                                "IsZoomSize": false,
+                                                "ImageText": null,
+                                                "LastModified": "2021-03-24T15:37:24.877"
+                                            },
+                                            "Offers": [
+                                                {
+                                                    "SellerId": "1",
+                                                    "SellerSkuId": "5",
+                                                    "OffersPerSalesChannel": [
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 1,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        },
+                                                        {
+                                                            "AvailableQuantity": 0,
+                                                            "SaleChannel": 2,
+                                                            "Price": 200.0,
+                                                            "ListPrice": 200.0,
+                                                            "PriceWithoutDiscount": 200.0,
+                                                            "IsAvailable": false
+                                                        }
+                                                    ],
+                                                    "AvailableSalesChannels": null
+                                                }
+                                            ],
+                                            "LastModified": "2021-07-06T19:13:45.831483",
+                                            "ProductId": "3"
+                                        },
+                                        "required": [
+                                            "SkuId",
+                                            "EanId",
+                                            "RefId",
+                                            "Name",
+                                            "NameComplete",
+                                            "IsActive",
+                                            "MainImage",
+                                            "Offers",
+                                            "LastModified",
+                                            "ProductId"
+                                        ],
+                                        "properties": {
+                                            "SkuId": {
+                                                "type": "string",
+                                                "title": "SkuId",
+                                                "description": "SKU ID.",
+                                                "default": "5"
+                                            },
+                                            "EanId": {
+                                                "type": "string",
+                                                "title": "EanId",
+                                                "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                "default": "272727"
+                                            },
+                                            "RefId": {
+                                                "type": "string",
+                                                "title": "RefId",
+                                                "description": "Unique reference code used internally for organizational purposes.",
+                                                "default": "BIGHEROBML"
+                                            },
+                                            "Name": {
+                                                "type": "string",
+                                                "title": "Name",
+                                                "description": "SKU name.",
+                                                "default": "Llf"
+                                            },
+                                            "NameComplete": {
+                                                "type": "string",
+                                                "title": "NameComplete",
+                                                "description": "SKU complete name.",
+                                                "default": "Cacilds Llf"
+                                            },
+                                            "IsActive": {
+                                                "type": "boolean",
+                                                "title": "IsActive",
+                                                "description": "If the SKU is active or not.",
+                                                "default": true
+                                            },
+                                            "MainImage": {
+                                                "type": "object",
+                                                "title": "MainImage",
+                                                "description": "General information of the main image of the SKU.",
+                                                "default": {
+                                                    "ImageId": "172754",
+                                                    "ImageLabel": null,
+                                                    "ImageTag": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />",
+                                                    "ImagePath": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg",
+                                                    "IsMain": true,
+                                                    "IsZoomSize": false,
+                                                    "ImageText": null,
+                                                    "LastModified": "2021-03-24T15:37:24.877"
+                                                },
+                                                "required": [
+                                                    "ImageId",
+                                                    "ImageLabel",
+                                                    "ImageTag",
+                                                    "ImagePath",
+                                                    "IsMain",
+                                                    "IsZoomSize",
+                                                    "ImageText",
+                                                    "LastModified"
+                                                ],
+                                                "properties": {
+                                                    "ImageId": {
+                                                        "type": "string",
+                                                        "title": "ImageId",
+                                                        "description": "Unique identifier of the association of the Image to the SKU.",
+                                                        "default": "172754"
+                                                    },
+                                                    "ImageLabel": {
+                                                        "type": "string",
+                                                        "title": "ImageLabel",
+                                                        "description": "Image Label.",
+                                                        "default": ""
+                                                    },
+                                                    "ImageTag": {
+                                                        "type": "string",
+                                                        "title": "ImageTag",
+                                                        "description": "Image HTML tag.",
+                                                        "default": "<img src=\"~/arquivos/ids/172754-#width#-#height#/Diablo.jpg\" width=\"#width#\" height=\"#height#\" alt=\"\" id=\"\" />"
+                                                    },
+                                                    "ImagePath": {
+                                                        "type": "string",
+                                                        "title": "ImagePath",
+                                                        "description": "Image file path.",
+                                                        "default": "~/arquivos/ids/172754-#width#-#height#/Diablo.jpg"
+                                                    },
+                                                    "IsMain": {
+                                                        "type": "boolean",
+                                                        "title": "IsMain",
+                                                        "description": "If the image is the main image of the SKU or not.",
+                                                        "default": true
+                                                    },
+                                                    "IsZoomSize": {
+                                                        "type": "boolean",
+                                                        "title": "IsZoomSize",
+                                                        "description": "If the image has zoom applied.",
+                                                        "default": false
+                                                    },
+                                                    "ImageText": {
+                                                        "type": "string",
+                                                        "title": "ImageText",
+                                                        "description": "General text of the image.",
+                                                        "default": ""
+                                                    },
+                                                    "LastModified": {
+                                                        "type": "string",
+                                                        "title": "LastModified",
+                                                        "description": "Time that the image was last modified.",
+                                                        "default": "2021-03-24T15:37:24.877"
+                                                    }
+                                                }
+                                            },
+                                            "Offers": {
+                                                "type": "array",
+                                                "title": "Offers",
+                                                "description": "An explanation about the purpose of this instance.",
+                                                "default": [
+                                                    {
+                                                        "SellerId": "1",
+                                                        "SellerSkuId": "5",
+                                                        "OffersPerSalesChannel": [
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 1,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            },
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 2,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            }
+                                                        ],
+                                                        "AvailableSalesChannels": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": {
+                                                        "SellerId": "1",
+                                                        "SellerSkuId": "5",
+                                                        "OffersPerSalesChannel": [
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 1,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            },
+                                                            {
+                                                                "AvailableQuantity": 0,
+                                                                "SaleChannel": 2,
+                                                                "Price": 200.0,
+                                                                "ListPrice": 200.0,
+                                                                "PriceWithoutDiscount": 200.0,
+                                                                "IsAvailable": false
+                                                            }
+                                                        ],
+                                                        "AvailableSalesChannels": null
+                                                    },
+                                                    "required": [
+                                                        "SellerId",
+                                                        "SellerSkuId",
+                                                        "OffersPerSalesChannel",
+                                                        "AvailableSalesChannels"
+                                                    ],
+                                                    "properties": {
+                                                        "SellerId": {
+                                                            "type": "string",
+                                                            "title": "SellerId",
+                                                            "description": "Seller ID.",
+                                                            "default": "1"
+                                                        },
+                                                        "SellerSkuId": {
+                                                            "type": "string",
+                                                            "title": "SellerSkuId",
+                                                            "description": "ID of the association of the SKU with the seller.",
+                                                            "default": "5"
+                                                        },
+                                                        "OffersPerSalesChannel": {
+                                                            "type": "array",
+                                                            "title": "OffersPerSalesChannel",
+                                                            "description": "Offers per trade policy.",
+                                                            "default": [
+                                                                {
+                                                                    "AvailableQuantity": 0,
+                                                                    "SaleChannel": 1,
+                                                                    "Price": 200.0,
+                                                                    "ListPrice": 200.0,
+                                                                    "PriceWithoutDiscount": 200.0,
+                                                                    "IsAvailable": false
+                                                                },
+                                                                {
+                                                                    "AvailableQuantity": 0,
+                                                                    "SaleChannel": 2,
+                                                                    "Price": 200.0,
+                                                                    "ListPrice": 200.0,
+                                                                    "PriceWithoutDiscount": 200.0,
+                                                                    "IsAvailable": false
+                                                                }
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "AvailableQuantity": 0,
+                                                                    "SaleChannel": 1,
+                                                                    "Price": 200.0,
+                                                                    "ListPrice": 200.0,
+                                                                    "PriceWithoutDiscount": 200.0,
+                                                                    "IsAvailable": false
+                                                                },
+                                                                "required": [
+                                                                    "AvailableQuantity",
+                                                                    "SaleChannel",
+                                                                    "Price",
+                                                                    "ListPrice",
+                                                                    "PriceWithoutDiscount",
+                                                                    "IsAvailable"
+                                                                ],
+                                                                "properties": {
+                                                                    "AvailableQuantity": {
+                                                                        "type": "integer",
+                                                                        "title": "AvailableQuantity",
+                                                                        "description": "SKU available quantity.",
+                                                                        "default": 50
+                                                                    },
+                                                                    "SaleChannel": {
+                                                                        "type": "integer",
+                                                                        "title": "SaleChannel",
+                                                                        "description": "SKU trade policy.",
+                                                                        "default": 1
+                                                                    },
+                                                                    "Price": {
+                                                                        "type": "number",
+                                                                        "title": "Price",
+                                                                        "description": "SKU price.",
+                                                                        "default": 200.0
+                                                                    },
+                                                                    "ListPrice": {
+                                                                        "type": "number",
+                                                                        "title": "ListPrice",
+                                                                        "description": "SKU list price.",
+                                                                        "default": 200.0
+                                                                    },
+                                                                    "PriceWithoutDiscount": {
+                                                                        "type": "number",
+                                                                        "title": "PriceWithoutDiscount",
+                                                                        "description": "SKU precie without discount.",
+                                                                        "default": 200.0
+                                                                    },
+                                                                    "IsAvailable": {
+                                                                        "type": "boolean",
+                                                                        "title": "IsAvailable",
+                                                                        "description": "If the SKU is available or not.",
+                                                                        "default": true
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "AvailableSalesChannels": {
+                                                            "type": "string",
+                                                            "title": "AvailableSalesChannels",
+                                                            "description": "Trade policy that the SKU in contained.",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "LastModified": {
+                                                "type": "string",
+                                                "title": "LastModified",
+                                                "description": "Time that the offer was last modified.",
+                                                "default": "2021-07-06T19:13:45.831483"
+                                            },
+                                            "ProductId": {
+                                                "type": "string",
+                                                "title": "ProductId",
+                                                "description": "Product ID.",
+                                                "default": "3"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/catalog_system/pub/facets/category/{categoryId}": {
             "get": {
                 "tags": [

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -3136,7 +3136,7 @@
 					"CrossSelling"
 				],
 				"summary": "ProductSearch Who Saw Also Bought",
-				"description": "",
+				"description": "Retrieves general information about other related products that the users saw and also bought.",
 				"operationId": "ProductSearchWhoSawAlsoBought",
 				"parameters": [
                     {
@@ -3184,18 +3184,3054 @@
 					{
 						"name": "productId",
 						"in": "path",
-						"description": "",
+						"description": "Product unique identifier",
 						"required": true,
 						"style": "simple",
 						"schema": {
-							"type": "string"
+							"type": "string",
+                            "default": 1
 						}
 					}
 				],
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {}
+						"headers": {},
+                        "content": {
+                            "application/json":{
+                                "example":[{
+                                    "productId": "35",
+                                    "productName": "Kit de Hoegaarden",
+                                    "brand": "Hoegaarden",
+                                    "brandId": 2000004,
+                                    "brandImageUrl": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg",
+                                    "linkText": "kit-6-cerveja-hoegaarden",
+                                    "productReference": "000806",
+                                    "productReferenceCode": null,
+                                    "categoryId": "1",
+                                    "productTitle": "",
+                                    "metaTagDescription": "",
+                                    "releaseDate": "2020-10-07T00:00:00",
+                                    "clusterHighlights": {
+                                        "138": "teste2"
+                                    },
+                                    "productClusters": {
+                                        "138": "teste2",
+                                        "143": "NaoPesquisavel",
+                                        "146": "colecaotestesubcategoria",
+                                        "161": "merch_import_test1"
+                                    },
+                                    "searchableClusters": {
+                                        "138": "teste2"
+                                    },
+                                    "categories": [
+                                        "/Beers Beers Mesmo/"
+                                    ],
+                                    "categoriesIds": [
+                                        "/1/"
+                                    ],
+                                    "link": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p",
+                                    "Percentuals": [
+                                        "4,9"
+                                    ],
+                                    "Percentual": [
+                                        "4,9"
+                                    ],
+                                    "Total": [
+                                        "Percentuals",
+                                        "Percentual"
+                                    ],
+                                    "Teste de Api": [
+                                        "a"
+                                    ],
+                                    "Ale": [
+                                        "1"
+                                    ],
+                                    "Teste da Api2": [
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "Alcool": [
+                                        "Percentual"
+                                    ],
+                                    "allSpecifications": [
+                                        "Percentuals",
+                                        "Percentual",
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "allSpecificationsGroups": [
+                                        "Total",
+                                        "Teste da Api2"
+                                    ],
+                                    "description": "",
+                                    "items": [{
+                                        "itemId": "310118469",
+                                        "name": "Kit com 6",
+                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                        "complementName": "",
+                                        "ean": "",
+                                        "referenceId": [{
+                                            "Key": "RefId",
+                                            "Value": "000806"
+                                        }],
+                                        "measurementUnit": "un",
+                                        "unitMultiplier": 1.0000,
+                                        "modalType": null,
+                                        "isKit": true,
+                                        "kitItems": [{
+                                            "itemId": "310118466",
+                                            "amount": 6
+                                        }],
+                                        "images": [{
+                                            "imageId": "155489",
+                                            "imageLabel": "",
+                                            "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                            "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                            "imageText": "hoegaarden-kit",
+                                            "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                        }],
+                                        "sellers": [{
+                                            "sellerId": "1",
+                                            "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                            "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                            "sellerDefault": true,
+                                            "commertialOffer": {
+                                                "DeliverySlaSamplesPerRegion": {
+                                                    "0": {
+                                                        "DeliverySlaPerTypes": [],
+                                                        "Region": null
+                                                    }
+                                                },
+                                                "Installments": [{
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa à vista"
+                                                    },
+                                                    {
+                                                        "Value": 21.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 2,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 2 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 14.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 3,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 3 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 10.5,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 4,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 4 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Promissory",
+                                                        "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                        "Name": "Promissory à vista"
+                                                    }
+                                                ],
+                                                "DiscountHighLight": [],
+                                                "GiftSkuIds": [],
+                                                "Teasers": [],
+                                                "BuyTogether": [],
+                                                "ItemMetadataAttachment": [],
+                                                "Price": 42.0,
+                                                "ListPrice": 42.0,
+                                                "PriceWithoutDiscount": 42.0,
+                                                "RewardValue": 0.0,
+                                                "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                "AvailableQuantity": 16,
+                                                "IsAvailable": true,
+                                                "Tax": 0.0,
+                                                "SaleChannel": 0,
+                                                "DeliverySlaSamples": [{
+                                                    "DeliverySlaPerTypes": [],
+                                                    "Region": null
+                                                }],
+                                                "GetInfoErrorMessage": null,
+                                                "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                "PaymentOptions": {
+                                                    "installmentOptions": [{
+                                                            "paymentSystem": "2",
+                                                            "bin": null,
+                                                            "paymentName": "Visa",
+                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 1,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 4200,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 2,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 2100,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 2,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 2100,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 3,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1400,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 3,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1400,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 4,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1050,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 4,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1050,
+                                                                        "total": 4200
+                                                                    }]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "paymentSystem": "17",
+                                                            "bin": null,
+                                                            "paymentName": "Promissory",
+                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                "count": 1,
+                                                                "hasInterestRate": false,
+                                                                "interestRate": 0,
+                                                                "value": 4200,
+                                                                "total": 4200,
+                                                                "sellerMerchantInstallments": [{
+                                                                    "id": "MERCH",
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200
+                                                                }]
+                                                            }]
+                                                        }
+                                                    ],
+                                                    "paymentSystems": [{
+                                                            "id": 17,
+                                                            "name": "Promissory",
+                                                            "groupName": "promissoryPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "17",
+                                                            "template": "promissoryPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "name": "Visa",
+                                                            "groupName": "creditCardPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "2",
+                                                            "template": "creditCardPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        }
+                                                    ],
+                                                    "payments": [],
+                                                    "giftCards": [],
+                                                    "giftCardMessages": [],
+                                                    "availableAccounts": [],
+                                                    "availableTokens": []
+                                                }
+                                            }
+                                        }],
+                                        "Videos": [],
+                                        "estimatedDateArrival": null
+                                    }]
+                                }],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "",
+                                        "required": [
+                                            "productId",
+                                            "productName",
+                                            "brand",
+                                            "brandId",
+                                            "brandImageUrl",
+                                            "linkText",
+                                            "productReference",
+                                            "productReferenceCode",
+                                            "categoryId",
+                                            "productTitle",
+                                            "metaTagDescription",
+                                            "releaseDate",
+                                            "clusterHighlights",
+                                            "productClusters",
+                                            "searchableClusters",
+                                            "categories",
+                                            "categoriesIds",
+                                            "link",
+                                            "Percentuals",
+                                            "Percentual",
+                                            "Total",
+                                            "Teste de Api",
+                                            "Ale",
+                                            "Teste da Api2",
+                                            "Alcool",
+                                            "allSpecifications",
+                                            "allSpecificationsGroups",
+                                            "description",
+                                            "items"
+                                        ],
+                                        "properties": {
+                                            "productId": {
+                                                "type": "string",
+                                                "title": "productId",
+                                                "description": "Product unique identifier.",
+                                                "default": "35"
+                                            },
+                                            "productName": {
+                                                "type": "string",
+                                                "title": "productName",
+                                                "description": "Product name.",
+                                                "default": "Kit de Hoegaarden"
+                                            },
+                                            "brand": {
+                                                "type": "string",
+                                                "title": "brand",
+                                                "description": "Brand name.",
+                                                "default": "Hoegaarden"
+                                            },
+                                            "brandId": {
+                                                "type": "integer",
+                                                "title": "brandId",
+                                                "description": "Product brand ID.",
+                                                "default": 2000004
+                                            },
+                                            "brandImageUrl": {
+                                                "type": "string",
+                                                "title": "brandImageUrl",
+                                                "description": "Product's brand image URL.",
+                                                "default": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg"
+                                            },
+                                            "linkText": {
+                                                "type": "string",
+                                                "title": "linkText",
+                                                "description": "Product URL.",
+                                                "default": "kit-6-cerveja-hoegaarden"
+                                            },
+                                            "productReference": {
+                                                "type": "string",
+                                                "title": "productReference",
+                                                "description": "Product reference.",
+                                                "default": "000806"
+                                            },
+                                            "productReferenceCode": {
+                                                "type": "integer",
+                                                "title": "productReferenceCode",
+                                                "description": "Product reference ID.",
+                                                "default": 1234
+                                            },
+                                            "categoryId": {
+                                                "type": "string",
+                                                "title": "categoryId",
+                                                "description": "Product category ID.",
+                                                "default": "1"
+                                            },
+                                            "productTitle": {
+                                                "type": "string",
+                                                "title": "productTitle",
+                                                "description": "Text that is in the browser tab and corresponds to the title of the product page. This field is important for SEO.",
+                                                "default": "Kit 6 cerveja Hoegaarden"
+                                            },
+                                            "metaTagDescription": {
+                                                "type": "string",
+                                                "title": "metaTagDescription",
+                                                "description": "Brief description of the category. It's recommended that you don't exceed 150 characters so that the search engines can display it correctly in the results page.",
+                                                "default": "Category for Beers"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "title": "releaseDate",
+                                                "description": "Product release date.",
+                                                "default": "2020-10-07T00:00:00"
+                                            },
+                                            "clusterHighlights": {
+                                                "type": "object",
+                                                "title": "clusterHighlights",
+                                                "description": "Cluster highlight ID and name.",
+                                                "default": {
+                                                        "138": "teste2"
+                                                    }
+                                            },
+                                            "productClusters": {
+                                                "type": "object",
+                                                "title": "productClusters",
+                                                "description": "Product clusters' IDs and names.",
+                                                "default": {
+                                                        "138": "teste2",
+                                                        "143": "NaoPesquisavel",
+                                                        "146": "colecaotestesubcategoria",
+                                                        "161": "merch_import_test1"
+                                                }
+                                            },
+                                            "searchableClusters": {
+                                                "type": "object",
+                                                "title": "searchableClusters",
+                                                "description": "Searchable clusters IDs and names",
+                                                "default": {
+                                                    "138": "teste2"
+                                                }
+                                            },
+                                            "categories": {
+                                                "type": "array",
+                                                "title": "categories",
+                                                "description": "Array of the product's categories URLs.",
+                                                "default": [
+                                                    "/Beers Beers Mesmo/"
+                                                ]
+                                            },
+                                            "categoriesIds": {
+                                                "type": "array",
+                                                "title": "categoriesIds",
+                                                "description": "Array of the product's categories IDs.",
+                                                "default": [
+                                                    "/1/"
+                                                ]
+                                            },
+                                            "link": {
+                                                "type": "string",
+                                                "title": "link",
+                                                "description": "Product URL.",
+                                                "default": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p"
+                                            },
+                                            "allSpecifications": {
+                                                "type": "array",
+                                                "title": "allSpecifications",
+                                                "description": "Array of the product's specifications.",
+                                                "default": [
+                                                    "Percentuals",
+                                                    "Percentual"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification.",
+                                                    "default": "Percentual"
+                                                }
+                                            },
+                                            "allSpecificationsGroups": {
+                                                "type": "array",
+                                                "title": "allSpecificationsGroups",
+                                                "description": "Array of the product's specifications groups.",
+                                                "default": [
+                                                    "Total",
+                                                    "Teste da Api2"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification group",
+                                                    "default": "Teste da Api2"
+                                                }
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "title": "description",
+                                                "description": "Description of the main information related to the product. A simple and easy to understand summary for the customer.",
+                                                "default": "Description example"
+                                            },
+                                            "items": {
+                                                "type": "array",
+                                                "title": "items",
+                                                "description": "Array containing the product SKU general information.",
+                                                "default": [
+                                                    {
+                                                        "itemId": "310118469",
+                                                        "name": "Kit com 6",
+                                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                        "complementName": "",
+                                                        "ean": "",
+                                                        "referenceId": [
+                                                            {
+                                                                "Key": "RefId",
+                                                                "Value": "000806"
+                                                            }
+                                                        ],
+                                                        "measurementUnit": "un",
+                                                        "unitMultiplier": 1.0,
+                                                        "modalType": null,
+                                                        "isKit": true,
+                                                        "kitItems": [
+                                                            {
+                                                                "itemId": "310118466",
+                                                                "amount": 6
+                                                            }
+                                                        ],
+                                                        "images": [
+                                                            {
+                                                                "imageId": "155489",
+                                                                "imageLabel": "",
+                                                                "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                "imageText": "hoegaarden-kit",
+                                                                "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                            }
+                                                        ],
+                                                        "sellers": [
+                                                            {
+                                                                "sellerId": "1",
+                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                "sellerDefault": true,
+                                                                "commertialOffer": {
+                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                        "0": {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    },
+                                                                    "Installments": [
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa à vista"
+                                                                        },
+                                                                        {
+                                                                            "Value": 21.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 2,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 14.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 3,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 3 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 10.5,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 4,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 4 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Promissory",
+                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                            "Name": "Promissory à vista"
+                                                                        }
+                                                                    ],
+                                                                    "DiscountHighLight": [],
+                                                                    "GiftSkuIds": [],
+                                                                    "Teasers": [],
+                                                                    "BuyTogether": [],
+                                                                    "ItemMetadataAttachment": [],
+                                                                    "Price": 42.0,
+                                                                    "ListPrice": 42.0,
+                                                                    "PriceWithoutDiscount": 42.0,
+                                                                    "RewardValue": 0.0,
+                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                    "AvailableQuantity": 16,
+                                                                    "IsAvailable": true,
+                                                                    "Tax": 0.0,
+                                                                    "SaleChannel": 0,
+                                                                    "DeliverySlaSamples": [
+                                                                        {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    ],
+                                                                    "GetInfoErrorMessage": null,
+                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                    "PaymentOptions": {
+                                                                        "installmentOptions": [
+                                                                            {
+                                                                                "paymentSystem": "2",
+                                                                                "bin": null,
+                                                                                "paymentName": "Visa",
+                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 2,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 2100,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 3,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1400,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 4,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1050,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "paymentSystem": "17",
+                                                                                "bin": null,
+                                                                                "paymentName": "Promissory",
+                                                                                "paymentGroupName": "promissoryPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "paymentSystems": [
+                                                                            {
+                                                                                "id": 17,
+                                                                                "name": "Promissory",
+                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "17",
+                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            },
+                                                                            {
+                                                                                "id": 2,
+                                                                                "name": "Visa",
+                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "2",
+                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            }
+                                                                        ],
+                                                                        "payments": [],
+                                                                        "giftCards": [],
+                                                                        "giftCardMessages": [],
+                                                                        "availableAccounts": [],
+                                                                        "availableTokens": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "Videos": [],
+                                                        "estimatedDateArrival": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": [
+                                                        {
+                                                            "itemId": "310118469",
+                                                            "name": "Kit com 6",
+                                                            "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                            "complementName": "",
+                                                            "ean": "",
+                                                            "referenceId": [
+                                                                {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                }
+                                                            ],
+                                                            "measurementUnit": "un",
+                                                            "unitMultiplier": 1.0,
+                                                            "modalType": null,
+                                                            "isKit": true,
+                                                            "kitItems": [
+                                                                {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                }
+                                                            ],
+                                                            "images": [
+                                                                {
+                                                                    "imageId": "155489",
+                                                                    "imageLabel": "",
+                                                                    "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                    "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                    "imageText": "hoegaarden-kit",
+                                                                    "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                }
+                                                            ],
+                                                            "sellers": [
+                                                                {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Videos": [],
+                                                            "estimatedDateArrival": null
+                                                        }
+                                                    ],
+                                                    "required": [
+                                                        "itemId",
+                                                        "name",
+                                                        "nameComplete",
+                                                        "complementName",
+                                                        "ean",
+                                                        "referenceId",
+                                                        "measurementUnit",
+                                                        "unitMultiplier",
+                                                        "modalType",
+                                                        "isKit",
+                                                        "kitItems",
+                                                        "images",
+                                                        "sellers",
+                                                        "Videos",
+                                                        "estimatedDateArrival"
+                                                    ],
+                                                    "properties": {
+                                                        "itemId": {
+                                                            "type": "string",
+                                                            "title": "itemId",
+                                                            "description": "SKU ID.",
+                                                            "default": "310118469"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "title": "name",
+                                                            "description": "SKU name.",
+                                                            "default": "Kit com 6"
+                                                        },
+                                                        "nameComplete": {
+                                                            "type": "string",
+                                                            "title": "nameComplete",
+                                                            "description": "SKU complete name.",
+                                                            "default": "Kit de Hoegaarden Kit com 6"
+                                                        },
+                                                        "complementName": {
+                                                            "type": "string",
+                                                            "title": "complementName",
+                                                            "description": "SKU complement name.",
+                                                            "default": "Complement name"
+                                                        },
+                                                        "ean": {
+                                                            "type": "string",
+                                                            "title": "ean",
+                                                            "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                            "default": "12345567"
+                                                        },
+                                                        "referenceId": {
+                                                            "type": "array",
+                                                            "title": "referenceId",
+                                                            "description": "Reference code ID.",
+                                                            "default": [
+                                                                    {
+                                                                        "Key": "RefId",
+                                                                        "Value": "000806"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                },
+                                                                "required": [
+                                                                    "Key",
+                                                                    "Value"
+                                                                ],
+                                                                "properties": {
+                                                                    "Key": {
+                                                                        "type": "string",
+                                                                        "title": "Key",
+                                                                        "description": "Reference Code.",
+                                                                        "default": [
+                                                                            "RefId"
+                                                                        ]
+                                                                    },
+                                                                    "Value": {
+                                                                        "type": "string",
+                                                                        "title": "Value",
+                                                                        "description": "Unique reference code used internally for organizational purposes.",
+                                                                        "default": [
+                                                                            "000806"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "measurementUnit": {
+                                                            "type": "string",
+                                                            "title": "measurementUnit",
+                                                            "description": "Used only in cases when you need to convert the unit of measure for sale. In common cases, use 'un'.",
+                                                            "default": [
+                                                                "un"
+                                                            ]
+                                                        },
+                                                        "unitMultiplier": {
+                                                            "type": "number",
+                                                            "title": "unitMultiplier",
+                                                            "description": "numerical unit that multiplies the selected quantity of the product when it is inserted in the cart.",
+                                                            "default": 1.0
+                                                        },
+                                                        "modalType": {
+                                                            "type": "string",
+                                                            "title": "modalType",
+                                                            "description": "Modal Type.",
+                                                            "default": "Modal Type test"
+                                                        },
+                                                        "isKit": {
+                                                            "type": "boolean",
+                                                            "title": "isKit",
+                                                            "description": "If the SKU is part of a kit.",
+                                                            "default": true
+                                                        },
+                                                        "kitItems": {
+                                                            "type": "array",
+                                                            "title": "kitItems",
+                                                            "description": "Array with information of SKUs components from a Kit.",
+                                                            "default": [
+                                                                    {
+                                                                        "itemId": "310118466",
+                                                                        "amount": 6
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                },
+                                                                "required": [
+                                                                    "itemId",
+                                                                    "amount"
+                                                                ],
+                                                                "properties": {
+                                                                    "itemId": {
+                                                                        "type": "string",
+                                                                        "title": "itemId",
+                                                                        "description": "SKU kit component ID.",
+                                                                        "default": [
+                                                                            "310118466"
+                                                                        ]
+                                                                    },
+                                                                    "amount": {
+                                                                        "type": "integer",
+                                                                        "title": "amount",
+                                                                        "description": "Amount of the SKU component in the kit.",
+                                                                        "default": 6
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "title": "images",
+                                                            "description": "Array of information about the SKU image.",
+                                                            "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                                "required": [
+                                                                    "imageId",
+                                                                    "imageLabel",
+                                                                    "imageTag",
+                                                                    "imageUrl",
+                                                                    "imageText",
+                                                                    "imageLastModified"
+                                                                ],
+                                                                "properties": {
+                                                                    "imageId": {
+                                                                        "type": "string",
+                                                                        "title": "imageId",
+                                                                        "description": "Image ID.",
+                                                                        "default": [
+                                                                            "155489"
+                                                                        ]
+                                                                    },
+                                                                    "imageLabel": {
+                                                                        "type": "string",
+                                                                        "title": "imageLabel",
+                                                                        "description": "Image label.",
+                                                                        "default": "Label test"
+                                                                    },
+                                                                    "imageTag": {
+                                                                        "type": "string",
+                                                                        "title": "imageTag",
+                                                                        "description": "Image tag.",
+                                                                        "default": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
+                                                                    },
+                                                                    "imageUrl": {
+                                                                        "type": "string",
+                                                                        "title": "imageUrl",
+                                                                        "description": "Image URL.",
+                                                                        "default": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
+                                                                    },
+                                                                    "imageText": {
+                                                                        "type": "string",
+                                                                        "title": "imageText",
+                                                                        "description": "Image text.",
+                                                                        "default": "hoegaarden-kit"
+                                                                    },
+                                                                    "imageLastModified": {
+                                                                        "type": "string",
+                                                                        "title": "imageLastModified",
+                                                                        "description": "Date and time of the last update of the image.",
+                                                                        "default": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "sellers": {
+                                                            "type": "array",
+                                                            "title": "sellers",
+                                                            "description": "Array of SKU sellers.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "sellerId": "1",
+                                                                        "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                        "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                        "sellerDefault": true,
+                                                                        "commertialOffer": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "sellerId",
+                                                                    "sellerName",
+                                                                    "addToCartLink",
+                                                                    "sellerDefault",
+                                                                    "commertialOffer"
+                                                                ],
+                                                                "properties": {
+                                                                    "sellerId": {
+                                                                        "type": "string",
+                                                                        "title": "sellerId",
+                                                                        "description": "SKU seller ID.",
+                                                                        "default": "1"
+                                                                    },
+                                                                    "sellerName": {
+                                                                        "type": "string",
+                                                                        "title": "sellerName",
+                                                                        "description": "SKU seller name.",
+                                                                        "default": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
+                                                                    },
+                                                                    "addToCartLink": {
+                                                                        "type": "string",
+                                                                        "title": "addToCartLink",
+                                                                        "description": "URL to add the product to the cart.",
+                                                                        "default": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
+                                                                    },
+                                                                    "sellerDefault": {
+                                                                        "type": "boolean",
+                                                                        "title": "sellerDefault",
+                                                                        "description": "If the seller is default or not.",
+                                                                        "default": true
+                                                                    },
+                                                                    "commertialOffer": {
+                                                                        "type": "object",
+                                                                        "title": "commertialOffer",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "DeliverySlaSamplesPerRegion",
+                                                                            "Installments",
+                                                                            "DiscountHighLight",
+                                                                            "GiftSkuIds",
+                                                                            "Teasers",
+                                                                            "BuyTogether",
+                                                                            "ItemMetadataAttachment",
+                                                                            "Price",
+                                                                            "ListPrice",
+                                                                            "PriceWithoutDiscount",
+                                                                            "RewardValue",
+                                                                            "PriceValidUntil",
+                                                                            "AvailableQuantity",
+                                                                            "IsAvailable",
+                                                                            "Tax",
+                                                                            "SaleChannel",
+                                                                            "DeliverySlaSamples",
+                                                                            "GetInfoErrorMessage",
+                                                                            "CacheVersionUsedToCallCheckout",
+                                                                            "PaymentOptions"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "type": "object",
+                                                                                "title": "DeliverySlaSamplesPerRegion",
+                                                                                "description": "Delivery SLA samples per region.",
+                                                                                "default": {
+                                                                                    "0": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": "null"
+                                                                                    }
+                                                                                },
+                                                                                "properties": {
+                                                                                    "0": {
+                                                                                        "type": "object",
+                                                                                        "title": "The 0 schema",
+                                                                                        "description": "0.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "required": [
+                                                                                            "DeliverySlaPerTypes",
+                                                                                            "Region"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "DeliverySlaPerTypes": {
+                                                                                                "type": "array",
+                                                                                                "title": "DeliverySlaPerTypes",
+                                                                                                "description": "Delivery SLA per types.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "Region": {
+                                                                                                "type": "string",
+                                                                                                "title": "Region",
+                                                                                                "description": "Region.",
+                                                                                                "default": ""
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "Installments": {
+                                                                                "type": "array",
+                                                                                "title": "Installments",
+                                                                                "description": "Installments options.",
+                                                                                "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 21.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 2,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                                        }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        }
+                                                                                    ],
+                                                                                    "required": [
+                                                                                        "Value",
+                                                                                        "InterestRate",
+                                                                                        "TotalValuePlusInterestRate",
+                                                                                        "NumberOfInstallments",
+                                                                                        "PaymentSystemName",
+                                                                                        "PaymentSystemGroupName",
+                                                                                        "Name"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "Value": {
+                                                                                            "type": "number",
+                                                                                            "title": "Value",
+                                                                                            "description": "Value of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "InterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "InterestRate",
+                                                                                            "description": "Interest rate of the installment.",
+                                                                                            "default": 0.0
+                                                                                        },
+                                                                                        "TotalValuePlusInterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "TotalValuePlusInterestRate",
+                                                                                            "description": "Total value plus interest rate of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "NumberOfInstallments": {
+                                                                                            "type": "integer",
+                                                                                            "title": "NumberOfInstallments",
+                                                                                            "description": "Number of the installment.",
+                                                                                            "default": 1
+                                                                                        },
+                                                                                        "PaymentSystemName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemName",
+                                                                                            "description": "Payment system name of the installment.",
+                                                                                            "default": "Visa"
+                                                                                        },
+                                                                                        "PaymentSystemGroupName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemGroupName",
+                                                                                            "description": "Payment system group name of the installment.",
+                                                                                            "default": "creditCardPaymentGroup"
+                                                                                        },
+                                                                                        "Name": {
+                                                                                            "type": "string",
+                                                                                            "title": "Name",
+                                                                                            "description": "Name of the installment.",
+                                                                                            "default": "Visa à vista"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "DiscountHighLight": {
+                                                                                "type": "array",
+                                                                                "title": "DiscountHighLight",
+                                                                                "description": "Discount hightlight.",
+                                                                                "default": []
+                                                                            },
+                                                                            "GiftSkuIds": {
+                                                                                "type": "array",
+                                                                                "title": "GiftSkuIds",
+                                                                                "description": "Array of SKU gifts IDs.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Teasers": {
+                                                                                "type": "array",
+                                                                                "title": "Teasers",
+                                                                                "description": "Teasers.",
+                                                                                "default": []
+                                                                            },
+                                                                            "BuyTogether": {
+                                                                                "type": "array",
+                                                                                "title": "BuyTogether",
+                                                                                "description": "Array of other products that can be bought together with the product in question.",
+                                                                                "default": []
+                                                                            },
+                                                                            "ItemMetadataAttachment": {
+                                                                                "type": "array",
+                                                                                "title": "ItemMetadataAttachment",
+                                                                                "description": "Item metadata attachment.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Price": {
+                                                                                "type": "number",
+                                                                                "title": "Price",
+                                                                                "description": "Price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "ListPrice": {
+                                                                                "type": "number",
+                                                                                "title": "ListPrice",
+                                                                                "description": "List price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "PriceWithoutDiscount": {
+                                                                                "type": "number",
+                                                                                "title": "PriceWithoutDiscount",
+                                                                                "description": "Price of the product without discount.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "RewardValue": {
+                                                                                "type": "number",
+                                                                                "title": "RewardValue",
+                                                                                "description": "Reward value of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "PriceValidUntil": {
+                                                                                "type": "string",
+                                                                                "title": "PriceValidUntil",
+                                                                                "description": "Price of the product valid until a certain date.",
+                                                                                "default": "4000-01-01T03:00:00Z"
+                                                                            },
+                                                                            "AvailableQuantity": {
+                                                                                "type": "integer",
+                                                                                "title": "AvailableQuantity",
+                                                                                "description": "Available quantity of the product.",
+                                                                                "default": 16
+                                                                            },
+                                                                            "IsAvailable": {
+                                                                                "type": "boolean",
+                                                                                "title": "IsAvailable",
+                                                                                "description": "If the product is available or not.",
+                                                                                "default": true
+                                                                            },
+                                                                            "Tax": {
+                                                                                "type": "number",
+                                                                                "title": "Tax",
+                                                                                "description": "Tax of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "SaleChannel": {
+                                                                                "type": "integer",
+                                                                                "title": "SaleChannel",
+                                                                                "description": "Trade policy which the product is contained.",
+                                                                                "default": 0
+                                                                            },
+                                                                            "DeliverySlaSamples": {
+                                                                                "type": "array",
+                                                                                "title": "DeliverySlaSamples",
+                                                                                "description": "Delivery SLA samples.",
+                                                                                "default": [
+                                                                                    {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "DeliverySlaPerTypes",
+                                                                                        "Region"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "DeliverySlaPerTypes": {
+                                                                                            "type": "array",
+                                                                                            "title": "DeliverySlaPerTypes",
+                                                                                            "description": "Delivery SLA per types.",
+                                                                                            "default": []
+                                                                                        },
+                                                                                        "Region": {
+                                                                                            "type": "string",
+                                                                                            "title": "Region",
+                                                                                            "description": "Region.",
+                                                                                            "default": null
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "GetInfoErrorMessage": {
+                                                                                "type": "string",
+                                                                                "title": "GetInfoErrorMessage",
+                                                                                "description": "Get info error message.",
+                                                                                "default": null
+                                                                            },
+                                                                            "CacheVersionUsedToCallCheckout": {
+                                                                                "type": "string",
+                                                                                "title": "CacheVersionUsedToCallCheckout",
+                                                                                "description": "Cache version used to call checkout.",
+                                                                                "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                            },
+                                                                            "PaymentOptions": {
+                                                                                "type": "object",
+                                                                                "title": "PaymentOptions",
+                                                                                "description": "Payment options.",
+                                                                                "default": {
+                                                                                    "installmentOptions": [
+                                                                                        {
+                                                                                            "paymentSystem": "2",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Visa",
+                                                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "paymentSystem": "17",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Promissory",
+                                                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ],
+                                                                                    "paymentSystems": [
+                                                                                        {
+                                                                                            "id": 17,
+                                                                                            "name": "Promissory",
+                                                                                            "groupName": "promissoryPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "17",
+                                                                                            "template": "promissoryPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        },
+                                                                                        {
+                                                                                            "id": 2,
+                                                                                            "name": "Visa",
+                                                                                            "groupName": "creditCardPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "2",
+                                                                                            "template": "creditCardPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        }
+                                                                                    ],
+                                                                                    "payments": [],
+                                                                                    "giftCards": [],
+                                                                                    "giftCardMessages": [],
+                                                                                    "availableAccounts": [],
+                                                                                    "availableTokens": []
+                                                                                },
+                                                                                "required": [
+                                                                                    "installmentOptions",
+                                                                                    "paymentSystems",
+                                                                                    "payments",
+                                                                                    "giftCards",
+                                                                                    "giftCardMessages",
+                                                                                    "availableAccounts",
+                                                                                    "availableTokens"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "installmentOptions": {
+                                                                                        "type": "array",
+                                                                                        "title": "installmentOptions",
+                                                                                        "description": "installment options.",
+                                                                                        "default": [
+                                                                                            [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "paymentSystem": "2",
+                                                                                                "bin": null,
+                                                                                                "paymentName": "Visa",
+                                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                "value": 4200,
+                                                                                                "installments": [
+                                                                                                    {
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 2,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 2100,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 3,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1400,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 4,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1050,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "paymentSystem",
+                                                                                                "bin",
+                                                                                                "paymentName",
+                                                                                                "paymentGroupName",
+                                                                                                "value",
+                                                                                                "installments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "paymentSystem": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentSystem",
+                                                                                                    "description": "Payment system.",
+                                                                                                    "default": "2"
+                                                                                                },
+                                                                                                "bin": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "bin",
+                                                                                                    "description": "Bin.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "paymentName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentName",
+                                                                                                    "description": "Payment name.",
+                                                                                                    "default": "Visa"
+                                                                                                },
+                                                                                                "paymentGroupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentGroupName",
+                                                                                                    "description": "Payment group name.",
+                                                                                                    "default": "creditCardPaymentGroup"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "value",
+                                                                                                    "description": "Value.",
+                                                                                                    "default": 4200
+                                                                                                },
+                                                                                                "installments": {
+                                                                                                    "type": "array",
+                                                                                                    "title": "installments",
+                                                                                                    "description": "Installments.",
+                                                                                                    "default": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ],
+                                                                                                    "items": {
+                                                                                                        "type": "object",
+                                                                                                        "title": "",
+                                                                                                        "default": {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "required": [
+                                                                                                            "count",
+                                                                                                            "hasInterestRate",
+                                                                                                            "interestRate",
+                                                                                                            "value",
+                                                                                                            "total",
+                                                                                                            "sellerMerchantInstallments"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                            "count": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "count",
+                                                                                                                "description": "Count.",
+                                                                                                                "default": 1
+                                                                                                            },
+                                                                                                            "hasInterestRate": {
+                                                                                                                "type": "boolean",
+                                                                                                                "title": "hasInterestRate",
+                                                                                                                "description": "Has interest rate.",
+                                                                                                                "default": false
+                                                                                                            },
+                                                                                                            "interestRate": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "interestRate",
+                                                                                                                "description": "Interest rate.",
+                                                                                                                "default": 0
+                                                                                                            },
+                                                                                                            "value": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "value",
+                                                                                                                "description": "Value.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "total": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "total",
+                                                                                                                "description": "Total.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "sellerMerchantInstallments": {
+                                                                                                                "type": "array",
+                                                                                                                "title": "sellerMerchantInstallments",
+                                                                                                                "description": "Seller merchant installments.",
+                                                                                                                "default": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "items": {
+                                                                                                                    "type": "object",
+                                                                                                                    "title": "",
+                                                                                                                    "default": {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                        "id",
+                                                                                                                        "count",
+                                                                                                                        "hasInterestRate",
+                                                                                                                        "interestRate",
+                                                                                                                        "value",
+                                                                                                                        "total"
+                                                                                                                    ],
+                                                                                                                    "properties": {
+                                                                                                                        "id": {
+                                                                                                                            "type": "string",
+                                                                                                                            "title": "id",
+                                                                                                                            "description": "ID.",
+                                                                                                                            "default": "MERCH"
+                                                                                                                        },
+                                                                                                                        "count": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "count",
+                                                                                                                            "description": "Count.",
+                                                                                                                            "default": 1
+                                                                                                                        },
+                                                                                                                        "hasInterestRate": {
+                                                                                                                            "type": "boolean",
+                                                                                                                            "title": "hasInterestRate",
+                                                                                                                            "description": "Has interest rate.",
+                                                                                                                            "default": false
+                                                                                                                        },
+                                                                                                                        "interestRate": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "interestRate",
+                                                                                                                            "description": "Interest rate.",
+                                                                                                                            "default": 0
+                                                                                                                        },
+                                                                                                                        "value": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "value",
+                                                                                                                            "description": "Value.",
+                                                                                                                            "default": 4200
+                                                                                                                        },
+                                                                                                                        "total": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "total",
+                                                                                                                            "description": "Total.",
+                                                                                                                            "default": 4200
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "paymentSystems": {
+                                                                                        "type": "array",
+                                                                                        "title": "paymentSystems",
+                                                                                        "description": "Payment systems.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            {
+                                                                                                "id": 2,
+                                                                                                "name": "Visa",
+                                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "2",
+                                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "id",
+                                                                                                "name",
+                                                                                                "groupName",
+                                                                                                "validator",
+                                                                                                "stringId",
+                                                                                                "template",
+                                                                                                "requiresDocument",
+                                                                                                "isCustom",
+                                                                                                "description",
+                                                                                                "requiresAuthentication",
+                                                                                                "dueDate",
+                                                                                                "availablePayments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "id": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "id",
+                                                                                                    "description": "ID.",
+                                                                                                    "default": 17
+                                                                                                },
+                                                                                                "name": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "name",
+                                                                                                    "description": "Name.",
+                                                                                                    "default": "Promissory"
+                                                                                                },
+                                                                                                "groupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "groupName",
+                                                                                                    "description": "Group name.",
+                                                                                                    "default": "promissoryPaymentGroup"
+                                                                                                },
+                                                                                                "validator": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "validator",
+                                                                                                    "description": "Validator.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "stringId": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "stringId",
+                                                                                                    "description": "String ID.",
+                                                                                                    "default": "17"
+                                                                                                },
+                                                                                                "template": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "template",
+                                                                                                    "description": "Template.",
+                                                                                                    "default": "promissoryPaymentGroup-template"
+                                                                                                },
+                                                                                                "requiresDocument": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresDocument",
+                                                                                                    "description": "If requires document or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "isCustom": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "isCustom",
+                                                                                                    "description": "If is custom or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "description": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "description",
+                                                                                                    "description": "Description.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "requiresAuthentication": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresAuthentication",
+                                                                                                    "description": "If requires authentication.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "dueDate": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "dueDate",
+                                                                                                    "description": "Due date.",
+                                                                                                    "default": "2021-07-01T18:43:00.0264384Z"
+                                                                                                },
+                                                                                                "availablePayments": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "availablePayments",
+                                                                                                    "description": "Available payments.",
+                                                                                                    "default": ""
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "payments": {
+                                                                                        "type": "array",
+                                                                                        "title": "payments",
+                                                                                        "description": "Payments.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCards": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCards",
+                                                                                        "description": "GiftCards.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCardMessages": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCardMessages",
+                                                                                        "description": "GiftCardMessages.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableAccounts": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableAccounts",
+                                                                                        "description": "Available accounts.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableTokens": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableTokens",
+                                                                                        "description": "Available tokens.",
+                                                                                        "default": []
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "Videos": {
+                                                            "type": "array",
+                                                            "title": "Videos",
+                                                            "description": "Videos.",
+                                                            "default": []
+                                                        },
+                                                        "estimatedDateArrival": {
+                                                            "type": "string",
+                                                            "title": "estimatedDateArrival",
+                                                            "description": "Estimated date arrival.",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
 					}
 				},
 				"deprecated": false,
@@ -3217,7 +6253,7 @@
 					"CrossSelling"
 				],
 				"summary": "ProductSearch Who Bought Also Bought",
-				"description": "",
+				"description": "Retrieves general information about other related products that the user also bought.",
 				"operationId": "ProductSearchWhoBoughtAlsoBought",
 				"parameters": [
                     {
@@ -3265,18 +6301,3054 @@
 					{
 						"name": "productId",
 						"in": "path",
-						"description": "",
+						"description": "Product unique identifier",
 						"required": true,
 						"style": "simple",
 						"schema": {
-							"type": "string"
+							"type": "string",
+                            "default": 1
 						}
 					}
 				],
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {}
+						"headers": {},
+                        "content": {
+                            "application/json":{
+                                "example":[{
+                                    "productId": "35",
+                                    "productName": "Kit de Hoegaarden",
+                                    "brand": "Hoegaarden",
+                                    "brandId": 2000004,
+                                    "brandImageUrl": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg",
+                                    "linkText": "kit-6-cerveja-hoegaarden",
+                                    "productReference": "000806",
+                                    "productReferenceCode": null,
+                                    "categoryId": "1",
+                                    "productTitle": "",
+                                    "metaTagDescription": "",
+                                    "releaseDate": "2020-10-07T00:00:00",
+                                    "clusterHighlights": {
+                                        "138": "teste2"
+                                    },
+                                    "productClusters": {
+                                        "138": "teste2",
+                                        "143": "NaoPesquisavel",
+                                        "146": "colecaotestesubcategoria",
+                                        "161": "merch_import_test1"
+                                    },
+                                    "searchableClusters": {
+                                        "138": "teste2"
+                                    },
+                                    "categories": [
+                                        "/Beers Beers Mesmo/"
+                                    ],
+                                    "categoriesIds": [
+                                        "/1/"
+                                    ],
+                                    "link": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p",
+                                    "Percentuals": [
+                                        "4,9"
+                                    ],
+                                    "Percentual": [
+                                        "4,9"
+                                    ],
+                                    "Total": [
+                                        "Percentuals",
+                                        "Percentual"
+                                    ],
+                                    "Teste de Api": [
+                                        "a"
+                                    ],
+                                    "Ale": [
+                                        "1"
+                                    ],
+                                    "Teste da Api2": [
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "Alcool": [
+                                        "Percentual"
+                                    ],
+                                    "allSpecifications": [
+                                        "Percentuals",
+                                        "Percentual",
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "allSpecificationsGroups": [
+                                        "Total",
+                                        "Teste da Api2"
+                                    ],
+                                    "description": "",
+                                    "items": [{
+                                        "itemId": "310118469",
+                                        "name": "Kit com 6",
+                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                        "complementName": "",
+                                        "ean": "",
+                                        "referenceId": [{
+                                            "Key": "RefId",
+                                            "Value": "000806"
+                                        }],
+                                        "measurementUnit": "un",
+                                        "unitMultiplier": 1.0000,
+                                        "modalType": null,
+                                        "isKit": true,
+                                        "kitItems": [{
+                                            "itemId": "310118466",
+                                            "amount": 6
+                                        }],
+                                        "images": [{
+                                            "imageId": "155489",
+                                            "imageLabel": "",
+                                            "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                            "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                            "imageText": "hoegaarden-kit",
+                                            "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                        }],
+                                        "sellers": [{
+                                            "sellerId": "1",
+                                            "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                            "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                            "sellerDefault": true,
+                                            "commertialOffer": {
+                                                "DeliverySlaSamplesPerRegion": {
+                                                    "0": {
+                                                        "DeliverySlaPerTypes": [],
+                                                        "Region": null
+                                                    }
+                                                },
+                                                "Installments": [{
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa à vista"
+                                                    },
+                                                    {
+                                                        "Value": 21.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 2,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 2 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 14.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 3,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 3 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 10.5,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 4,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 4 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Promissory",
+                                                        "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                        "Name": "Promissory à vista"
+                                                    }
+                                                ],
+                                                "DiscountHighLight": [],
+                                                "GiftSkuIds": [],
+                                                "Teasers": [],
+                                                "BuyTogether": [],
+                                                "ItemMetadataAttachment": [],
+                                                "Price": 42.0,
+                                                "ListPrice": 42.0,
+                                                "PriceWithoutDiscount": 42.0,
+                                                "RewardValue": 0.0,
+                                                "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                "AvailableQuantity": 16,
+                                                "IsAvailable": true,
+                                                "Tax": 0.0,
+                                                "SaleChannel": 0,
+                                                "DeliverySlaSamples": [{
+                                                    "DeliverySlaPerTypes": [],
+                                                    "Region": null
+                                                }],
+                                                "GetInfoErrorMessage": null,
+                                                "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                "PaymentOptions": {
+                                                    "installmentOptions": [{
+                                                            "paymentSystem": "2",
+                                                            "bin": null,
+                                                            "paymentName": "Visa",
+                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 1,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 4200,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 2,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 2100,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 2,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 2100,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 3,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1400,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 3,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1400,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 4,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1050,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 4,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1050,
+                                                                        "total": 4200
+                                                                    }]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "paymentSystem": "17",
+                                                            "bin": null,
+                                                            "paymentName": "Promissory",
+                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                "count": 1,
+                                                                "hasInterestRate": false,
+                                                                "interestRate": 0,
+                                                                "value": 4200,
+                                                                "total": 4200,
+                                                                "sellerMerchantInstallments": [{
+                                                                    "id": "MERCH",
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200
+                                                                }]
+                                                            }]
+                                                        }
+                                                    ],
+                                                    "paymentSystems": [{
+                                                            "id": 17,
+                                                            "name": "Promissory",
+                                                            "groupName": "promissoryPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "17",
+                                                            "template": "promissoryPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "name": "Visa",
+                                                            "groupName": "creditCardPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "2",
+                                                            "template": "creditCardPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        }
+                                                    ],
+                                                    "payments": [],
+                                                    "giftCards": [],
+                                                    "giftCardMessages": [],
+                                                    "availableAccounts": [],
+                                                    "availableTokens": []
+                                                }
+                                            }
+                                        }],
+                                        "Videos": [],
+                                        "estimatedDateArrival": null
+                                    }]
+                                }],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "",
+                                        "required": [
+                                            "productId",
+                                            "productName",
+                                            "brand",
+                                            "brandId",
+                                            "brandImageUrl",
+                                            "linkText",
+                                            "productReference",
+                                            "productReferenceCode",
+                                            "categoryId",
+                                            "productTitle",
+                                            "metaTagDescription",
+                                            "releaseDate",
+                                            "clusterHighlights",
+                                            "productClusters",
+                                            "searchableClusters",
+                                            "categories",
+                                            "categoriesIds",
+                                            "link",
+                                            "Percentuals",
+                                            "Percentual",
+                                            "Total",
+                                            "Teste de Api",
+                                            "Ale",
+                                            "Teste da Api2",
+                                            "Alcool",
+                                            "allSpecifications",
+                                            "allSpecificationsGroups",
+                                            "description",
+                                            "items"
+                                        ],
+                                        "properties": {
+                                            "productId": {
+                                                "type": "string",
+                                                "title": "productId",
+                                                "description": "Product unique identifier.",
+                                                "default": "35"
+                                            },
+                                            "productName": {
+                                                "type": "string",
+                                                "title": "productName",
+                                                "description": "Product name.",
+                                                "default": "Kit de Hoegaarden"
+                                            },
+                                            "brand": {
+                                                "type": "string",
+                                                "title": "brand",
+                                                "description": "Brand name.",
+                                                "default": "Hoegaarden"
+                                            },
+                                            "brandId": {
+                                                "type": "integer",
+                                                "title": "brandId",
+                                                "description": "Product brand ID.",
+                                                "default": 2000004
+                                            },
+                                            "brandImageUrl": {
+                                                "type": "string",
+                                                "title": "brandImageUrl",
+                                                "description": "Product's brand image URL.",
+                                                "default": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg"
+                                            },
+                                            "linkText": {
+                                                "type": "string",
+                                                "title": "linkText",
+                                                "description": "Product URL.",
+                                                "default": "kit-6-cerveja-hoegaarden"
+                                            },
+                                            "productReference": {
+                                                "type": "string",
+                                                "title": "productReference",
+                                                "description": "Product reference.",
+                                                "default": "000806"
+                                            },
+                                            "productReferenceCode": {
+                                                "type": "integer",
+                                                "title": "productReferenceCode",
+                                                "description": "Product reference ID.",
+                                                "default": 1234
+                                            },
+                                            "categoryId": {
+                                                "type": "string",
+                                                "title": "categoryId",
+                                                "description": "Product category ID.",
+                                                "default": "1"
+                                            },
+                                            "productTitle": {
+                                                "type": "string",
+                                                "title": "productTitle",
+                                                "description": "Text that is in the browser tab and corresponds to the title of the product page. This field is important for SEO.",
+                                                "default": "Kit 6 cerveja Hoegaarden"
+                                            },
+                                            "metaTagDescription": {
+                                                "type": "string",
+                                                "title": "metaTagDescription",
+                                                "description": "Brief description of the category. It's recommended that you don't exceed 150 characters so that the search engines can display it correctly in the results page.",
+                                                "default": "Category for Beers"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "title": "releaseDate",
+                                                "description": "Product release date.",
+                                                "default": "2020-10-07T00:00:00"
+                                            },
+                                            "clusterHighlights": {
+                                                "type": "object",
+                                                "title": "clusterHighlights",
+                                                "description": "Cluster highlight ID and name.",
+                                                "default": {
+                                                        "138": "teste2"
+                                                    }
+                                            },
+                                            "productClusters": {
+                                                "type": "object",
+                                                "title": "productClusters",
+                                                "description": "Product clusters' IDs and names.",
+                                                "default": {
+                                                        "138": "teste2",
+                                                        "143": "NaoPesquisavel",
+                                                        "146": "colecaotestesubcategoria",
+                                                        "161": "merch_import_test1"
+                                                }
+                                            },
+                                            "searchableClusters": {
+                                                "type": "object",
+                                                "title": "searchableClusters",
+                                                "description": "Searchable clusters IDs and names",
+                                                "default": {
+                                                    "138": "teste2"
+                                                }
+                                            },
+                                            "categories": {
+                                                "type": "array",
+                                                "title": "categories",
+                                                "description": "Array of the product's categories URLs.",
+                                                "default": [
+                                                    "/Beers Beers Mesmo/"
+                                                ]
+                                            },
+                                            "categoriesIds": {
+                                                "type": "array",
+                                                "title": "categoriesIds",
+                                                "description": "Array of the product's categories IDs.",
+                                                "default": [
+                                                    "/1/"
+                                                ]
+                                            },
+                                            "link": {
+                                                "type": "string",
+                                                "title": "link",
+                                                "description": "Product URL.",
+                                                "default": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p"
+                                            },
+                                            "allSpecifications": {
+                                                "type": "array",
+                                                "title": "allSpecifications",
+                                                "description": "Array of the product's specifications.",
+                                                "default": [
+                                                    "Percentuals",
+                                                    "Percentual"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification.",
+                                                    "default": "Percentual"
+                                                }
+                                            },
+                                            "allSpecificationsGroups": {
+                                                "type": "array",
+                                                "title": "allSpecificationsGroups",
+                                                "description": "Array of the product's specifications groups.",
+                                                "default": [
+                                                    "Total",
+                                                    "Teste da Api2"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification group",
+                                                    "default": "Teste da Api2"
+                                                }
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "title": "description",
+                                                "description": "Description of the main information related to the product. A simple and easy to understand summary for the customer.",
+                                                "default": "Description example"
+                                            },
+                                            "items": {
+                                                "type": "array",
+                                                "title": "items",
+                                                "description": "Array containing the product SKU general information.",
+                                                "default": [
+                                                    {
+                                                        "itemId": "310118469",
+                                                        "name": "Kit com 6",
+                                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                        "complementName": "",
+                                                        "ean": "",
+                                                        "referenceId": [
+                                                            {
+                                                                "Key": "RefId",
+                                                                "Value": "000806"
+                                                            }
+                                                        ],
+                                                        "measurementUnit": "un",
+                                                        "unitMultiplier": 1.0,
+                                                        "modalType": null,
+                                                        "isKit": true,
+                                                        "kitItems": [
+                                                            {
+                                                                "itemId": "310118466",
+                                                                "amount": 6
+                                                            }
+                                                        ],
+                                                        "images": [
+                                                            {
+                                                                "imageId": "155489",
+                                                                "imageLabel": "",
+                                                                "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                "imageText": "hoegaarden-kit",
+                                                                "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                            }
+                                                        ],
+                                                        "sellers": [
+                                                            {
+                                                                "sellerId": "1",
+                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                "sellerDefault": true,
+                                                                "commertialOffer": {
+                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                        "0": {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    },
+                                                                    "Installments": [
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa à vista"
+                                                                        },
+                                                                        {
+                                                                            "Value": 21.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 2,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 14.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 3,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 3 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 10.5,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 4,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 4 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Promissory",
+                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                            "Name": "Promissory à vista"
+                                                                        }
+                                                                    ],
+                                                                    "DiscountHighLight": [],
+                                                                    "GiftSkuIds": [],
+                                                                    "Teasers": [],
+                                                                    "BuyTogether": [],
+                                                                    "ItemMetadataAttachment": [],
+                                                                    "Price": 42.0,
+                                                                    "ListPrice": 42.0,
+                                                                    "PriceWithoutDiscount": 42.0,
+                                                                    "RewardValue": 0.0,
+                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                    "AvailableQuantity": 16,
+                                                                    "IsAvailable": true,
+                                                                    "Tax": 0.0,
+                                                                    "SaleChannel": 0,
+                                                                    "DeliverySlaSamples": [
+                                                                        {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    ],
+                                                                    "GetInfoErrorMessage": null,
+                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                    "PaymentOptions": {
+                                                                        "installmentOptions": [
+                                                                            {
+                                                                                "paymentSystem": "2",
+                                                                                "bin": null,
+                                                                                "paymentName": "Visa",
+                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 2,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 2100,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 3,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1400,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 4,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1050,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "paymentSystem": "17",
+                                                                                "bin": null,
+                                                                                "paymentName": "Promissory",
+                                                                                "paymentGroupName": "promissoryPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "paymentSystems": [
+                                                                            {
+                                                                                "id": 17,
+                                                                                "name": "Promissory",
+                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "17",
+                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            },
+                                                                            {
+                                                                                "id": 2,
+                                                                                "name": "Visa",
+                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "2",
+                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            }
+                                                                        ],
+                                                                        "payments": [],
+                                                                        "giftCards": [],
+                                                                        "giftCardMessages": [],
+                                                                        "availableAccounts": [],
+                                                                        "availableTokens": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "Videos": [],
+                                                        "estimatedDateArrival": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": [
+                                                        {
+                                                            "itemId": "310118469",
+                                                            "name": "Kit com 6",
+                                                            "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                            "complementName": "",
+                                                            "ean": "",
+                                                            "referenceId": [
+                                                                {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                }
+                                                            ],
+                                                            "measurementUnit": "un",
+                                                            "unitMultiplier": 1.0,
+                                                            "modalType": null,
+                                                            "isKit": true,
+                                                            "kitItems": [
+                                                                {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                }
+                                                            ],
+                                                            "images": [
+                                                                {
+                                                                    "imageId": "155489",
+                                                                    "imageLabel": "",
+                                                                    "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                    "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                    "imageText": "hoegaarden-kit",
+                                                                    "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                }
+                                                            ],
+                                                            "sellers": [
+                                                                {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Videos": [],
+                                                            "estimatedDateArrival": null
+                                                        }
+                                                    ],
+                                                    "required": [
+                                                        "itemId",
+                                                        "name",
+                                                        "nameComplete",
+                                                        "complementName",
+                                                        "ean",
+                                                        "referenceId",
+                                                        "measurementUnit",
+                                                        "unitMultiplier",
+                                                        "modalType",
+                                                        "isKit",
+                                                        "kitItems",
+                                                        "images",
+                                                        "sellers",
+                                                        "Videos",
+                                                        "estimatedDateArrival"
+                                                    ],
+                                                    "properties": {
+                                                        "itemId": {
+                                                            "type": "string",
+                                                            "title": "itemId",
+                                                            "description": "SKU ID.",
+                                                            "default": "310118469"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "title": "name",
+                                                            "description": "SKU name.",
+                                                            "default": "Kit com 6"
+                                                        },
+                                                        "nameComplete": {
+                                                            "type": "string",
+                                                            "title": "nameComplete",
+                                                            "description": "SKU complete name.",
+                                                            "default": "Kit de Hoegaarden Kit com 6"
+                                                        },
+                                                        "complementName": {
+                                                            "type": "string",
+                                                            "title": "complementName",
+                                                            "description": "SKU complement name.",
+                                                            "default": "Complement name"
+                                                        },
+                                                        "ean": {
+                                                            "type": "string",
+                                                            "title": "ean",
+                                                            "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                            "default": "12345567"
+                                                        },
+                                                        "referenceId": {
+                                                            "type": "array",
+                                                            "title": "referenceId",
+                                                            "description": "Reference code ID.",
+                                                            "default": [
+                                                                    {
+                                                                        "Key": "RefId",
+                                                                        "Value": "000806"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                },
+                                                                "required": [
+                                                                    "Key",
+                                                                    "Value"
+                                                                ],
+                                                                "properties": {
+                                                                    "Key": {
+                                                                        "type": "string",
+                                                                        "title": "Key",
+                                                                        "description": "Reference Code.",
+                                                                        "default": [
+                                                                            "RefId"
+                                                                        ]
+                                                                    },
+                                                                    "Value": {
+                                                                        "type": "string",
+                                                                        "title": "Value",
+                                                                        "description": "Unique reference code used internally for organizational purposes.",
+                                                                        "default": [
+                                                                            "000806"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "measurementUnit": {
+                                                            "type": "string",
+                                                            "title": "measurementUnit",
+                                                            "description": "Used only in cases when you need to convert the unit of measure for sale. In common cases, use 'un'.",
+                                                            "default": [
+                                                                "un"
+                                                            ]
+                                                        },
+                                                        "unitMultiplier": {
+                                                            "type": "number",
+                                                            "title": "unitMultiplier",
+                                                            "description": "numerical unit that multiplies the selected quantity of the product when it is inserted in the cart.",
+                                                            "default": 1.0
+                                                        },
+                                                        "modalType": {
+                                                            "type": "string",
+                                                            "title": "modalType",
+                                                            "description": "Modal Type.",
+                                                            "default": "Modal Type test"
+                                                        },
+                                                        "isKit": {
+                                                            "type": "boolean",
+                                                            "title": "isKit",
+                                                            "description": "If the SKU is part of a kit.",
+                                                            "default": true
+                                                        },
+                                                        "kitItems": {
+                                                            "type": "array",
+                                                            "title": "kitItems",
+                                                            "description": "Array with information of SKUs components from a Kit.",
+                                                            "default": [
+                                                                    {
+                                                                        "itemId": "310118466",
+                                                                        "amount": 6
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                },
+                                                                "required": [
+                                                                    "itemId",
+                                                                    "amount"
+                                                                ],
+                                                                "properties": {
+                                                                    "itemId": {
+                                                                        "type": "string",
+                                                                        "title": "itemId",
+                                                                        "description": "SKU kit component ID.",
+                                                                        "default": [
+                                                                            "310118466"
+                                                                        ]
+                                                                    },
+                                                                    "amount": {
+                                                                        "type": "integer",
+                                                                        "title": "amount",
+                                                                        "description": "Amount of the SKU component in the kit.",
+                                                                        "default": 6
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "title": "images",
+                                                            "description": "Array of information about the SKU image.",
+                                                            "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                                "required": [
+                                                                    "imageId",
+                                                                    "imageLabel",
+                                                                    "imageTag",
+                                                                    "imageUrl",
+                                                                    "imageText",
+                                                                    "imageLastModified"
+                                                                ],
+                                                                "properties": {
+                                                                    "imageId": {
+                                                                        "type": "string",
+                                                                        "title": "imageId",
+                                                                        "description": "Image ID.",
+                                                                        "default": [
+                                                                            "155489"
+                                                                        ]
+                                                                    },
+                                                                    "imageLabel": {
+                                                                        "type": "string",
+                                                                        "title": "imageLabel",
+                                                                        "description": "Image label.",
+                                                                        "default": "Label test"
+                                                                    },
+                                                                    "imageTag": {
+                                                                        "type": "string",
+                                                                        "title": "imageTag",
+                                                                        "description": "Image tag.",
+                                                                        "default": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
+                                                                    },
+                                                                    "imageUrl": {
+                                                                        "type": "string",
+                                                                        "title": "imageUrl",
+                                                                        "description": "Image URL.",
+                                                                        "default": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
+                                                                    },
+                                                                    "imageText": {
+                                                                        "type": "string",
+                                                                        "title": "imageText",
+                                                                        "description": "Image text.",
+                                                                        "default": "hoegaarden-kit"
+                                                                    },
+                                                                    "imageLastModified": {
+                                                                        "type": "string",
+                                                                        "title": "imageLastModified",
+                                                                        "description": "Date and time of the last update of the image.",
+                                                                        "default": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "sellers": {
+                                                            "type": "array",
+                                                            "title": "sellers",
+                                                            "description": "Array of SKU sellers.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "sellerId": "1",
+                                                                        "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                        "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                        "sellerDefault": true,
+                                                                        "commertialOffer": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "sellerId",
+                                                                    "sellerName",
+                                                                    "addToCartLink",
+                                                                    "sellerDefault",
+                                                                    "commertialOffer"
+                                                                ],
+                                                                "properties": {
+                                                                    "sellerId": {
+                                                                        "type": "string",
+                                                                        "title": "sellerId",
+                                                                        "description": "SKU seller ID.",
+                                                                        "default": "1"
+                                                                    },
+                                                                    "sellerName": {
+                                                                        "type": "string",
+                                                                        "title": "sellerName",
+                                                                        "description": "SKU seller name.",
+                                                                        "default": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
+                                                                    },
+                                                                    "addToCartLink": {
+                                                                        "type": "string",
+                                                                        "title": "addToCartLink",
+                                                                        "description": "URL to add the product to the cart.",
+                                                                        "default": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
+                                                                    },
+                                                                    "sellerDefault": {
+                                                                        "type": "boolean",
+                                                                        "title": "sellerDefault",
+                                                                        "description": "If the seller is default or not.",
+                                                                        "default": true
+                                                                    },
+                                                                    "commertialOffer": {
+                                                                        "type": "object",
+                                                                        "title": "commertialOffer",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "DeliverySlaSamplesPerRegion",
+                                                                            "Installments",
+                                                                            "DiscountHighLight",
+                                                                            "GiftSkuIds",
+                                                                            "Teasers",
+                                                                            "BuyTogether",
+                                                                            "ItemMetadataAttachment",
+                                                                            "Price",
+                                                                            "ListPrice",
+                                                                            "PriceWithoutDiscount",
+                                                                            "RewardValue",
+                                                                            "PriceValidUntil",
+                                                                            "AvailableQuantity",
+                                                                            "IsAvailable",
+                                                                            "Tax",
+                                                                            "SaleChannel",
+                                                                            "DeliverySlaSamples",
+                                                                            "GetInfoErrorMessage",
+                                                                            "CacheVersionUsedToCallCheckout",
+                                                                            "PaymentOptions"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "type": "object",
+                                                                                "title": "DeliverySlaSamplesPerRegion",
+                                                                                "description": "Delivery SLA samples per region.",
+                                                                                "default": {
+                                                                                    "0": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": "null"
+                                                                                    }
+                                                                                },
+                                                                                "properties": {
+                                                                                    "0": {
+                                                                                        "type": "object",
+                                                                                        "title": "The 0 schema",
+                                                                                        "description": "0.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "required": [
+                                                                                            "DeliverySlaPerTypes",
+                                                                                            "Region"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "DeliverySlaPerTypes": {
+                                                                                                "type": "array",
+                                                                                                "title": "DeliverySlaPerTypes",
+                                                                                                "description": "Delivery SLA per types.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "Region": {
+                                                                                                "type": "string",
+                                                                                                "title": "Region",
+                                                                                                "description": "Region.",
+                                                                                                "default": ""
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "Installments": {
+                                                                                "type": "array",
+                                                                                "title": "Installments",
+                                                                                "description": "Installments options.",
+                                                                                "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 21.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 2,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                                        }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        }
+                                                                                    ],
+                                                                                    "required": [
+                                                                                        "Value",
+                                                                                        "InterestRate",
+                                                                                        "TotalValuePlusInterestRate",
+                                                                                        "NumberOfInstallments",
+                                                                                        "PaymentSystemName",
+                                                                                        "PaymentSystemGroupName",
+                                                                                        "Name"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "Value": {
+                                                                                            "type": "number",
+                                                                                            "title": "Value",
+                                                                                            "description": "Value of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "InterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "InterestRate",
+                                                                                            "description": "Interest rate of the installment.",
+                                                                                            "default": 0.0
+                                                                                        },
+                                                                                        "TotalValuePlusInterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "TotalValuePlusInterestRate",
+                                                                                            "description": "Total value plus interest rate of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "NumberOfInstallments": {
+                                                                                            "type": "integer",
+                                                                                            "title": "NumberOfInstallments",
+                                                                                            "description": "Number of the installment.",
+                                                                                            "default": 1
+                                                                                        },
+                                                                                        "PaymentSystemName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemName",
+                                                                                            "description": "Payment system name of the installment.",
+                                                                                            "default": "Visa"
+                                                                                        },
+                                                                                        "PaymentSystemGroupName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemGroupName",
+                                                                                            "description": "Payment system group name of the installment.",
+                                                                                            "default": "creditCardPaymentGroup"
+                                                                                        },
+                                                                                        "Name": {
+                                                                                            "type": "string",
+                                                                                            "title": "Name",
+                                                                                            "description": "Name of the installment.",
+                                                                                            "default": "Visa à vista"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "DiscountHighLight": {
+                                                                                "type": "array",
+                                                                                "title": "DiscountHighLight",
+                                                                                "description": "Discount hightlight.",
+                                                                                "default": []
+                                                                            },
+                                                                            "GiftSkuIds": {
+                                                                                "type": "array",
+                                                                                "title": "GiftSkuIds",
+                                                                                "description": "Array of SKU gifts IDs.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Teasers": {
+                                                                                "type": "array",
+                                                                                "title": "Teasers",
+                                                                                "description": "Teasers.",
+                                                                                "default": []
+                                                                            },
+                                                                            "BuyTogether": {
+                                                                                "type": "array",
+                                                                                "title": "BuyTogether",
+                                                                                "description": "Array of other products that can be bought together with the product in question.",
+                                                                                "default": []
+                                                                            },
+                                                                            "ItemMetadataAttachment": {
+                                                                                "type": "array",
+                                                                                "title": "ItemMetadataAttachment",
+                                                                                "description": "Item metadata attachment.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Price": {
+                                                                                "type": "number",
+                                                                                "title": "Price",
+                                                                                "description": "Price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "ListPrice": {
+                                                                                "type": "number",
+                                                                                "title": "ListPrice",
+                                                                                "description": "List price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "PriceWithoutDiscount": {
+                                                                                "type": "number",
+                                                                                "title": "PriceWithoutDiscount",
+                                                                                "description": "Price of the product without discount.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "RewardValue": {
+                                                                                "type": "number",
+                                                                                "title": "RewardValue",
+                                                                                "description": "Reward value of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "PriceValidUntil": {
+                                                                                "type": "string",
+                                                                                "title": "PriceValidUntil",
+                                                                                "description": "Price of the product valid until a certain date.",
+                                                                                "default": "4000-01-01T03:00:00Z"
+                                                                            },
+                                                                            "AvailableQuantity": {
+                                                                                "type": "integer",
+                                                                                "title": "AvailableQuantity",
+                                                                                "description": "Available quantity of the product.",
+                                                                                "default": 16
+                                                                            },
+                                                                            "IsAvailable": {
+                                                                                "type": "boolean",
+                                                                                "title": "IsAvailable",
+                                                                                "description": "If the product is available or not.",
+                                                                                "default": true
+                                                                            },
+                                                                            "Tax": {
+                                                                                "type": "number",
+                                                                                "title": "Tax",
+                                                                                "description": "Tax of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "SaleChannel": {
+                                                                                "type": "integer",
+                                                                                "title": "SaleChannel",
+                                                                                "description": "Trade policy which the product is contained.",
+                                                                                "default": 0
+                                                                            },
+                                                                            "DeliverySlaSamples": {
+                                                                                "type": "array",
+                                                                                "title": "DeliverySlaSamples",
+                                                                                "description": "Delivery SLA samples.",
+                                                                                "default": [
+                                                                                    {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "DeliverySlaPerTypes",
+                                                                                        "Region"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "DeliverySlaPerTypes": {
+                                                                                            "type": "array",
+                                                                                            "title": "DeliverySlaPerTypes",
+                                                                                            "description": "Delivery SLA per types.",
+                                                                                            "default": []
+                                                                                        },
+                                                                                        "Region": {
+                                                                                            "type": "string",
+                                                                                            "title": "Region",
+                                                                                            "description": "Region.",
+                                                                                            "default": null
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "GetInfoErrorMessage": {
+                                                                                "type": "string",
+                                                                                "title": "GetInfoErrorMessage",
+                                                                                "description": "Get info error message.",
+                                                                                "default": null
+                                                                            },
+                                                                            "CacheVersionUsedToCallCheckout": {
+                                                                                "type": "string",
+                                                                                "title": "CacheVersionUsedToCallCheckout",
+                                                                                "description": "Cache version used to call checkout.",
+                                                                                "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                            },
+                                                                            "PaymentOptions": {
+                                                                                "type": "object",
+                                                                                "title": "PaymentOptions",
+                                                                                "description": "Payment options.",
+                                                                                "default": {
+                                                                                    "installmentOptions": [
+                                                                                        {
+                                                                                            "paymentSystem": "2",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Visa",
+                                                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "paymentSystem": "17",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Promissory",
+                                                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ],
+                                                                                    "paymentSystems": [
+                                                                                        {
+                                                                                            "id": 17,
+                                                                                            "name": "Promissory",
+                                                                                            "groupName": "promissoryPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "17",
+                                                                                            "template": "promissoryPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        },
+                                                                                        {
+                                                                                            "id": 2,
+                                                                                            "name": "Visa",
+                                                                                            "groupName": "creditCardPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "2",
+                                                                                            "template": "creditCardPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        }
+                                                                                    ],
+                                                                                    "payments": [],
+                                                                                    "giftCards": [],
+                                                                                    "giftCardMessages": [],
+                                                                                    "availableAccounts": [],
+                                                                                    "availableTokens": []
+                                                                                },
+                                                                                "required": [
+                                                                                    "installmentOptions",
+                                                                                    "paymentSystems",
+                                                                                    "payments",
+                                                                                    "giftCards",
+                                                                                    "giftCardMessages",
+                                                                                    "availableAccounts",
+                                                                                    "availableTokens"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "installmentOptions": {
+                                                                                        "type": "array",
+                                                                                        "title": "installmentOptions",
+                                                                                        "description": "installment options.",
+                                                                                        "default": [
+                                                                                            [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "paymentSystem": "2",
+                                                                                                "bin": null,
+                                                                                                "paymentName": "Visa",
+                                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                "value": 4200,
+                                                                                                "installments": [
+                                                                                                    {
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 2,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 2100,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 3,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1400,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 4,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1050,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "paymentSystem",
+                                                                                                "bin",
+                                                                                                "paymentName",
+                                                                                                "paymentGroupName",
+                                                                                                "value",
+                                                                                                "installments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "paymentSystem": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentSystem",
+                                                                                                    "description": "Payment system.",
+                                                                                                    "default": "2"
+                                                                                                },
+                                                                                                "bin": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "bin",
+                                                                                                    "description": "Bin.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "paymentName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentName",
+                                                                                                    "description": "Payment name.",
+                                                                                                    "default": "Visa"
+                                                                                                },
+                                                                                                "paymentGroupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentGroupName",
+                                                                                                    "description": "Payment group name.",
+                                                                                                    "default": "creditCardPaymentGroup"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "value",
+                                                                                                    "description": "Value.",
+                                                                                                    "default": 4200
+                                                                                                },
+                                                                                                "installments": {
+                                                                                                    "type": "array",
+                                                                                                    "title": "installments",
+                                                                                                    "description": "Installments.",
+                                                                                                    "default": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ],
+                                                                                                    "items": {
+                                                                                                        "type": "object",
+                                                                                                        "title": "",
+                                                                                                        "default": {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "required": [
+                                                                                                            "count",
+                                                                                                            "hasInterestRate",
+                                                                                                            "interestRate",
+                                                                                                            "value",
+                                                                                                            "total",
+                                                                                                            "sellerMerchantInstallments"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                            "count": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "count",
+                                                                                                                "description": "Count.",
+                                                                                                                "default": 1
+                                                                                                            },
+                                                                                                            "hasInterestRate": {
+                                                                                                                "type": "boolean",
+                                                                                                                "title": "hasInterestRate",
+                                                                                                                "description": "Has interest rate.",
+                                                                                                                "default": false
+                                                                                                            },
+                                                                                                            "interestRate": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "interestRate",
+                                                                                                                "description": "Interest rate.",
+                                                                                                                "default": 0
+                                                                                                            },
+                                                                                                            "value": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "value",
+                                                                                                                "description": "Value.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "total": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "total",
+                                                                                                                "description": "Total.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "sellerMerchantInstallments": {
+                                                                                                                "type": "array",
+                                                                                                                "title": "sellerMerchantInstallments",
+                                                                                                                "description": "Seller merchant installments.",
+                                                                                                                "default": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "items": {
+                                                                                                                    "type": "object",
+                                                                                                                    "title": "",
+                                                                                                                    "default": {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                        "id",
+                                                                                                                        "count",
+                                                                                                                        "hasInterestRate",
+                                                                                                                        "interestRate",
+                                                                                                                        "value",
+                                                                                                                        "total"
+                                                                                                                    ],
+                                                                                                                    "properties": {
+                                                                                                                        "id": {
+                                                                                                                            "type": "string",
+                                                                                                                            "title": "id",
+                                                                                                                            "description": "ID.",
+                                                                                                                            "default": "MERCH"
+                                                                                                                        },
+                                                                                                                        "count": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "count",
+                                                                                                                            "description": "Count.",
+                                                                                                                            "default": 1
+                                                                                                                        },
+                                                                                                                        "hasInterestRate": {
+                                                                                                                            "type": "boolean",
+                                                                                                                            "title": "hasInterestRate",
+                                                                                                                            "description": "Has interest rate.",
+                                                                                                                            "default": false
+                                                                                                                        },
+                                                                                                                        "interestRate": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "interestRate",
+                                                                                                                            "description": "Interest rate.",
+                                                                                                                            "default": 0
+                                                                                                                        },
+                                                                                                                        "value": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "value",
+                                                                                                                            "description": "Value.",
+                                                                                                                            "default": 4200
+                                                                                                                        },
+                                                                                                                        "total": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "total",
+                                                                                                                            "description": "Total.",
+                                                                                                                            "default": 4200
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "paymentSystems": {
+                                                                                        "type": "array",
+                                                                                        "title": "paymentSystems",
+                                                                                        "description": "Payment systems.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            {
+                                                                                                "id": 2,
+                                                                                                "name": "Visa",
+                                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "2",
+                                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "id",
+                                                                                                "name",
+                                                                                                "groupName",
+                                                                                                "validator",
+                                                                                                "stringId",
+                                                                                                "template",
+                                                                                                "requiresDocument",
+                                                                                                "isCustom",
+                                                                                                "description",
+                                                                                                "requiresAuthentication",
+                                                                                                "dueDate",
+                                                                                                "availablePayments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "id": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "id",
+                                                                                                    "description": "ID.",
+                                                                                                    "default": 17
+                                                                                                },
+                                                                                                "name": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "name",
+                                                                                                    "description": "Name.",
+                                                                                                    "default": "Promissory"
+                                                                                                },
+                                                                                                "groupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "groupName",
+                                                                                                    "description": "Group name.",
+                                                                                                    "default": "promissoryPaymentGroup"
+                                                                                                },
+                                                                                                "validator": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "validator",
+                                                                                                    "description": "Validator.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "stringId": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "stringId",
+                                                                                                    "description": "String ID.",
+                                                                                                    "default": "17"
+                                                                                                },
+                                                                                                "template": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "template",
+                                                                                                    "description": "Template.",
+                                                                                                    "default": "promissoryPaymentGroup-template"
+                                                                                                },
+                                                                                                "requiresDocument": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresDocument",
+                                                                                                    "description": "If requires document or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "isCustom": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "isCustom",
+                                                                                                    "description": "If is custom or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "description": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "description",
+                                                                                                    "description": "Description.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "requiresAuthentication": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresAuthentication",
+                                                                                                    "description": "If requires authentication.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "dueDate": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "dueDate",
+                                                                                                    "description": "Due date.",
+                                                                                                    "default": "2021-07-01T18:43:00.0264384Z"
+                                                                                                },
+                                                                                                "availablePayments": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "availablePayments",
+                                                                                                    "description": "Available payments.",
+                                                                                                    "default": ""
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "payments": {
+                                                                                        "type": "array",
+                                                                                        "title": "payments",
+                                                                                        "description": "Payments.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCards": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCards",
+                                                                                        "description": "GiftCards.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCardMessages": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCardMessages",
+                                                                                        "description": "GiftCardMessages.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableAccounts": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableAccounts",
+                                                                                        "description": "Available accounts.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableTokens": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableTokens",
+                                                                                        "description": "Available tokens.",
+                                                                                        "default": []
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "Videos": {
+                                                            "type": "array",
+                                                            "title": "Videos",
+                                                            "description": "Videos.",
+                                                            "default": []
+                                                        },
+                                                        "estimatedDateArrival": {
+                                                            "type": "string",
+                                                            "title": "estimatedDateArrival",
+                                                            "description": "Estimated date arrival.",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
 					}
 				},
 				"deprecated": false,

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -9370,7 +9370,7 @@
 					"CrossSelling"
 				],
 				"summary": "ProductSearch Accessories",
-				"description": "",
+				"description": "Retrieves general information about the product's accessories.",
 				"operationId": "ProductSearchAccessories",
 				"parameters": [
                     {
@@ -9451,7 +9451,7 @@
 					"CrossSelling"
 				],
 				"summary": "ProductSearch Similars",
-				"description": "",
+				"description": "Retrieves general information about related product searches.",
 				"operationId": "ProductSearchSimilars",
 				"parameters": [
                     {
@@ -9497,15 +9497,15 @@
 						}
 					},
 					{
-						"name": "productId",
-						"in": "path",
-						"description": "",
-						"required": true,
-						"style": "simple",
-						"schema": {
-							"type": "string"
-						}
-					}
+                        "name": "productId",
+                        "in": "path",
+                        "required": true,
+                        "description": "Product's unique identifier",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
 				],
 				"responses": {
 					"200": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19231,7 +19231,7 @@
 					{
 						"name": "map",
 						"in": "query",
-						"description": "Mapping of the term. It can be `c` for a category, `b` for a brand, or `specificationFilter_{specificationId}` for a specification.",
+						"description": "Mapping of the term. It can be `c` for a category, `b` for a brand, or `specificationFilter_{specificationId}` for a specification. You need to include a map for each term you are searching for in the same term's order.",
 						"required": true,
 						"style": "form",
 						"explode": true,
@@ -20204,109 +20204,6 @@
 						}
 					}
 				}
-			}
-		},
-		"/api/catalog_system/pub/facets/search/{categoryName}/{specificationValue}": {
-			"get": {
-				"tags": [
-					"Facets"
-				],
-				"summary": "Facets Category and  Specification",
-				"description": "",
-				"operationId": "FacetsCategoryandSpecification",
-				"parameters": [
-                    {
-                        "name": "accountName",
-                        "in": "path",
-                        "required": true,
-                        "description": "Name of the VTEX account. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "apiexamples"
-                        }
-                    },
-                    {
-                        "name": "environment",
-                        "in": "path",
-                        "required": true,
-                        "description": "Environment to use. Used as part of the URL",
-                        "schema": {
-                            "type": "string",
-                            "default": "vtexcommercestable"
-                        }
-                    },
-					{
-						"name": "map",
-						"in": "query",
-						"description": "",
-						"required": true,
-						"style": "form",
-						"explode": true,
-						"schema": {
-							"type": "string",
-							"example": "c,specificationFilter_{{specificationId}}"
-						}
-					},
-					{
-						"name": "Accept",
-						"in": "header",
-						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
-						"required": true,
-						"style": "simple",
-						"schema": {
-							"type": "string",
-							"example": "application/json"
-						}
-					},
-					{
-						"name": "Content-Type",
-						"in": "header",
-						"description": "Describes the type of the content being sent",
-						"required": true,
-						"style": "simple",
-						"schema": {
-							"type": "string",
-							"example": "application/json"
-						}
-					},
-					{
-						"name": "categoryName",
-						"in": "path",
-						"description": "",
-						"required": true,
-						"style": "simple",
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "specificationValue",
-						"in": "path",
-						"description": "",
-						"required": true,
-						"style": "simple",
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "",
-						"headers": {}
-					}
-				},
-				"deprecated": false,
-				"servers": [
-					{
-						"url": "http://example.com/.{environment}.com.br",
-						"variables": {
-							"environment": {
-								"default": "DefaultParameterValue"
-							}
-						}
-					}
-				]
 			}
 		},
 		"/buscaautocomplete": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -12914,228 +12914,3042 @@
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {
-							"Cache-Control": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "no-cache"
-									}
-								}
-							},
-							"Connection": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "keep-alive"
-									}
-								}
-							},
-							"Content-Encoding": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "gzip"
-									}
-								}
-							},
-							"Content-Length": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "2536"
-									}
-								}
-							},
-							"Date": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Mon, 13 Feb 2017 18:31:57 GMT"
-									}
-								}
-							},
-							"Expires": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "-1"
-									}
-								}
-							},
-							"Pragma": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "no-cache"
-									}
-								}
-							},
-							"Server": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "nginx"
-									}
-								}
-							},
-							"Vary": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Accept-Encoding, resources"
-									}
-								}
-							},
-							"X-CacheServer": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "janus-apicache-nginx6"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.3.9"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-Edge": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.35.3"
-									}
-								}
-							},
-							"X-Track": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "stable"
-									}
-								}
-							},
-							"X-VTEX-Cache-Status-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "HIT"
-									}
-								}
-							},
-							"X-VTEX-Cache-Status-Janus-Edge": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "HIT"
-									}
-								}
-							},
-							"X-VTEX-Janus-Router-Backend-App": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "portal-v1.4.690-stable+1206"
-									}
-								}
-							},
-							"no": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "-DINS692KJ1P"
-									}
-								}
-							},
-							"p3p": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "policyref=\"/w3c/p3p.xml\",CP=\"ADMa OUR NOR CNT NID DSP NOI COR\""
-									}
-								}
-							},
-							"powered": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "vtex"
-									}
-								}
-							},
-							"resources": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "0-9/3"
-									}
-								}
-							},
-							"x-vtex-operation-id": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "7cec5b63-0c21-4adc-ab52-1e9392faa994"
-									}
-								}
-							}
-						},
-						"content": {
-							"application/json; charset=utf-8": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/Example"
-									}
-								}
-							}
-						}
+						"headers": {},
+                        "content": {
+                            "application/json":{
+                                "example":[{
+                                    "productId": "35",
+                                    "productName": "Kit de Hoegaarden",
+                                    "brand": "Hoegaarden",
+                                    "brandId": 2000004,
+                                    "brandImageUrl": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg",
+                                    "linkText": "kit-6-cerveja-hoegaarden",
+                                    "productReference": "000806",
+                                    "productReferenceCode": null,
+                                    "categoryId": "1",
+                                    "productTitle": "",
+                                    "metaTagDescription": "",
+                                    "releaseDate": "2020-10-07T00:00:00",
+                                    "clusterHighlights": {
+                                        "138": "teste2"
+                                    },
+                                    "productClusters": {
+                                        "138": "teste2",
+                                        "143": "NaoPesquisavel",
+                                        "146": "colecaotestesubcategoria",
+                                        "161": "merch_import_test1"
+                                    },
+                                    "searchableClusters": {
+                                        "138": "teste2"
+                                    },
+                                    "categories": [
+                                        "/Beers Beers Mesmo/"
+                                    ],
+                                    "categoriesIds": [
+                                        "/1/"
+                                    ],
+                                    "link": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p",
+                                    "Percentuals": [
+                                        "4,9"
+                                    ],
+                                    "Percentual": [
+                                        "4,9"
+                                    ],
+                                    "Total": [
+                                        "Percentuals",
+                                        "Percentual"
+                                    ],
+                                    "Teste de Api": [
+                                        "a"
+                                    ],
+                                    "Ale": [
+                                        "1"
+                                    ],
+                                    "Teste da Api2": [
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "Alcool": [
+                                        "Percentual"
+                                    ],
+                                    "allSpecifications": [
+                                        "Percentuals",
+                                        "Percentual",
+                                        "Teste de Api",
+                                        "Ale"
+                                    ],
+                                    "allSpecificationsGroups": [
+                                        "Total",
+                                        "Teste da Api2"
+                                    ],
+                                    "description": "",
+                                    "items": [{
+                                        "itemId": "310118469",
+                                        "name": "Kit com 6",
+                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                        "complementName": "",
+                                        "ean": "",
+                                        "referenceId": [{
+                                            "Key": "RefId",
+                                            "Value": "000806"
+                                        }],
+                                        "measurementUnit": "un",
+                                        "unitMultiplier": 1.0000,
+                                        "modalType": null,
+                                        "isKit": true,
+                                        "kitItems": [{
+                                            "itemId": "310118466",
+                                            "amount": 6
+                                        }],
+                                        "images": [{
+                                            "imageId": "155489",
+                                            "imageLabel": "",
+                                            "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                            "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                            "imageText": "hoegaarden-kit",
+                                            "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                        }],
+                                        "sellers": [{
+                                            "sellerId": "1",
+                                            "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                            "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                            "sellerDefault": true,
+                                            "commertialOffer": {
+                                                "DeliverySlaSamplesPerRegion": {
+                                                    "0": {
+                                                        "DeliverySlaPerTypes": [],
+                                                        "Region": null
+                                                    }
+                                                },
+                                                "Installments": [{
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa à vista"
+                                                    },
+                                                    {
+                                                        "Value": 21.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 2,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 2 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 14.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 3,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 3 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 10.5,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 4,
+                                                        "PaymentSystemName": "Visa",
+                                                        "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                        "Name": "Visa 4 vezes sem juros"
+                                                    },
+                                                    {
+                                                        "Value": 42.0,
+                                                        "InterestRate": 0.0,
+                                                        "TotalValuePlusInterestRate": 42.0,
+                                                        "NumberOfInstallments": 1,
+                                                        "PaymentSystemName": "Promissory",
+                                                        "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                        "Name": "Promissory à vista"
+                                                    }
+                                                ],
+                                                "DiscountHighLight": [],
+                                                "GiftSkuIds": [],
+                                                "Teasers": [],
+                                                "BuyTogether": [],
+                                                "ItemMetadataAttachment": [],
+                                                "Price": 42.0,
+                                                "ListPrice": 42.0,
+                                                "PriceWithoutDiscount": 42.0,
+                                                "RewardValue": 0.0,
+                                                "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                "AvailableQuantity": 16,
+                                                "IsAvailable": true,
+                                                "Tax": 0.0,
+                                                "SaleChannel": 0,
+                                                "DeliverySlaSamples": [{
+                                                    "DeliverySlaPerTypes": [],
+                                                    "Region": null
+                                                }],
+                                                "GetInfoErrorMessage": null,
+                                                "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                "PaymentOptions": {
+                                                    "installmentOptions": [{
+                                                            "paymentSystem": "2",
+                                                            "bin": null,
+                                                            "paymentName": "Visa",
+                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 1,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 4200,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 2,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 2100,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 2,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 2100,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 3,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1400,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 3,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1400,
+                                                                        "total": 4200
+                                                                    }]
+                                                                },
+                                                                {
+                                                                    "count": 4,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 1050,
+                                                                    "total": 4200,
+                                                                    "sellerMerchantInstallments": [{
+                                                                        "id": "MERCH",
+                                                                        "count": 4,
+                                                                        "hasInterestRate": false,
+                                                                        "interestRate": 0,
+                                                                        "value": 1050,
+                                                                        "total": 4200
+                                                                    }]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "paymentSystem": "17",
+                                                            "bin": null,
+                                                            "paymentName": "Promissory",
+                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                            "value": 4200,
+                                                            "installments": [{
+                                                                "count": 1,
+                                                                "hasInterestRate": false,
+                                                                "interestRate": 0,
+                                                                "value": 4200,
+                                                                "total": 4200,
+                                                                "sellerMerchantInstallments": [{
+                                                                    "id": "MERCH",
+                                                                    "count": 1,
+                                                                    "hasInterestRate": false,
+                                                                    "interestRate": 0,
+                                                                    "value": 4200,
+                                                                    "total": 4200
+                                                                }]
+                                                            }]
+                                                        }
+                                                    ],
+                                                    "paymentSystems": [{
+                                                            "id": 17,
+                                                            "name": "Promissory",
+                                                            "groupName": "promissoryPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "17",
+                                                            "template": "promissoryPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        },
+                                                        {
+                                                            "id": 2,
+                                                            "name": "Visa",
+                                                            "groupName": "creditCardPaymentGroup",
+                                                            "validator": null,
+                                                            "stringId": "2",
+                                                            "template": "creditCardPaymentGroup-template",
+                                                            "requiresDocument": false,
+                                                            "isCustom": false,
+                                                            "description": null,
+                                                            "requiresAuthentication": false,
+                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                            "availablePayments": null
+                                                        }
+                                                    ],
+                                                    "payments": [],
+                                                    "giftCards": [],
+                                                    "giftCardMessages": [],
+                                                    "availableAccounts": [],
+                                                    "availableTokens": []
+                                                }
+                                            }
+                                        }],
+                                        "Videos": [],
+                                        "estimatedDateArrival": null
+                                    }]
+                                }],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "",
+                                        "required": [
+                                            "productId",
+                                            "productName",
+                                            "brand",
+                                            "brandId",
+                                            "brandImageUrl",
+                                            "linkText",
+                                            "productReference",
+                                            "productReferenceCode",
+                                            "categoryId",
+                                            "productTitle",
+                                            "metaTagDescription",
+                                            "releaseDate",
+                                            "clusterHighlights",
+                                            "productClusters",
+                                            "searchableClusters",
+                                            "categories",
+                                            "categoriesIds",
+                                            "link",
+                                            "Percentuals",
+                                            "Percentual",
+                                            "Total",
+                                            "Teste de Api",
+                                            "Ale",
+                                            "Teste da Api2",
+                                            "Alcool",
+                                            "allSpecifications",
+                                            "allSpecificationsGroups",
+                                            "description",
+                                            "items"
+                                        ],
+                                        "properties": {
+                                            "productId": {
+                                                "type": "string",
+                                                "title": "productId",
+                                                "description": "Product unique identifier.",
+                                                "default": "35"
+                                            },
+                                            "productName": {
+                                                "type": "string",
+                                                "title": "productName",
+                                                "description": "Product name.",
+                                                "default": "Kit de Hoegaarden"
+                                            },
+                                            "brand": {
+                                                "type": "string",
+                                                "title": "brand",
+                                                "description": "Brand name.",
+                                                "default": "Hoegaarden"
+                                            },
+                                            "brandId": {
+                                                "type": "integer",
+                                                "title": "brandId",
+                                                "description": "Product brand ID.",
+                                                "default": 2000004
+                                            },
+                                            "brandImageUrl": {
+                                                "type": "string",
+                                                "title": "brandImageUrl",
+                                                "description": "Product's brand image URL.",
+                                                "default": "https://merch.vteximg.com.br/arquivos/ids/155532/hoegardden-logo.jpg"
+                                            },
+                                            "linkText": {
+                                                "type": "string",
+                                                "title": "linkText",
+                                                "description": "Product URL.",
+                                                "default": "kit-6-cerveja-hoegaarden"
+                                            },
+                                            "productReference": {
+                                                "type": "string",
+                                                "title": "productReference",
+                                                "description": "Product reference.",
+                                                "default": "000806"
+                                            },
+                                            "productReferenceCode": {
+                                                "type": "integer",
+                                                "title": "productReferenceCode",
+                                                "description": "Product reference ID.",
+                                                "default": 1234
+                                            },
+                                            "categoryId": {
+                                                "type": "string",
+                                                "title": "categoryId",
+                                                "description": "Product category ID.",
+                                                "default": "1"
+                                            },
+                                            "productTitle": {
+                                                "type": "string",
+                                                "title": "productTitle",
+                                                "description": "Text that is in the browser tab and corresponds to the title of the product page. This field is important for SEO.",
+                                                "default": "Kit 6 cerveja Hoegaarden"
+                                            },
+                                            "metaTagDescription": {
+                                                "type": "string",
+                                                "title": "metaTagDescription",
+                                                "description": "Brief description of the category. It's recommended that you don't exceed 150 characters so that the search engines can display it correctly in the results page.",
+                                                "default": "Category for Beers"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "title": "releaseDate",
+                                                "description": "Product release date.",
+                                                "default": "2020-10-07T00:00:00"
+                                            },
+                                            "clusterHighlights": {
+                                                "type": "object",
+                                                "title": "clusterHighlights",
+                                                "description": "Cluster highlight ID and name.",
+                                                "default": {
+                                                        "138": "teste2"
+                                                    }
+                                            },
+                                            "productClusters": {
+                                                "type": "object",
+                                                "title": "productClusters",
+                                                "description": "Product clusters' IDs and names.",
+                                                "default": {
+                                                        "138": "teste2",
+                                                        "143": "NaoPesquisavel",
+                                                        "146": "colecaotestesubcategoria",
+                                                        "161": "merch_import_test1"
+                                                }
+                                            },
+                                            "searchableClusters": {
+                                                "type": "object",
+                                                "title": "searchableClusters",
+                                                "description": "Searchable clusters IDs and names",
+                                                "default": {
+                                                    "138": "teste2"
+                                                }
+                                            },
+                                            "categories": {
+                                                "type": "array",
+                                                "title": "categories",
+                                                "description": "Array of the product's categories URLs.",
+                                                "default": [
+                                                    "/Beers Beers Mesmo/"
+                                                ]
+                                            },
+                                            "categoriesIds": {
+                                                "type": "array",
+                                                "title": "categoriesIds",
+                                                "description": "Array of the product's categories IDs.",
+                                                "default": [
+                                                    "/1/"
+                                                ]
+                                            },
+                                            "link": {
+                                                "type": "string",
+                                                "title": "link",
+                                                "description": "Product URL.",
+                                                "default": "https://merch.vtexcommercestable.com.br/kit-6-cerveja-hoegaarden/p"
+                                            },
+                                            "allSpecifications": {
+                                                "type": "array",
+                                                "title": "allSpecifications",
+                                                "description": "Array of the product's specifications.",
+                                                "default": [
+                                                    "Percentuals",
+                                                    "Percentual"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification.",
+                                                    "default": "Percentual"
+                                                }
+                                            },
+                                            "allSpecificationsGroups": {
+                                                "type": "array",
+                                                "title": "allSpecificationsGroups",
+                                                "description": "Array of the product's specifications groups.",
+                                                "default": [
+                                                    "Total",
+                                                    "Teste da Api2"
+                                                ],
+                                                "items": {
+                                                    "type": "string",
+                                                    "title": "",
+                                                    "description": "Product specification group",
+                                                    "default": "Teste da Api2"
+                                                }
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "title": "description",
+                                                "description": "Description of the main information related to the product. A simple and easy to understand summary for the customer.",
+                                                "default": "Description example"
+                                            },
+                                            "items": {
+                                                "type": "array",
+                                                "title": "items",
+                                                "description": "Array containing the product SKU general information.",
+                                                "default": [
+                                                    {
+                                                        "itemId": "310118469",
+                                                        "name": "Kit com 6",
+                                                        "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                        "complementName": "",
+                                                        "ean": "",
+                                                        "referenceId": [
+                                                            {
+                                                                "Key": "RefId",
+                                                                "Value": "000806"
+                                                            }
+                                                        ],
+                                                        "measurementUnit": "un",
+                                                        "unitMultiplier": 1.0,
+                                                        "modalType": null,
+                                                        "isKit": true,
+                                                        "kitItems": [
+                                                            {
+                                                                "itemId": "310118466",
+                                                                "amount": 6
+                                                            }
+                                                        ],
+                                                        "images": [
+                                                            {
+                                                                "imageId": "155489",
+                                                                "imageLabel": "",
+                                                                "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                "imageText": "hoegaarden-kit",
+                                                                "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                            }
+                                                        ],
+                                                        "sellers": [
+                                                            {
+                                                                "sellerId": "1",
+                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                "sellerDefault": true,
+                                                                "commertialOffer": {
+                                                                    "DeliverySlaSamplesPerRegion": {
+                                                                        "0": {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    },
+                                                                    "Installments": [
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa à vista"
+                                                                        },
+                                                                        {
+                                                                            "Value": 21.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 2,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 14.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 3,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 3 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 10.5,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 4,
+                                                                            "PaymentSystemName": "Visa",
+                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                            "Name": "Visa 4 vezes sem juros"
+                                                                        },
+                                                                        {
+                                                                            "Value": 42.0,
+                                                                            "InterestRate": 0.0,
+                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                            "NumberOfInstallments": 1,
+                                                                            "PaymentSystemName": "Promissory",
+                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                            "Name": "Promissory à vista"
+                                                                        }
+                                                                    ],
+                                                                    "DiscountHighLight": [],
+                                                                    "GiftSkuIds": [],
+                                                                    "Teasers": [],
+                                                                    "BuyTogether": [],
+                                                                    "ItemMetadataAttachment": [],
+                                                                    "Price": 42.0,
+                                                                    "ListPrice": 42.0,
+                                                                    "PriceWithoutDiscount": 42.0,
+                                                                    "RewardValue": 0.0,
+                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                    "AvailableQuantity": 16,
+                                                                    "IsAvailable": true,
+                                                                    "Tax": 0.0,
+                                                                    "SaleChannel": 0,
+                                                                    "DeliverySlaSamples": [
+                                                                        {
+                                                                            "DeliverySlaPerTypes": [],
+                                                                            "Region": null
+                                                                        }
+                                                                    ],
+                                                                    "GetInfoErrorMessage": null,
+                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                    "PaymentOptions": {
+                                                                        "installmentOptions": [
+                                                                            {
+                                                                                "paymentSystem": "2",
+                                                                                "bin": null,
+                                                                                "paymentName": "Visa",
+                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 2,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 2100,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 3,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1400,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "count": 4,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 1050,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "paymentSystem": "17",
+                                                                                "bin": null,
+                                                                                "paymentName": "Promissory",
+                                                                                "paymentGroupName": "promissoryPaymentGroup",
+                                                                                "value": 4200,
+                                                                                "installments": [
+                                                                                    {
+                                                                                        "count": 1,
+                                                                                        "hasInterestRate": false,
+                                                                                        "interestRate": 0,
+                                                                                        "value": 4200,
+                                                                                        "total": 4200,
+                                                                                        "sellerMerchantInstallments": [
+                                                                                            {
+                                                                                                "id": "MERCH",
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ],
+                                                                        "paymentSystems": [
+                                                                            {
+                                                                                "id": 17,
+                                                                                "name": "Promissory",
+                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "17",
+                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            },
+                                                                            {
+                                                                                "id": 2,
+                                                                                "name": "Visa",
+                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                "validator": null,
+                                                                                "stringId": "2",
+                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                "requiresDocument": false,
+                                                                                "isCustom": false,
+                                                                                "description": null,
+                                                                                "requiresAuthentication": false,
+                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                "availablePayments": null
+                                                                            }
+                                                                        ],
+                                                                        "payments": [],
+                                                                        "giftCards": [],
+                                                                        "giftCardMessages": [],
+                                                                        "availableAccounts": [],
+                                                                        "availableTokens": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "Videos": [],
+                                                        "estimatedDateArrival": null
+                                                    }
+                                                ],
+                                                "items": {
+                                                    "type": "object",
+                                                    "title": "",
+                                                    "default": [
+                                                        {
+                                                            "itemId": "310118469",
+                                                            "name": "Kit com 6",
+                                                            "nameComplete": "Kit de Hoegaarden Kit com 6",
+                                                            "complementName": "",
+                                                            "ean": "",
+                                                            "referenceId": [
+                                                                {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                }
+                                                            ],
+                                                            "measurementUnit": "un",
+                                                            "unitMultiplier": 1.0,
+                                                            "modalType": null,
+                                                            "isKit": true,
+                                                            "kitItems": [
+                                                                {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                }
+                                                            ],
+                                                            "images": [
+                                                                {
+                                                                    "imageId": "155489",
+                                                                    "imageLabel": "",
+                                                                    "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                    "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                    "imageText": "hoegaarden-kit",
+                                                                    "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                }
+                                                            ],
+                                                            "sellers": [
+                                                                {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Videos": [],
+                                                            "estimatedDateArrival": null
+                                                        }
+                                                    ],
+                                                    "required": [
+                                                        "itemId",
+                                                        "name",
+                                                        "nameComplete",
+                                                        "complementName",
+                                                        "ean",
+                                                        "referenceId",
+                                                        "measurementUnit",
+                                                        "unitMultiplier",
+                                                        "modalType",
+                                                        "isKit",
+                                                        "kitItems",
+                                                        "images",
+                                                        "sellers",
+                                                        "Videos",
+                                                        "estimatedDateArrival"
+                                                    ],
+                                                    "properties": {
+                                                        "itemId": {
+                                                            "type": "string",
+                                                            "title": "itemId",
+                                                            "description": "SKU ID.",
+                                                            "default": "310118469"
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "title": "name",
+                                                            "description": "SKU name.",
+                                                            "default": "Kit com 6"
+                                                        },
+                                                        "nameComplete": {
+                                                            "type": "string",
+                                                            "title": "nameComplete",
+                                                            "description": "SKU complete name.",
+                                                            "default": "Kit de Hoegaarden Kit com 6"
+                                                        },
+                                                        "complementName": {
+                                                            "type": "string",
+                                                            "title": "complementName",
+                                                            "description": "SKU complement name.",
+                                                            "default": "Complement name"
+                                                        },
+                                                        "ean": {
+                                                            "type": "string",
+                                                            "title": "ean",
+                                                            "description": "SKU unique identification code (barcode), accepts up to 13 numerical characters.",
+                                                            "default": "12345567"
+                                                        },
+                                                        "referenceId": {
+                                                            "type": "array",
+                                                            "title": "referenceId",
+                                                            "description": "Reference code ID.",
+                                                            "default": [
+                                                                    {
+                                                                        "Key": "RefId",
+                                                                        "Value": "000806"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "Key": "RefId",
+                                                                    "Value": "000806"
+                                                                },
+                                                                "required": [
+                                                                    "Key",
+                                                                    "Value"
+                                                                ],
+                                                                "properties": {
+                                                                    "Key": {
+                                                                        "type": "string",
+                                                                        "title": "Key",
+                                                                        "description": "Reference Code.",
+                                                                        "default": [
+                                                                            "RefId"
+                                                                        ]
+                                                                    },
+                                                                    "Value": {
+                                                                        "type": "string",
+                                                                        "title": "Value",
+                                                                        "description": "Unique reference code used internally for organizational purposes.",
+                                                                        "default": [
+                                                                            "000806"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "measurementUnit": {
+                                                            "type": "string",
+                                                            "title": "measurementUnit",
+                                                            "description": "Used only in cases when you need to convert the unit of measure for sale. In common cases, use 'un'.",
+                                                            "default": [
+                                                                "un"
+                                                            ]
+                                                        },
+                                                        "unitMultiplier": {
+                                                            "type": "number",
+                                                            "title": "unitMultiplier",
+                                                            "description": "numerical unit that multiplies the selected quantity of the product when it is inserted in the cart.",
+                                                            "default": 1.0
+                                                        },
+                                                        "modalType": {
+                                                            "type": "string",
+                                                            "title": "modalType",
+                                                            "description": "Modal Type.",
+                                                            "default": "Modal Type test"
+                                                        },
+                                                        "isKit": {
+                                                            "type": "boolean",
+                                                            "title": "isKit",
+                                                            "description": "If the SKU is part of a kit.",
+                                                            "default": true
+                                                        },
+                                                        "kitItems": {
+                                                            "type": "array",
+                                                            "title": "kitItems",
+                                                            "description": "Array with information of SKUs components from a Kit.",
+                                                            "default": [
+                                                                    {
+                                                                        "itemId": "310118466",
+                                                                        "amount": 6
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "itemId": "310118466",
+                                                                    "amount": 6
+                                                                },
+                                                                "required": [
+                                                                    "itemId",
+                                                                    "amount"
+                                                                ],
+                                                                "properties": {
+                                                                    "itemId": {
+                                                                        "type": "string",
+                                                                        "title": "itemId",
+                                                                        "description": "SKU kit component ID.",
+                                                                        "default": [
+                                                                            "310118466"
+                                                                        ]
+                                                                    },
+                                                                    "amount": {
+                                                                        "type": "integer",
+                                                                        "title": "amount",
+                                                                        "description": "Amount of the SKU component in the kit.",
+                                                                        "default": 6
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "images": {
+                                                            "type": "array",
+                                                            "title": "images",
+                                                            "description": "Array of information about the SKU image.",
+                                                            "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": [
+                                                                    {
+                                                                        "imageId": "155489",
+                                                                        "imageLabel": "",
+                                                                        "imageTag": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />",
+                                                                        "imageUrl": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000",
+                                                                        "imageText": "hoegaarden-kit",
+                                                                        "imageLastModified": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                ],
+                                                                "required": [
+                                                                    "imageId",
+                                                                    "imageLabel",
+                                                                    "imageTag",
+                                                                    "imageUrl",
+                                                                    "imageText",
+                                                                    "imageLastModified"
+                                                                ],
+                                                                "properties": {
+                                                                    "imageId": {
+                                                                        "type": "string",
+                                                                        "title": "imageId",
+                                                                        "description": "Image ID.",
+                                                                        "default": [
+                                                                            "155489"
+                                                                        ]
+                                                                    },
+                                                                    "imageLabel": {
+                                                                        "type": "string",
+                                                                        "title": "imageLabel",
+                                                                        "description": "Image label.",
+                                                                        "default": "Label test"
+                                                                    },
+                                                                    "imageTag": {
+                                                                        "type": "string",
+                                                                        "title": "imageTag",
+                                                                        "description": "Image tag.",
+                                                                        "default": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
+                                                                    },
+                                                                    "imageUrl": {
+                                                                        "type": "string",
+                                                                        "title": "imageUrl",
+                                                                        "description": "Image URL.",
+                                                                        "default": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
+                                                                    },
+                                                                    "imageText": {
+                                                                        "type": "string",
+                                                                        "title": "imageText",
+                                                                        "description": "Image text.",
+                                                                        "default": "hoegaarden-kit"
+                                                                    },
+                                                                    "imageLastModified": {
+                                                                        "type": "string",
+                                                                        "title": "imageLastModified",
+                                                                        "description": "Date and time of the last update of the image.",
+                                                                        "default": "2020-10-07T12:49:27.5800000Z"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "sellers": {
+                                                            "type": "array",
+                                                            "title": "sellers",
+                                                            "description": "Array of SKU sellers.",
+                                                            "default": [
+                                                                [
+                                                                    {
+                                                                        "sellerId": "1",
+                                                                        "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                        "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                        "sellerDefault": true,
+                                                                        "commertialOffer": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "items": {
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "sellerId",
+                                                                    "sellerName",
+                                                                    "addToCartLink",
+                                                                    "sellerDefault",
+                                                                    "commertialOffer"
+                                                                ],
+                                                                "properties": {
+                                                                    "sellerId": {
+                                                                        "type": "string",
+                                                                        "title": "sellerId",
+                                                                        "description": "SKU seller ID.",
+                                                                        "default": "1"
+                                                                    },
+                                                                    "sellerName": {
+                                                                        "type": "string",
+                                                                        "title": "sellerName",
+                                                                        "description": "SKU seller name.",
+                                                                        "default": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
+                                                                    },
+                                                                    "addToCartLink": {
+                                                                        "type": "string",
+                                                                        "title": "addToCartLink",
+                                                                        "description": "URL to add the product to the cart.",
+                                                                        "default": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
+                                                                    },
+                                                                    "sellerDefault": {
+                                                                        "type": "boolean",
+                                                                        "title": "sellerDefault",
+                                                                        "description": "If the seller is default or not.",
+                                                                        "default": true
+                                                                    },
+                                                                    "commertialOffer": {
+                                                                        "type": "object",
+                                                                        "title": "commertialOffer",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "DeliverySlaSamplesPerRegion",
+                                                                            "Installments",
+                                                                            "DiscountHighLight",
+                                                                            "GiftSkuIds",
+                                                                            "Teasers",
+                                                                            "BuyTogether",
+                                                                            "ItemMetadataAttachment",
+                                                                            "Price",
+                                                                            "ListPrice",
+                                                                            "PriceWithoutDiscount",
+                                                                            "RewardValue",
+                                                                            "PriceValidUntil",
+                                                                            "AvailableQuantity",
+                                                                            "IsAvailable",
+                                                                            "Tax",
+                                                                            "SaleChannel",
+                                                                            "DeliverySlaSamples",
+                                                                            "GetInfoErrorMessage",
+                                                                            "CacheVersionUsedToCallCheckout",
+                                                                            "PaymentOptions"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "type": "object",
+                                                                                "title": "DeliverySlaSamplesPerRegion",
+                                                                                "description": "Delivery SLA samples per region.",
+                                                                                "default": {
+                                                                                    "0": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": "null"
+                                                                                    }
+                                                                                },
+                                                                                "properties": {
+                                                                                    "0": {
+                                                                                        "type": "object",
+                                                                                        "title": "The 0 schema",
+                                                                                        "description": "0.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "required": [
+                                                                                            "DeliverySlaPerTypes",
+                                                                                            "Region"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "DeliverySlaPerTypes": {
+                                                                                                "type": "array",
+                                                                                                "title": "DeliverySlaPerTypes",
+                                                                                                "description": "Delivery SLA per types.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "Region": {
+                                                                                                "type": "string",
+                                                                                                "title": "Region",
+                                                                                                "description": "Region.",
+                                                                                                "default": ""
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "Installments": {
+                                                                                "type": "array",
+                                                                                "title": "Installments",
+                                                                                "description": "Installments options.",
+                                                                                "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        },
+                                                                                        {
+                                                                                            "Value": 21.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 2,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa 2 vezes sem juros"
+                                                                                        }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": [
+                                                                                        {
+                                                                                            "Value": 42.0,
+                                                                                            "InterestRate": 0.0,
+                                                                                            "TotalValuePlusInterestRate": 42.0,
+                                                                                            "NumberOfInstallments": 1,
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
+                                                                                        }
+                                                                                    ],
+                                                                                    "required": [
+                                                                                        "Value",
+                                                                                        "InterestRate",
+                                                                                        "TotalValuePlusInterestRate",
+                                                                                        "NumberOfInstallments",
+                                                                                        "PaymentSystemName",
+                                                                                        "PaymentSystemGroupName",
+                                                                                        "Name"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "Value": {
+                                                                                            "type": "number",
+                                                                                            "title": "Value",
+                                                                                            "description": "Value of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "InterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "InterestRate",
+                                                                                            "description": "Interest rate of the installment.",
+                                                                                            "default": 0.0
+                                                                                        },
+                                                                                        "TotalValuePlusInterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "TotalValuePlusInterestRate",
+                                                                                            "description": "Total value plus interest rate of the installment.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "NumberOfInstallments": {
+                                                                                            "type": "integer",
+                                                                                            "title": "NumberOfInstallments",
+                                                                                            "description": "Number of the installment.",
+                                                                                            "default": 1
+                                                                                        },
+                                                                                        "PaymentSystemName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemName",
+                                                                                            "description": "Payment system name of the installment.",
+                                                                                            "default": "Visa"
+                                                                                        },
+                                                                                        "PaymentSystemGroupName": {
+                                                                                            "type": "string",
+                                                                                            "title": "PaymentSystemGroupName",
+                                                                                            "description": "Payment system group name of the installment.",
+                                                                                            "default": "creditCardPaymentGroup"
+                                                                                        },
+                                                                                        "Name": {
+                                                                                            "type": "string",
+                                                                                            "title": "Name",
+                                                                                            "description": "Name of the installment.",
+                                                                                            "default": "Visa à vista"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "DiscountHighLight": {
+                                                                                "type": "array",
+                                                                                "title": "DiscountHighLight",
+                                                                                "description": "Discount hightlight.",
+                                                                                "default": []
+                                                                            },
+                                                                            "GiftSkuIds": {
+                                                                                "type": "array",
+                                                                                "title": "GiftSkuIds",
+                                                                                "description": "Array of SKU gifts IDs.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Teasers": {
+                                                                                "type": "array",
+                                                                                "title": "Teasers",
+                                                                                "description": "Teasers.",
+                                                                                "default": []
+                                                                            },
+                                                                            "BuyTogether": {
+                                                                                "type": "array",
+                                                                                "title": "BuyTogether",
+                                                                                "description": "Array of other products that can be bought together with the product in question.",
+                                                                                "default": []
+                                                                            },
+                                                                            "ItemMetadataAttachment": {
+                                                                                "type": "array",
+                                                                                "title": "ItemMetadataAttachment",
+                                                                                "description": "Item metadata attachment.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Price": {
+                                                                                "type": "number",
+                                                                                "title": "Price",
+                                                                                "description": "Price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "ListPrice": {
+                                                                                "type": "number",
+                                                                                "title": "ListPrice",
+                                                                                "description": "List price of the product.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "PriceWithoutDiscount": {
+                                                                                "type": "number",
+                                                                                "title": "PriceWithoutDiscount",
+                                                                                "description": "Price of the product without discount.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "RewardValue": {
+                                                                                "type": "number",
+                                                                                "title": "RewardValue",
+                                                                                "description": "Reward value of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "PriceValidUntil": {
+                                                                                "type": "string",
+                                                                                "title": "PriceValidUntil",
+                                                                                "description": "Price of the product valid until a certain date.",
+                                                                                "default": "4000-01-01T03:00:00Z"
+                                                                            },
+                                                                            "AvailableQuantity": {
+                                                                                "type": "integer",
+                                                                                "title": "AvailableQuantity",
+                                                                                "description": "Available quantity of the product.",
+                                                                                "default": 16
+                                                                            },
+                                                                            "IsAvailable": {
+                                                                                "type": "boolean",
+                                                                                "title": "IsAvailable",
+                                                                                "description": "If the product is available or not.",
+                                                                                "default": true
+                                                                            },
+                                                                            "Tax": {
+                                                                                "type": "number",
+                                                                                "title": "Tax",
+                                                                                "description": "Tax of the product.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "SaleChannel": {
+                                                                                "type": "integer",
+                                                                                "title": "SaleChannel",
+                                                                                "description": "Trade policy which the product is contained.",
+                                                                                "default": 0
+                                                                            },
+                                                                            "DeliverySlaSamples": {
+                                                                                "type": "array",
+                                                                                "title": "DeliverySlaSamples",
+                                                                                "description": "Delivery SLA samples.",
+                                                                                "default": [
+                                                                                    {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "",
+                                                                                    "default": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "DeliverySlaPerTypes",
+                                                                                        "Region"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "DeliverySlaPerTypes": {
+                                                                                            "type": "array",
+                                                                                            "title": "DeliverySlaPerTypes",
+                                                                                            "description": "Delivery SLA per types.",
+                                                                                            "default": []
+                                                                                        },
+                                                                                        "Region": {
+                                                                                            "type": "string",
+                                                                                            "title": "Region",
+                                                                                            "description": "Region.",
+                                                                                            "default": null
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "GetInfoErrorMessage": {
+                                                                                "type": "string",
+                                                                                "title": "GetInfoErrorMessage",
+                                                                                "description": "Get info error message.",
+                                                                                "default": null
+                                                                            },
+                                                                            "CacheVersionUsedToCallCheckout": {
+                                                                                "type": "string",
+                                                                                "title": "CacheVersionUsedToCallCheckout",
+                                                                                "description": "Cache version used to call checkout.",
+                                                                                "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                            },
+                                                                            "PaymentOptions": {
+                                                                                "type": "object",
+                                                                                "title": "PaymentOptions",
+                                                                                "description": "Payment options.",
+                                                                                "default": {
+                                                                                    "installmentOptions": [
+                                                                                        {
+                                                                                            "paymentSystem": "2",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Visa",
+                                                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "paymentSystem": "17",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Promissory",
+                                                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ],
+                                                                                    "paymentSystems": [
+                                                                                        {
+                                                                                            "id": 17,
+                                                                                            "name": "Promissory",
+                                                                                            "groupName": "promissoryPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "17",
+                                                                                            "template": "promissoryPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        },
+                                                                                        {
+                                                                                            "id": 2,
+                                                                                            "name": "Visa",
+                                                                                            "groupName": "creditCardPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "2",
+                                                                                            "template": "creditCardPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        }
+                                                                                    ],
+                                                                                    "payments": [],
+                                                                                    "giftCards": [],
+                                                                                    "giftCardMessages": [],
+                                                                                    "availableAccounts": [],
+                                                                                    "availableTokens": []
+                                                                                },
+                                                                                "required": [
+                                                                                    "installmentOptions",
+                                                                                    "paymentSystems",
+                                                                                    "payments",
+                                                                                    "giftCards",
+                                                                                    "giftCardMessages",
+                                                                                    "availableAccounts",
+                                                                                    "availableTokens"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "installmentOptions": {
+                                                                                        "type": "array",
+                                                                                        "title": "installmentOptions",
+                                                                                        "description": "installment options.",
+                                                                                        "default": [
+                                                                                            [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "paymentSystem": "2",
+                                                                                                "bin": null,
+                                                                                                "paymentName": "Visa",
+                                                                                                "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                "value": 4200,
+                                                                                                "installments": [
+                                                                                                    {
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 1,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 4200,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 2,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 2100,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 3,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1400,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200,
+                                                                                                        "sellerMerchantInstallments": [
+                                                                                                            {
+                                                                                                                "id": "MERCH",
+                                                                                                                "count": 4,
+                                                                                                                "hasInterestRate": false,
+                                                                                                                "interestRate": 0,
+                                                                                                                "value": 1050,
+                                                                                                                "total": 4200
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "paymentSystem",
+                                                                                                "bin",
+                                                                                                "paymentName",
+                                                                                                "paymentGroupName",
+                                                                                                "value",
+                                                                                                "installments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "paymentSystem": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentSystem",
+                                                                                                    "description": "Payment system.",
+                                                                                                    "default": "2"
+                                                                                                },
+                                                                                                "bin": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "bin",
+                                                                                                    "description": "Bin.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "paymentName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentName",
+                                                                                                    "description": "Payment name.",
+                                                                                                    "default": "Visa"
+                                                                                                },
+                                                                                                "paymentGroupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "paymentGroupName",
+                                                                                                    "description": "Payment group name.",
+                                                                                                    "default": "creditCardPaymentGroup"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "value",
+                                                                                                    "description": "Value.",
+                                                                                                    "default": 4200
+                                                                                                },
+                                                                                                "installments": {
+                                                                                                    "type": "array",
+                                                                                                    "title": "installments",
+                                                                                                    "description": "Installments.",
+                                                                                                    "default": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ],
+                                                                                                    "items": {
+                                                                                                        "type": "object",
+                                                                                                        "title": "",
+                                                                                                        "default": {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "required": [
+                                                                                                            "count",
+                                                                                                            "hasInterestRate",
+                                                                                                            "interestRate",
+                                                                                                            "value",
+                                                                                                            "total",
+                                                                                                            "sellerMerchantInstallments"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                            "count": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "count",
+                                                                                                                "description": "Count.",
+                                                                                                                "default": 1
+                                                                                                            },
+                                                                                                            "hasInterestRate": {
+                                                                                                                "type": "boolean",
+                                                                                                                "title": "hasInterestRate",
+                                                                                                                "description": "Has interest rate.",
+                                                                                                                "default": false
+                                                                                                            },
+                                                                                                            "interestRate": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "interestRate",
+                                                                                                                "description": "Interest rate.",
+                                                                                                                "default": 0
+                                                                                                            },
+                                                                                                            "value": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "value",
+                                                                                                                "description": "Value.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "total": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "total",
+                                                                                                                "description": "Total.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "sellerMerchantInstallments": {
+                                                                                                                "type": "array",
+                                                                                                                "title": "sellerMerchantInstallments",
+                                                                                                                "description": "Seller merchant installments.",
+                                                                                                                "default": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "items": {
+                                                                                                                    "type": "object",
+                                                                                                                    "title": "",
+                                                                                                                    "default": {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                        "id",
+                                                                                                                        "count",
+                                                                                                                        "hasInterestRate",
+                                                                                                                        "interestRate",
+                                                                                                                        "value",
+                                                                                                                        "total"
+                                                                                                                    ],
+                                                                                                                    "properties": {
+                                                                                                                        "id": {
+                                                                                                                            "type": "string",
+                                                                                                                            "title": "id",
+                                                                                                                            "description": "ID.",
+                                                                                                                            "default": "MERCH"
+                                                                                                                        },
+                                                                                                                        "count": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "count",
+                                                                                                                            "description": "Count.",
+                                                                                                                            "default": 1
+                                                                                                                        },
+                                                                                                                        "hasInterestRate": {
+                                                                                                                            "type": "boolean",
+                                                                                                                            "title": "hasInterestRate",
+                                                                                                                            "description": "Has interest rate.",
+                                                                                                                            "default": false
+                                                                                                                        },
+                                                                                                                        "interestRate": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "interestRate",
+                                                                                                                            "description": "Interest rate.",
+                                                                                                                            "default": 0
+                                                                                                                        },
+                                                                                                                        "value": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "value",
+                                                                                                                            "description": "Value.",
+                                                                                                                            "default": 4200
+                                                                                                                        },
+                                                                                                                        "total": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "total",
+                                                                                                                            "description": "Total.",
+                                                                                                                            "default": 4200
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "paymentSystems": {
+                                                                                        "type": "array",
+                                                                                        "title": "paymentSystems",
+                                                                                        "description": "Payment systems.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            {
+                                                                                                "id": 2,
+                                                                                                "name": "Visa",
+                                                                                                "groupName": "creditCardPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "2",
+                                                                                                "template": "creditCardPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "",
+                                                                                            "default": {
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "id",
+                                                                                                "name",
+                                                                                                "groupName",
+                                                                                                "validator",
+                                                                                                "stringId",
+                                                                                                "template",
+                                                                                                "requiresDocument",
+                                                                                                "isCustom",
+                                                                                                "description",
+                                                                                                "requiresAuthentication",
+                                                                                                "dueDate",
+                                                                                                "availablePayments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "id": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "id",
+                                                                                                    "description": "ID.",
+                                                                                                    "default": 17
+                                                                                                },
+                                                                                                "name": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "name",
+                                                                                                    "description": "Name.",
+                                                                                                    "default": "Promissory"
+                                                                                                },
+                                                                                                "groupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "groupName",
+                                                                                                    "description": "Group name.",
+                                                                                                    "default": "promissoryPaymentGroup"
+                                                                                                },
+                                                                                                "validator": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "validator",
+                                                                                                    "description": "Validator.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "stringId": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "stringId",
+                                                                                                    "description": "String ID.",
+                                                                                                    "default": "17"
+                                                                                                },
+                                                                                                "template": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "template",
+                                                                                                    "description": "Template.",
+                                                                                                    "default": "promissoryPaymentGroup-template"
+                                                                                                },
+                                                                                                "requiresDocument": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresDocument",
+                                                                                                    "description": "If requires document or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "isCustom": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "isCustom",
+                                                                                                    "description": "If is custom or not.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "description": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "description",
+                                                                                                    "description": "Description.",
+                                                                                                    "default": ""
+                                                                                                },
+                                                                                                "requiresAuthentication": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "requiresAuthentication",
+                                                                                                    "description": "If requires authentication.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "dueDate": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "dueDate",
+                                                                                                    "description": "Due date.",
+                                                                                                    "default": "2021-07-01T18:43:00.0264384Z"
+                                                                                                },
+                                                                                                "availablePayments": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "availablePayments",
+                                                                                                    "description": "Available payments.",
+                                                                                                    "default": ""
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "payments": {
+                                                                                        "type": "array",
+                                                                                        "title": "payments",
+                                                                                        "description": "Payments.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCards": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCards",
+                                                                                        "description": "GiftCards.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "giftCardMessages": {
+                                                                                        "type": "array",
+                                                                                        "title": "giftCardMessages",
+                                                                                        "description": "GiftCardMessages.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableAccounts": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableAccounts",
+                                                                                        "description": "Available accounts.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableTokens": {
+                                                                                        "type": "array",
+                                                                                        "title": "availableTokens",
+                                                                                        "description": "Available tokens.",
+                                                                                        "default": []
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "Videos": {
+                                                            "type": "array",
+                                                            "title": "Videos",
+                                                            "description": "Videos.",
+                                                            "default": []
+                                                        },
+                                                        "estimatedDateArrival": {
+                                                            "type": "string",
+                                                            "title": "estimatedDateArrival",
+                                                            "description": "Estimated date arrival.",
+                                                            "default": ""
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
 					}
 				},
 				"deprecated": false,

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19083,13 +19083,129 @@
 				]
 			}
 		},
+        "/api/catalog_system/pub/facets/category/{categoryId}": {
+            "get": {
+                "tags": [
+					"Facets"
+				],
+                "summary": "Get Category Facets",
+                "description": "Retrieves the names and IDs of the categories facets.",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "required": true,
+                        "description": "Name of the VTEX account. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+					{
+						"name": "Accept",
+						"in": "header",
+						"description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand ",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+					{
+						"name": "Content-Type",
+						"in": "header",
+						"description": "Describes the type of the content being sent",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+							"example": "application/json"
+						}
+					},
+					{
+						"name": "categoryId",
+						"in": "path",
+						"description": "Category unique number identifier.",
+						"required": true,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+                            "default": "1"
+						}
+					}
+				],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json":{
+                                "example": [
+                                    [
+                                        {
+                                            "Name": "Tamanho Global",
+                                            "Id": 45
+                                        },
+                                        {
+                                            "Name": "Percentuals",
+                                            "Id": 25
+                                        }
+                                    ]
+                                ],
+                                "schema":{
+                                    "type": "array",
+                                    "title": "",
+                                    "items": {
+                                        "type": "object",
+                                        "title": "",
+                                        "description": "Object with name and ID of the category.",
+                                        "default": {
+                                            "Name": "Tamanho Global",
+                                            "Id": 45
+                                        },
+                                        "required": [
+                                            "Name",
+                                            "Id"
+                                        ],
+                                        "properties": {
+                                            "Name": {
+                                                "type": "string",
+                                                "title": "Name",
+                                                "description": "Category name.",
+                                                "default": "Tamanho Global"
+                                            },
+                                            "Id": {
+                                                "type": "integer",
+                                                "title": "Id",
+                                                "description": "Category ID",
+                                                "default": 45
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
 		"/api/catalog_system/pub/facets/search/{category1}/{category2}": {
 			"get": {
 				"tags": [
 					"Facets"
 				],
-				"summary": "Search by Facets category",
-				"description": "",
+				"summary": "Search by Category Facets",
+				"description": "Search of ",
 				"operationId": "Facetscategory",
 				"parameters": [
                     {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -512,7 +512,7 @@
                                                         "143": "NaoPesquisavel",
                                                         "146": "colecaotestesubcategoria",
                                                         "161": "merch_import_test1"
-                                                    }
+                                                }
                                             },
                                             "searchableClusters": {
                                                 "type": "object",
@@ -1227,7 +1227,7 @@
                                                         "isKit": {
                                                             "type": "boolean",
                                                             "title": "isKit",
-                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "description": "If the SKU is part of a kit.",
                                                             "default": true
                                                         },
                                                         "kitItems": {
@@ -1271,10 +1271,9 @@
                                                         },
                                                         "images": {
                                                             "type": "array",
-                                                            "title": "The images schema",
-                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "title": "images",
+                                                            "description": "Array of information about the SKU image.",
                                                             "default": [
-                                                                [
                                                                     {
                                                                         "imageId": "155489",
                                                                         "imageLabel": "",
@@ -1283,12 +1282,10 @@
                                                                         "imageText": "hoegaarden-kit",
                                                                         "imageLastModified": "2020-10-07T12:49:27.5800000Z"
                                                                     }
-                                                                ]
-                                                            ],
+                                                                ],
                                                             "items": {
                                                                 "type": "object",
-                                                                "title": "The first anyOf schema",
-                                                                "description": "An explanation about the purpose of this instance.",
+                                                                "title": "",
                                                                 "default": [
                                                                     {
                                                                         "imageId": "155489",
@@ -1310,56 +1307,48 @@
                                                                 "properties": {
                                                                     "imageId": {
                                                                         "type": "string",
-                                                                        "title": "The imageId schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "title": "imageId",
+                                                                        "description": "Image ID.",
                                                                         "default": [
                                                                             "155489"
                                                                         ]
                                                                     },
                                                                     "imageLabel": {
                                                                         "type": "string",
-                                                                        "title": "The imageLabel schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                        "default": ""
+                                                                        "title": "imageLabel",
+                                                                        "description": "Image label.",
+                                                                        "default": "Label test"
                                                                     },
                                                                     "imageTag": {
                                                                         "type": "string",
-                                                                        "title": "The imageTag schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                        "default": [
-                                                                            "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
-                                                                        ]
+                                                                        "title": "imageTag",
+                                                                        "description": "Image tag.",
+                                                                        "default": "<img src=\"~/arquivos/ids/155489-#width#-#height#/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000\" width=\"#width#\" height=\"#height#\" alt=\"hoegaarden-kit\" id=\"\" />"
                                                                     },
                                                                     "imageUrl": {
                                                                         "type": "string",
-                                                                        "title": "The imageUrl schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                        "default": [
-                                                                            "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
-                                                                        ]
+                                                                        "title": "imageUrl",
+                                                                        "description": "Image URL.",
+                                                                        "default": "https://merch.vteximg.com.br/arquivos/ids/155489/99B14097-BFEA-4C0E-899E-35C95A2E1509_4_5005_c.jpg?v=637376717675800000"
                                                                     },
                                                                     "imageText": {
                                                                         "type": "string",
-                                                                        "title": "The imageText schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                        "default": [
-                                                                            "hoegaarden-kit"
-                                                                        ]
+                                                                        "title": "imageText",
+                                                                        "description": "Image text.",
+                                                                        "default": "hoegaarden-kit"
                                                                     },
                                                                     "imageLastModified": {
                                                                         "type": "string",
-                                                                        "title": "The imageLastModified schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                        "default": [
-                                                                            "2020-10-07T12:49:27.5800000Z"
-                                                                        ]
+                                                                        "title": "imageLastModified",
+                                                                        "description": "Date and time of the last update of the image.",
+                                                                        "default": "2020-10-07T12:49:27.5800000Z"
                                                                     }
                                                                 }
                                                             }
                                                         },
                                                         "sellers": {
                                                             "type": "array",
-                                                            "title": "The sellers schema",
+                                                            "title": "sellers",
                                                             "description": "An explanation about the purpose of this instance.",
                                                             "default": [
                                                                 [
@@ -1591,25 +1580,559 @@
                                                                 ]
                                                             ],
                                                             "items": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "type": "object",
-                                                                        "title": "The first anyOf schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                        "default": [
+                                                                "type": "object",
+                                                                "title": "",
+                                                                "default": {
+                                                                    "sellerId": "1",
+                                                                    "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
+                                                                    "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
+                                                                    "sellerDefault": true,
+                                                                    "commertialOffer": {
+                                                                        "DeliverySlaSamplesPerRegion": {
+                                                                            "0": {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        },
+                                                                        "Installments": [
                                                                             {
-                                                                                "sellerId": "1",
-                                                                                "sellerName": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE",
-                                                                                "addToCartLink": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1",
-                                                                                "sellerDefault": true,
-                                                                                "commertialOffer": {
-                                                                                    "DeliverySlaSamplesPerRegion": {
-                                                                                        "0": {
-                                                                                            "DeliverySlaPerTypes": [],
-                                                                                            "Region": null
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa à vista"
+                                                                            },
+                                                                            {
+                                                                                "Value": 21.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 2,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 2 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 14.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 3,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 3 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 10.5,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 4,
+                                                                                "PaymentSystemName": "Visa",
+                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                "Name": "Visa 4 vezes sem juros"
+                                                                            },
+                                                                            {
+                                                                                "Value": 42.0,
+                                                                                "InterestRate": 0.0,
+                                                                                "TotalValuePlusInterestRate": 42.0,
+                                                                                "NumberOfInstallments": 1,
+                                                                                "PaymentSystemName": "Promissory",
+                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                "Name": "Promissory à vista"
+                                                                            }
+                                                                        ],
+                                                                        "DiscountHighLight": [],
+                                                                        "GiftSkuIds": [],
+                                                                        "Teasers": [],
+                                                                        "BuyTogether": [],
+                                                                        "ItemMetadataAttachment": [],
+                                                                        "Price": 42.0,
+                                                                        "ListPrice": 42.0,
+                                                                        "PriceWithoutDiscount": 42.0,
+                                                                        "RewardValue": 0.0,
+                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                        "AvailableQuantity": 16,
+                                                                        "IsAvailable": true,
+                                                                        "Tax": 0.0,
+                                                                        "SaleChannel": 0,
+                                                                        "DeliverySlaSamples": [
+                                                                            {
+                                                                                "DeliverySlaPerTypes": [],
+                                                                                "Region": null
+                                                                            }
+                                                                        ],
+                                                                        "GetInfoErrorMessage": null,
+                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                        "PaymentOptions": {
+                                                                            "installmentOptions": [
+                                                                                {
+                                                                                    "paymentSystem": "2",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Visa",
+                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 2,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 2100,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 3,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1400,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "count": 4,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 1050,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
                                                                                         }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "paymentSystem": "17",
+                                                                                    "bin": null,
+                                                                                    "paymentName": "Promissory",
+                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                    "value": 4200,
+                                                                                    "installments": [
+                                                                                        {
+                                                                                            "count": 1,
+                                                                                            "hasInterestRate": false,
+                                                                                            "interestRate": 0,
+                                                                                            "value": 4200,
+                                                                                            "total": 4200,
+                                                                                            "sellerMerchantInstallments": [
+                                                                                                {
+                                                                                                    "id": "MERCH",
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "paymentSystems": [
+                                                                                {
+                                                                                    "id": 17,
+                                                                                    "name": "Promissory",
+                                                                                    "groupName": "promissoryPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "17",
+                                                                                    "template": "promissoryPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                },
+                                                                                {
+                                                                                    "id": 2,
+                                                                                    "name": "Visa",
+                                                                                    "groupName": "creditCardPaymentGroup",
+                                                                                    "validator": null,
+                                                                                    "stringId": "2",
+                                                                                    "template": "creditCardPaymentGroup-template",
+                                                                                    "requiresDocument": false,
+                                                                                    "isCustom": false,
+                                                                                    "description": null,
+                                                                                    "requiresAuthentication": false,
+                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                    "availablePayments": null
+                                                                                }
+                                                                            ],
+                                                                            "payments": [],
+                                                                            "giftCards": [],
+                                                                            "giftCardMessages": [],
+                                                                            "availableAccounts": [],
+                                                                            "availableTokens": []
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "sellerId",
+                                                                    "sellerName",
+                                                                    "addToCartLink",
+                                                                    "sellerDefault",
+                                                                    "commertialOffer"
+                                                                ],
+                                                                "properties": {
+                                                                    "sellerId": {
+                                                                        "type": "string",
+                                                                        "title": "sellerId",
+                                                                        "description": "SKU seller ID.",
+                                                                        "default": "1"
+                                                                    },
+                                                                    "sellerName": {
+                                                                        "type": "string",
+                                                                        "title": "sellerName",
+                                                                        "description": "SKU seller name.",
+                                                                        "default": "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
+                                                                    },
+                                                                    "addToCartLink": {
+                                                                        "type": "string",
+                                                                        "title": "addToCartLink",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
+                                                                    },
+                                                                    "sellerDefault": {
+                                                                        "type": "boolean",
+                                                                        "title": "sellerDefault",
+                                                                        "description": "If the seller is default or not.",
+                                                                        "default": true
+                                                                    },
+                                                                    "commertialOffer": {
+                                                                        "type": "object",
+                                                                        "title": "commertialOffer",
+                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "default": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "0": {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            },
+                                                                            "Installments": [
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa à vista"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 21.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 2,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 2 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 14.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 3,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 3 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 10.5,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 4,
+                                                                                    "PaymentSystemName": "Visa",
+                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                    "Name": "Visa 4 vezes sem juros"
+                                                                                },
+                                                                                {
+                                                                                    "Value": 42.0,
+                                                                                    "InterestRate": 0.0,
+                                                                                    "TotalValuePlusInterestRate": 42.0,
+                                                                                    "NumberOfInstallments": 1,
+                                                                                    "PaymentSystemName": "Promissory",
+                                                                                    "PaymentSystemGroupName": "promissoryPaymentGroup",
+                                                                                    "Name": "Promissory à vista"
+                                                                                }
+                                                                            ],
+                                                                            "DiscountHighLight": [],
+                                                                            "GiftSkuIds": [],
+                                                                            "Teasers": [],
+                                                                            "BuyTogether": [],
+                                                                            "ItemMetadataAttachment": [],
+                                                                            "Price": 42.0,
+                                                                            "ListPrice": 42.0,
+                                                                            "PriceWithoutDiscount": 42.0,
+                                                                            "RewardValue": 0.0,
+                                                                            "PriceValidUntil": "4000-01-01T03:00:00Z",
+                                                                            "AvailableQuantity": 16,
+                                                                            "IsAvailable": true,
+                                                                            "Tax": 0.0,
+                                                                            "SaleChannel": 0,
+                                                                            "DeliverySlaSamples": [
+                                                                                {
+                                                                                    "DeliverySlaPerTypes": [],
+                                                                                    "Region": null
+                                                                                }
+                                                                            ],
+                                                                            "GetInfoErrorMessage": null,
+                                                                            "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
+                                                                            "PaymentOptions": {
+                                                                                "installmentOptions": [
+                                                                                    {
+                                                                                        "paymentSystem": "2",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Visa",
+                                                                                        "paymentGroupName": "creditCardPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 2,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 2100,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 2,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 2100,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 3,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1400,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 3,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1400,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "count": 4,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 1050,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 4,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 1050,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
                                                                                     },
-                                                                                    "Installments": [
+                                                                                    {
+                                                                                        "paymentSystem": "17",
+                                                                                        "bin": null,
+                                                                                        "paymentName": "Promissory",
+                                                                                        "paymentGroupName": "promissoryPaymentGroup",
+                                                                                        "value": 4200,
+                                                                                        "installments": [
+                                                                                            {
+                                                                                                "count": 1,
+                                                                                                "hasInterestRate": false,
+                                                                                                "interestRate": 0,
+                                                                                                "value": 4200,
+                                                                                                "total": 4200,
+                                                                                                "sellerMerchantInstallments": [
+                                                                                                    {
+                                                                                                        "id": "MERCH",
+                                                                                                        "count": 1,
+                                                                                                        "hasInterestRate": false,
+                                                                                                        "interestRate": 0,
+                                                                                                        "value": 4200,
+                                                                                                        "total": 4200
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ],
+                                                                                "paymentSystems": [
+                                                                                    {
+                                                                                        "id": 17,
+                                                                                        "name": "Promissory",
+                                                                                        "groupName": "promissoryPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "17",
+                                                                                        "template": "promissoryPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    },
+                                                                                    {
+                                                                                        "id": 2,
+                                                                                        "name": "Visa",
+                                                                                        "groupName": "creditCardPaymentGroup",
+                                                                                        "validator": null,
+                                                                                        "stringId": "2",
+                                                                                        "template": "creditCardPaymentGroup-template",
+                                                                                        "requiresDocument": false,
+                                                                                        "isCustom": false,
+                                                                                        "description": null,
+                                                                                        "requiresAuthentication": false,
+                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                        "availablePayments": null
+                                                                                    }
+                                                                                ],
+                                                                                "payments": [],
+                                                                                "giftCards": [],
+                                                                                "giftCardMessages": [],
+                                                                                "availableAccounts": [],
+                                                                                "availableTokens": []
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "DeliverySlaSamplesPerRegion",
+                                                                            "Installments",
+                                                                            "DiscountHighLight",
+                                                                            "GiftSkuIds",
+                                                                            "Teasers",
+                                                                            "BuyTogether",
+                                                                            "ItemMetadataAttachment",
+                                                                            "Price",
+                                                                            "ListPrice",
+                                                                            "PriceWithoutDiscount",
+                                                                            "RewardValue",
+                                                                            "PriceValidUntil",
+                                                                            "AvailableQuantity",
+                                                                            "IsAvailable",
+                                                                            "Tax",
+                                                                            "SaleChannel",
+                                                                            "DeliverySlaSamples",
+                                                                            "GetInfoErrorMessage",
+                                                                            "CacheVersionUsedToCallCheckout",
+                                                                            "PaymentOptions"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "DeliverySlaSamplesPerRegion": {
+                                                                                "type": "object",
+                                                                                "title": "DeliverySlaSamplesPerRegion",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": {
+                                                                                    "0": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    }
+                                                                                },
+                                                                                "properties": {
+                                                                                    "0": {
+                                                                                        "type": "object",
+                                                                                        "title": "The 0 schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": [
+                                                                                            {
+                                                                                                "DeliverySlaPerTypes": [],
+                                                                                                "Region": null
+                                                                                            }
+                                                                                        ],
+                                                                                        "required": [
+                                                                                            "DeliverySlaPerTypes",
+                                                                                            "Region"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                            "DeliverySlaPerTypes": {
+                                                                                                "type": "array",
+                                                                                                "title": "The DeliverySlaPerTypes schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": []
+                                                                                            },
+                                                                                            "Region": {
+                                                                                                "type": "string",
+                                                                                                "title": "The Region schema",
+                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                "default": null
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "Installments": {
+                                                                                "type": "array",
+                                                                                "title": "The Installments schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": [
+                                                                                    [
                                                                                         {
                                                                                             "Value": 42.0,
                                                                                             "InterestRate": 0.0,
@@ -1627,60 +2150,485 @@
                                                                                             "PaymentSystemName": "Visa",
                                                                                             "PaymentSystemGroupName": "creditCardPaymentGroup",
                                                                                             "Name": "Visa 2 vezes sem juros"
-                                                                                        },
-                                                                                        {
-                                                                                            "Value": 14.0,
-                                                                                            "InterestRate": 0.0,
-                                                                                            "TotalValuePlusInterestRate": 42.0,
-                                                                                            "NumberOfInstallments": 3,
-                                                                                            "PaymentSystemName": "Visa",
-                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                            "Name": "Visa 3 vezes sem juros"
-                                                                                        },
-                                                                                        {
-                                                                                            "Value": 10.5,
-                                                                                            "InterestRate": 0.0,
-                                                                                            "TotalValuePlusInterestRate": 42.0,
-                                                                                            "NumberOfInstallments": 4,
-                                                                                            "PaymentSystemName": "Visa",
-                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                            "Name": "Visa 4 vezes sem juros"
-                                                                                        },
+                                                                                        }
+                                                                                    ]
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "The first anyOf schema",
+                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                    "default": [
                                                                                         {
                                                                                             "Value": 42.0,
                                                                                             "InterestRate": 0.0,
                                                                                             "TotalValuePlusInterestRate": 42.0,
                                                                                             "NumberOfInstallments": 1,
-                                                                                            "PaymentSystemName": "Promissory",
-                                                                                            "PaymentSystemGroupName": "promissoryPaymentGroup",
-                                                                                            "Name": "Promissory à vista"
+                                                                                            "PaymentSystemName": "Visa",
+                                                                                            "PaymentSystemGroupName": "creditCardPaymentGroup",
+                                                                                            "Name": "Visa à vista"
                                                                                         }
                                                                                     ],
-                                                                                    "DiscountHighLight": [],
-                                                                                    "GiftSkuIds": [],
-                                                                                    "Teasers": [],
-                                                                                    "BuyTogether": [],
-                                                                                    "ItemMetadataAttachment": [],
-                                                                                    "Price": 42.0,
-                                                                                    "ListPrice": 42.0,
-                                                                                    "PriceWithoutDiscount": 42.0,
-                                                                                    "RewardValue": 0.0,
-                                                                                    "PriceValidUntil": "4000-01-01T03:00:00Z",
-                                                                                    "AvailableQuantity": 16,
-                                                                                    "IsAvailable": true,
-                                                                                    "Tax": 0.0,
-                                                                                    "SaleChannel": 0,
-                                                                                    "DeliverySlaSamples": [
+                                                                                    "required": [
+                                                                                        "Value",
+                                                                                        "InterestRate",
+                                                                                        "TotalValuePlusInterestRate",
+                                                                                        "NumberOfInstallments",
+                                                                                        "PaymentSystemName",
+                                                                                        "PaymentSystemGroupName",
+                                                                                        "Name"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "Value": {
+                                                                                            "type": "number",
+                                                                                            "title": "The Value schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "InterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "The InterestRate schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": 0.0
+                                                                                        },
+                                                                                        "TotalValuePlusInterestRate": {
+                                                                                            "type": "number",
+                                                                                            "title": "The TotalValuePlusInterestRate schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": 42.0
+                                                                                        },
+                                                                                        "NumberOfInstallments": {
+                                                                                            "type": "integer",
+                                                                                            "title": "The NumberOfInstallments schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": 1
+                                                                                        },
+                                                                                        "PaymentSystemName": {
+                                                                                            "type": "string",
+                                                                                            "title": "The PaymentSystemName schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": "Visa"
+                                                                                        },
+                                                                                        "PaymentSystemGroupName": {
+                                                                                            "type": "string",
+                                                                                            "title": "The PaymentSystemGroupName schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": "creditCardPaymentGroup"
+                                                                                        },
+                                                                                        "Name": {
+                                                                                            "type": "string",
+                                                                                            "title": "The Name schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": "Visa à vista"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "DiscountHighLight": {
+                                                                                "type": "array",
+                                                                                "title": "The DiscountHighLight schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": []
+                                                                            },
+                                                                            "GiftSkuIds": {
+                                                                                "type": "array",
+                                                                                "title": "The GiftSkuIds schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Teasers": {
+                                                                                "type": "array",
+                                                                                "title": "The Teasers schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": []
+                                                                            },
+                                                                            "BuyTogether": {
+                                                                                "type": "array",
+                                                                                "title": "The BuyTogether schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": []
+                                                                            },
+                                                                            "ItemMetadataAttachment": {
+                                                                                "type": "array",
+                                                                                "title": "The ItemMetadataAttachment schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": []
+                                                                            },
+                                                                            "Price": {
+                                                                                "type": "number",
+                                                                                "title": "The Price schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "ListPrice": {
+                                                                                "type": "number",
+                                                                                "title": "The ListPrice schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "PriceWithoutDiscount": {
+                                                                                "type": "number",
+                                                                                "title": "The PriceWithoutDiscount schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": 42.0
+                                                                            },
+                                                                            "RewardValue": {
+                                                                                "type": "number",
+                                                                                "title": "The RewardValue schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "PriceValidUntil": {
+                                                                                "type": "string",
+                                                                                "title": "The PriceValidUntil schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": "4000-01-01T03:00:00Z"
+                                                                            },
+                                                                            "AvailableQuantity": {
+                                                                                "type": "integer",
+                                                                                "title": "The AvailableQuantity schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": 16
+                                                                            },
+                                                                            "IsAvailable": {
+                                                                                "type": "boolean",
+                                                                                "title": "The IsAvailable schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": true
+                                                                            },
+                                                                            "Tax": {
+                                                                                "type": "number",
+                                                                                "title": "The Tax schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": 0.0
+                                                                            },
+                                                                            "SaleChannel": {
+                                                                                "type": "integer",
+                                                                                "title": "The SaleChannel schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": 0
+                                                                            },
+                                                                            "DeliverySlaSamples": {
+                                                                                "type": "array",
+                                                                                "title": "The DeliverySlaSamples schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": [
+                                                                                    {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    }
+                                                                                ],
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "title": "The first anyOf schema",
+                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                    "default": {
+                                                                                        "DeliverySlaPerTypes": [],
+                                                                                        "Region": null
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "DeliverySlaPerTypes",
+                                                                                        "Region"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "DeliverySlaPerTypes": {
+                                                                                            "type": "array",
+                                                                                            "title": "The DeliverySlaPerTypes schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": []
+                                                                                        },
+                                                                                        "Region": {
+                                                                                            "type": "string",
+                                                                                            "title": "The Region schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": null
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "GetInfoErrorMessage": {
+                                                                                "type": "string",
+                                                                                "title": "The GetInfoErrorMessage schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": null
+                                                                            },
+                                                                            "CacheVersionUsedToCallCheckout": {
+                                                                                "type": "string",
+                                                                                "title": "The CacheVersionUsedToCallCheckout schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                            },
+                                                                            "PaymentOptions": {
+                                                                                "type": "object",
+                                                                                "title": "The PaymentOptions schema",
+                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "default": {
+                                                                                    "installmentOptions": [
                                                                                         {
-                                                                                            "DeliverySlaPerTypes": [],
-                                                                                            "Region": null
+                                                                                            "paymentSystem": "2",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Visa",
+                                                                                            "paymentGroupName": "creditCardPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 2,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 2100,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 3,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1400,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "count": 4,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 1050,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "paymentSystem": "17",
+                                                                                            "bin": null,
+                                                                                            "paymentName": "Promissory",
+                                                                                            "paymentGroupName": "promissoryPaymentGroup",
+                                                                                            "value": 4200,
+                                                                                            "installments": [
+                                                                                                {
+                                                                                                    "count": 1,
+                                                                                                    "hasInterestRate": false,
+                                                                                                    "interestRate": 0,
+                                                                                                    "value": 4200,
+                                                                                                    "total": 4200,
+                                                                                                    "sellerMerchantInstallments": [
+                                                                                                        {
+                                                                                                            "id": "MERCH",
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
                                                                                         }
                                                                                     ],
-                                                                                    "GetInfoErrorMessage": null,
-                                                                                    "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
-                                                                                    "PaymentOptions": {
-                                                                                        "installmentOptions": [
-                                                                                            {
+                                                                                    "paymentSystems": [
+                                                                                        {
+                                                                                            "id": 17,
+                                                                                            "name": "Promissory",
+                                                                                            "groupName": "promissoryPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "17",
+                                                                                            "template": "promissoryPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        },
+                                                                                        {
+                                                                                            "id": 2,
+                                                                                            "name": "Visa",
+                                                                                            "groupName": "creditCardPaymentGroup",
+                                                                                            "validator": null,
+                                                                                            "stringId": "2",
+                                                                                            "template": "creditCardPaymentGroup-template",
+                                                                                            "requiresDocument": false,
+                                                                                            "isCustom": false,
+                                                                                            "description": null,
+                                                                                            "requiresAuthentication": false,
+                                                                                            "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                            "availablePayments": null
+                                                                                        }
+                                                                                    ],
+                                                                                    "payments": [],
+                                                                                    "giftCards": [],
+                                                                                    "giftCardMessages": [],
+                                                                                    "availableAccounts": [],
+                                                                                    "availableTokens": []
+                                                                                },
+                                                                                "required": [
+                                                                                    "installmentOptions",
+                                                                                    "paymentSystems",
+                                                                                    "payments",
+                                                                                    "giftCards",
+                                                                                    "giftCardMessages",
+                                                                                    "availableAccounts",
+                                                                                    "availableTokens"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "installmentOptions": {
+                                                                                        "type": "array",
+                                                                                        "title": "The installmentOptions schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": [
+                                                                                            [
+                                                                                                {
+                                                                                                    "paymentSystem": "2",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Visa",
+                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 3,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1400,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 3,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1400,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 4,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 1050,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 4,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 1050,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                {
+                                                                                                    "paymentSystem": "17",
+                                                                                                    "bin": null,
+                                                                                                    "paymentName": "Promissory",
+                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
+                                                                                                    "value": 4200,
+                                                                                                    "installments": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        ],
+                                                                                        "items": {
+                                                                                            "type": "object",
+                                                                                            "title": "The first anyOf schema",
+                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "default": {
                                                                                                 "paymentSystem": "2",
                                                                                                 "bin": null,
                                                                                                 "paymentName": "Visa",
@@ -1757,34 +2705,230 @@
                                                                                                     }
                                                                                                 ]
                                                                                             },
-                                                                                            {
-                                                                                                "paymentSystem": "17",
-                                                                                                "bin": null,
-                                                                                                "paymentName": "Promissory",
-                                                                                                "paymentGroupName": "promissoryPaymentGroup",
-                                                                                                "value": 4200,
-                                                                                                "installments": [
-                                                                                                    {
-                                                                                                        "count": 1,
-                                                                                                        "hasInterestRate": false,
-                                                                                                        "interestRate": 0,
-                                                                                                        "value": 4200,
-                                                                                                        "total": 4200,
-                                                                                                        "sellerMerchantInstallments": [
-                                                                                                            {
-                                                                                                                "id": "MERCH",
-                                                                                                                "count": 1,
-                                                                                                                "hasInterestRate": false,
-                                                                                                                "interestRate": 0,
-                                                                                                                "value": 4200,
-                                                                                                                "total": 4200
+                                                                                            "required": [
+                                                                                                "paymentSystem",
+                                                                                                "bin",
+                                                                                                "paymentName",
+                                                                                                "paymentGroupName",
+                                                                                                "value",
+                                                                                                "installments"
+                                                                                            ],
+                                                                                            "properties": {
+                                                                                                "paymentSystem": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The paymentSystem schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "2"
+                                                                                                },
+                                                                                                "bin": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The bin schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "paymentName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The paymentName schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "Visa"
+                                                                                                },
+                                                                                                "paymentGroupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The paymentGroupName schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "creditCardPaymentGroup"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "The value schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": 4200
+                                                                                                },
+                                                                                                "installments": {
+                                                                                                    "type": "array",
+                                                                                                    "title": "The installments schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": [
+                                                                                                        {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "count": 2,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 2100,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 2,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 2100,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ],
+                                                                                                    "items": {
+                                                                                                        "type": "object",
+                                                                                                        "title": "The first anyOf schema",
+                                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                                        "default": {
+                                                                                                            "count": 1,
+                                                                                                            "hasInterestRate": false,
+                                                                                                            "interestRate": 0,
+                                                                                                            "value": 4200,
+                                                                                                            "total": 4200,
+                                                                                                            "sellerMerchantInstallments": [
+                                                                                                                {
+                                                                                                                    "id": "MERCH",
+                                                                                                                    "count": 1,
+                                                                                                                    "hasInterestRate": false,
+                                                                                                                    "interestRate": 0,
+                                                                                                                    "value": 4200,
+                                                                                                                    "total": 4200
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "required": [
+                                                                                                            "count",
+                                                                                                            "hasInterestRate",
+                                                                                                            "interestRate",
+                                                                                                            "value",
+                                                                                                            "total",
+                                                                                                            "sellerMerchantInstallments"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                            "count": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "The count schema",
+                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "default": 1
+                                                                                                            },
+                                                                                                            "hasInterestRate": {
+                                                                                                                "type": "boolean",
+                                                                                                                "title": "The hasInterestRate schema",
+                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "default": false
+                                                                                                            },
+                                                                                                            "interestRate": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "The interestRate schema",
+                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "default": 0
+                                                                                                            },
+                                                                                                            "value": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "The value schema",
+                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "total": {
+                                                                                                                "type": "integer",
+                                                                                                                "title": "The total schema",
+                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "default": 4200
+                                                                                                            },
+                                                                                                            "sellerMerchantInstallments": {
+                                                                                                                "type": "array",
+                                                                                                                "title": "The sellerMerchantInstallments schema",
+                                                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                                                "default": [
+                                                                                                                    {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "items": {
+                                                                                                                    "type": "object",
+                                                                                                                    "title": "The first anyOf schema",
+                                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                                    "default": {
+                                                                                                                        "id": "MERCH",
+                                                                                                                        "count": 1,
+                                                                                                                        "hasInterestRate": false,
+                                                                                                                        "interestRate": 0,
+                                                                                                                        "value": 4200,
+                                                                                                                        "total": 4200
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                        "id",
+                                                                                                                        "count",
+                                                                                                                        "hasInterestRate",
+                                                                                                                        "interestRate",
+                                                                                                                        "value",
+                                                                                                                        "total"
+                                                                                                                    ],
+                                                                                                                    "properties": {
+                                                                                                                        "id": {
+                                                                                                                            "type": "string",
+                                                                                                                            "title": "The id schema",
+                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "default": "MERCH"
+                                                                                                                        },
+                                                                                                                        "count": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "The count schema",
+                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "default": 1
+                                                                                                                        },
+                                                                                                                        "hasInterestRate": {
+                                                                                                                            "type": "boolean",
+                                                                                                                            "title": "The hasInterestRate schema",
+                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "default": false
+                                                                                                                        },
+                                                                                                                        "interestRate": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "The interestRate schema",
+                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "default": 0
+                                                                                                                        },
+                                                                                                                        "value": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "The value schema",
+                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "default": 4200
+                                                                                                                        },
+                                                                                                                        "total": {
+                                                                                                                            "type": "integer",
+                                                                                                                            "title": "The total schema",
+                                                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                                                            "default": 4200
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
                                                                                                             }
-                                                                                                        ]
+                                                                                                        }
                                                                                                     }
-                                                                                                ]
+                                                                                                }
                                                                                             }
-                                                                                        ],
-                                                                                        "paymentSystems": [
+                                                                                        }
+                                                                                    },
+                                                                                    "paymentSystems": {
+                                                                                        "type": "array",
+                                                                                        "title": "The paymentSystems schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": [
                                                                                             {
                                                                                                 "id": 17,
                                                                                                 "name": "Promissory",
@@ -1814,1322 +2958,149 @@
                                                                                                 "availablePayments": null
                                                                                             }
                                                                                         ],
-                                                                                        "payments": [],
-                                                                                        "giftCards": [],
-                                                                                        "giftCardMessages": [],
-                                                                                        "availableAccounts": [],
-                                                                                        "availableTokens": []
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                        ],
-                                                                        "required": [
-                                                                            "sellerId",
-                                                                            "sellerName",
-                                                                            "addToCartLink",
-                                                                            "sellerDefault",
-                                                                            "commertialOffer"
-                                                                        ],
-                                                                        "properties": {
-                                                                            "sellerId": {
-                                                                                "type": "string",
-                                                                                "title": "The sellerId schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                "default": "1"
-                                                                            },
-                                                                            "sellerName": {
-                                                                                "type": "string",
-                                                                                "title": "The sellerName schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                "default": [
-                                                                                    "COMPANHIA BRASILEIRA DE TECNOLOGIA PARA E-COMMERCE"
-                                                                                ]
-                                                                            },
-                                                                            "addToCartLink": {
-                                                                                "type": "string",
-                                                                                "title": "The addToCartLink schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                "default": [
-                                                                                    "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
-                                                                                ]
-                                                                            },
-                                                                            "sellerDefault": {
-                                                                                "type": "boolean",
-                                                                                "title": "The sellerDefault schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                "default": true
-                                                                            },
-                                                                            "commertialOffer": {
-                                                                                "type": "object",
-                                                                                "title": "The commertialOffer schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                "default": [
-                                                                                    {
-                                                                                        "DeliverySlaSamplesPerRegion": {
-                                                                                            "0": {
-                                                                                                "DeliverySlaPerTypes": [],
-                                                                                                "Region": null
-                                                                                            }
-                                                                                        },
-                                                                                        "Installments": [
-                                                                                            {
-                                                                                                "Value": 42.0,
-                                                                                                "InterestRate": 0.0,
-                                                                                                "TotalValuePlusInterestRate": 42.0,
-                                                                                                "NumberOfInstallments": 1,
-                                                                                                "PaymentSystemName": "Visa",
-                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                                "Name": "Visa à vista"
-                                                                                            },
-                                                                                            {
-                                                                                                "Value": 21.0,
-                                                                                                "InterestRate": 0.0,
-                                                                                                "TotalValuePlusInterestRate": 42.0,
-                                                                                                "NumberOfInstallments": 2,
-                                                                                                "PaymentSystemName": "Visa",
-                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                                "Name": "Visa 2 vezes sem juros"
-                                                                                            },
-                                                                                            {
-                                                                                                "Value": 14.0,
-                                                                                                "InterestRate": 0.0,
-                                                                                                "TotalValuePlusInterestRate": 42.0,
-                                                                                                "NumberOfInstallments": 3,
-                                                                                                "PaymentSystemName": "Visa",
-                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                                "Name": "Visa 3 vezes sem juros"
-                                                                                            },
-                                                                                            {
-                                                                                                "Value": 10.5,
-                                                                                                "InterestRate": 0.0,
-                                                                                                "TotalValuePlusInterestRate": 42.0,
-                                                                                                "NumberOfInstallments": 4,
-                                                                                                "PaymentSystemName": "Visa",
-                                                                                                "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                                "Name": "Visa 4 vezes sem juros"
-                                                                                            },
-                                                                                            {
-                                                                                                "Value": 42.0,
-                                                                                                "InterestRate": 0.0,
-                                                                                                "TotalValuePlusInterestRate": 42.0,
-                                                                                                "NumberOfInstallments": 1,
-                                                                                                "PaymentSystemName": "Promissory",
-                                                                                                "PaymentSystemGroupName": "promissoryPaymentGroup",
-                                                                                                "Name": "Promissory à vista"
-                                                                                            }
-                                                                                        ],
-                                                                                        "DiscountHighLight": [],
-                                                                                        "GiftSkuIds": [],
-                                                                                        "Teasers": [],
-                                                                                        "BuyTogether": [],
-                                                                                        "ItemMetadataAttachment": [],
-                                                                                        "Price": 42.0,
-                                                                                        "ListPrice": 42.0,
-                                                                                        "PriceWithoutDiscount": 42.0,
-                                                                                        "RewardValue": 0.0,
-                                                                                        "PriceValidUntil": "4000-01-01T03:00:00Z",
-                                                                                        "AvailableQuantity": 16,
-                                                                                        "IsAvailable": true,
-                                                                                        "Tax": 0.0,
-                                                                                        "SaleChannel": 0,
-                                                                                        "DeliverySlaSamples": [
-                                                                                            {
-                                                                                                "DeliverySlaPerTypes": [],
-                                                                                                "Region": null
-                                                                                            }
-                                                                                        ],
-                                                                                        "GetInfoErrorMessage": null,
-                                                                                        "CacheVersionUsedToCallCheckout": "95EF7E5476DF276E679167A399FE3103_",
-                                                                                        "PaymentOptions": {
-                                                                                            "installmentOptions": [
-                                                                                                {
-                                                                                                    "paymentSystem": "2",
-                                                                                                    "bin": null,
-                                                                                                    "paymentName": "Visa",
-                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
-                                                                                                    "value": 4200,
-                                                                                                    "installments": [
-                                                                                                        {
-                                                                                                            "count": 1,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 4200,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "count": 2,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 2100,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 2,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 2100,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "count": 3,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 1400,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 3,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 1400,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "count": 4,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 1050,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 4,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 1050,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        }
-                                                                                                    ]
-                                                                                                },
-                                                                                                {
-                                                                                                    "paymentSystem": "17",
-                                                                                                    "bin": null,
-                                                                                                    "paymentName": "Promissory",
-                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
-                                                                                                    "value": 4200,
-                                                                                                    "installments": [
-                                                                                                        {
-                                                                                                            "count": 1,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 4200,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        }
-                                                                                                    ]
-                                                                                                }
-                                                                                            ],
-                                                                                            "paymentSystems": [
-                                                                                                {
-                                                                                                    "id": 17,
-                                                                                                    "name": "Promissory",
-                                                                                                    "groupName": "promissoryPaymentGroup",
-                                                                                                    "validator": null,
-                                                                                                    "stringId": "17",
-                                                                                                    "template": "promissoryPaymentGroup-template",
-                                                                                                    "requiresDocument": false,
-                                                                                                    "isCustom": false,
-                                                                                                    "description": null,
-                                                                                                    "requiresAuthentication": false,
-                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
-                                                                                                    "availablePayments": null
-                                                                                                },
-                                                                                                {
-                                                                                                    "id": 2,
-                                                                                                    "name": "Visa",
-                                                                                                    "groupName": "creditCardPaymentGroup",
-                                                                                                    "validator": null,
-                                                                                                    "stringId": "2",
-                                                                                                    "template": "creditCardPaymentGroup-template",
-                                                                                                    "requiresDocument": false,
-                                                                                                    "isCustom": false,
-                                                                                                    "description": null,
-                                                                                                    "requiresAuthentication": false,
-                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
-                                                                                                    "availablePayments": null
-                                                                                                }
-                                                                                            ],
-                                                                                            "payments": [],
-                                                                                            "giftCards": [],
-                                                                                            "giftCardMessages": [],
-                                                                                            "availableAccounts": [],
-                                                                                            "availableTokens": []
-                                                                                        }
-                                                                                    }
-                                                                                ],
-                                                                                "required": [
-                                                                                    "DeliverySlaSamplesPerRegion",
-                                                                                    "Installments",
-                                                                                    "DiscountHighLight",
-                                                                                    "GiftSkuIds",
-                                                                                    "Teasers",
-                                                                                    "BuyTogether",
-                                                                                    "ItemMetadataAttachment",
-                                                                                    "Price",
-                                                                                    "ListPrice",
-                                                                                    "PriceWithoutDiscount",
-                                                                                    "RewardValue",
-                                                                                    "PriceValidUntil",
-                                                                                    "AvailableQuantity",
-                                                                                    "IsAvailable",
-                                                                                    "Tax",
-                                                                                    "SaleChannel",
-                                                                                    "DeliverySlaSamples",
-                                                                                    "GetInfoErrorMessage",
-                                                                                    "CacheVersionUsedToCallCheckout",
-                                                                                    "PaymentOptions"
-                                                                                ],
-                                                                                "properties": {
-                                                                                    "DeliverySlaSamplesPerRegion": {
-                                                                                        "type": "object",
-                                                                                        "title": "The DeliverySlaSamplesPerRegion schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": [
-                                                                                            {
-                                                                                                "0": {
-                                                                                                    "DeliverySlaPerTypes": [],
-                                                                                                    "Region": null
-                                                                                                }
-                                                                                            }
-                                                                                        ],
-                                                                                        "required": [
-                                                                                            "0"
-                                                                                        ],
-                                                                                        "properties": {
-                                                                                            "0": {
-                                                                                                "type": "object",
-                                                                                                "title": "The 0 schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": [
-                                                                                                    {
-                                                                                                        "DeliverySlaPerTypes": [],
-                                                                                                        "Region": null
-                                                                                                    }
-                                                                                                ],
-                                                                                                "required": [
-                                                                                                    "DeliverySlaPerTypes",
-                                                                                                    "Region"
-                                                                                                ],
-                                                                                                "properties": {
-                                                                                                    "DeliverySlaPerTypes": {
-                                                                                                        "type": "array",
-                                                                                                        "title": "The DeliverySlaPerTypes schema",
-                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                        "default": []
-                                                                                                    },
-                                                                                                    "Region": {
-                                                                                                        "type": "string",
-                                                                                                        "title": "The Region schema",
-                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                        "default": null
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                        }
-                                                                                    },
-                                                                                    "Installments": {
-                                                                                        "type": "array",
-                                                                                        "title": "The Installments schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": [
-                                                                                            [
-                                                                                                {
-                                                                                                    "Value": 42.0,
-                                                                                                    "InterestRate": 0.0,
-                                                                                                    "TotalValuePlusInterestRate": 42.0,
-                                                                                                    "NumberOfInstallments": 1,
-                                                                                                    "PaymentSystemName": "Visa",
-                                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                                    "Name": "Visa à vista"
-                                                                                                },
-                                                                                                {
-                                                                                                    "Value": 21.0,
-                                                                                                    "InterestRate": 0.0,
-                                                                                                    "TotalValuePlusInterestRate": 42.0,
-                                                                                                    "NumberOfInstallments": 2,
-                                                                                                    "PaymentSystemName": "Visa",
-                                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                                    "Name": "Visa 2 vezes sem juros"
-                                                                                                }
-                                                                                            ]
-                                                                                        ],
-                                                                                        "items": {
-                                                                                            "type": "object",
-                                                                                            "title": "The first anyOf schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                            "default": [
-                                                                                                {
-                                                                                                    "Value": 42.0,
-                                                                                                    "InterestRate": 0.0,
-                                                                                                    "TotalValuePlusInterestRate": 42.0,
-                                                                                                    "NumberOfInstallments": 1,
-                                                                                                    "PaymentSystemName": "Visa",
-                                                                                                    "PaymentSystemGroupName": "creditCardPaymentGroup",
-                                                                                                    "Name": "Visa à vista"
-                                                                                                }
-                                                                                            ],
-                                                                                            "required": [
-                                                                                                "Value",
-                                                                                                "InterestRate",
-                                                                                                "TotalValuePlusInterestRate",
-                                                                                                "NumberOfInstallments",
-                                                                                                "PaymentSystemName",
-                                                                                                "PaymentSystemGroupName",
-                                                                                                "Name"
-                                                                                            ],
-                                                                                            "properties": {
-                                                                                                "Value": {
-                                                                                                    "type": "number",
-                                                                                                    "title": "The Value schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": 42.0
-                                                                                                },
-                                                                                                "InterestRate": {
-                                                                                                    "type": "number",
-                                                                                                    "title": "The InterestRate schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": 0.0
-                                                                                                },
-                                                                                                "TotalValuePlusInterestRate": {
-                                                                                                    "type": "number",
-                                                                                                    "title": "The TotalValuePlusInterestRate schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": 42.0
-                                                                                                },
-                                                                                                "NumberOfInstallments": {
-                                                                                                    "type": "integer",
-                                                                                                    "title": "The NumberOfInstallments schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": 1
-                                                                                                },
-                                                                                                "PaymentSystemName": {
-                                                                                                    "type": "string",
-                                                                                                    "title": "The PaymentSystemName schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": "Visa"
-                                                                                                },
-                                                                                                "PaymentSystemGroupName": {
-                                                                                                    "type": "string",
-                                                                                                    "title": "The PaymentSystemGroupName schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": "creditCardPaymentGroup"
-                                                                                                },
-                                                                                                "Name": {
-                                                                                                    "type": "string",
-                                                                                                    "title": "The Name schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": "Visa à vista"
-                                                                                                }
-                                                                                            }
-                                                                                        }
-                                                                                    },
-                                                                                    "DiscountHighLight": {
-                                                                                        "type": "array",
-                                                                                        "title": "The DiscountHighLight schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": []
-                                                                                    },
-                                                                                    "GiftSkuIds": {
-                                                                                        "type": "array",
-                                                                                        "title": "The GiftSkuIds schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": []
-                                                                                    },
-                                                                                    "Teasers": {
-                                                                                        "type": "array",
-                                                                                        "title": "The Teasers schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": []
-                                                                                    },
-                                                                                    "BuyTogether": {
-                                                                                        "type": "array",
-                                                                                        "title": "The BuyTogether schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": []
-                                                                                    },
-                                                                                    "ItemMetadataAttachment": {
-                                                                                        "type": "array",
-                                                                                        "title": "The ItemMetadataAttachment schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": []
-                                                                                    },
-                                                                                    "Price": {
-                                                                                        "type": "number",
-                                                                                        "title": "The Price schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": 42.0
-                                                                                    },
-                                                                                    "ListPrice": {
-                                                                                        "type": "number",
-                                                                                        "title": "The ListPrice schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": 42.0
-                                                                                    },
-                                                                                    "PriceWithoutDiscount": {
-                                                                                        "type": "number",
-                                                                                        "title": "The PriceWithoutDiscount schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": 42.0
-                                                                                    },
-                                                                                    "RewardValue": {
-                                                                                        "type": "number",
-                                                                                        "title": "The RewardValue schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": 0.0
-                                                                                    },
-                                                                                    "PriceValidUntil": {
-                                                                                        "type": "string",
-                                                                                        "title": "The PriceValidUntil schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": "4000-01-01T03:00:00Z"
-                                                                                    },
-                                                                                    "AvailableQuantity": {
-                                                                                        "type": "integer",
-                                                                                        "title": "The AvailableQuantity schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": 16
-                                                                                    },
-                                                                                    "IsAvailable": {
-                                                                                        "type": "boolean",
-                                                                                        "title": "The IsAvailable schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": true
-                                                                                    },
-                                                                                    "Tax": {
-                                                                                        "type": "number",
-                                                                                        "title": "The Tax schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": 0.0
-                                                                                    },
-                                                                                    "SaleChannel": {
-                                                                                        "type": "integer",
-                                                                                        "title": "The SaleChannel schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": 0
-                                                                                    },
-                                                                                    "DeliverySlaSamples": {
-                                                                                        "type": "array",
-                                                                                        "title": "The DeliverySlaSamples schema",
-                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": [
-                                                                                            {
-                                                                                                "DeliverySlaPerTypes": [],
-                                                                                                "Region": null
-                                                                                            }
-                                                                                        ],
                                                                                         "items": {
                                                                                             "type": "object",
                                                                                             "title": "The first anyOf schema",
                                                                                             "description": "An explanation about the purpose of this instance.",
                                                                                             "default": {
-                                                                                                "DeliverySlaPerTypes": [],
-                                                                                                "Region": null
+                                                                                                "id": 17,
+                                                                                                "name": "Promissory",
+                                                                                                "groupName": "promissoryPaymentGroup",
+                                                                                                "validator": null,
+                                                                                                "stringId": "17",
+                                                                                                "template": "promissoryPaymentGroup-template",
+                                                                                                "requiresDocument": false,
+                                                                                                "isCustom": false,
+                                                                                                "description": null,
+                                                                                                "requiresAuthentication": false,
+                                                                                                "dueDate": "2021-07-01T18:43:00.0264384Z",
+                                                                                                "availablePayments": null
                                                                                             },
                                                                                             "required": [
-                                                                                                "DeliverySlaPerTypes",
-                                                                                                "Region"
+                                                                                                "id",
+                                                                                                "name",
+                                                                                                "groupName",
+                                                                                                "validator",
+                                                                                                "stringId",
+                                                                                                "template",
+                                                                                                "requiresDocument",
+                                                                                                "isCustom",
+                                                                                                "description",
+                                                                                                "requiresAuthentication",
+                                                                                                "dueDate",
+                                                                                                "availablePayments"
                                                                                             ],
                                                                                             "properties": {
-                                                                                                "DeliverySlaPerTypes": {
-                                                                                                    "type": "array",
-                                                                                                    "title": "The DeliverySlaPerTypes schema",
+                                                                                                "id": {
+                                                                                                    "type": "integer",
+                                                                                                    "title": "The id schema",
                                                                                                     "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": []
+                                                                                                    "default": 17
                                                                                                 },
-                                                                                                "Region": {
+                                                                                                "name": {
                                                                                                     "type": "string",
-                                                                                                    "title": "The Region schema",
+                                                                                                    "title": "The name schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "Promissory"
+                                                                                                },
+                                                                                                "groupName": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The groupName schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "promissoryPaymentGroup"
+                                                                                                },
+                                                                                                "validator": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The validator schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "stringId": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The stringId schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "17"
+                                                                                                },
+                                                                                                "template": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The template schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "promissoryPaymentGroup-template"
+                                                                                                },
+                                                                                                "requiresDocument": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "The requiresDocument schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "isCustom": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "The isCustom schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "description": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The description schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": null
+                                                                                                },
+                                                                                                "requiresAuthentication": {
+                                                                                                    "type": "boolean",
+                                                                                                    "title": "The requiresAuthentication schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": false
+                                                                                                },
+                                                                                                "dueDate": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The dueDate schema",
+                                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                                    "default": "2021-07-01T18:43:00.0264384Z"
+                                                                                                },
+                                                                                                "availablePayments": {
+                                                                                                    "type": "string",
+                                                                                                    "title": "The availablePayments schema",
                                                                                                     "description": "An explanation about the purpose of this instance.",
                                                                                                     "default": null
                                                                                                 }
                                                                                             }
                                                                                         }
                                                                                     },
-                                                                                    "GetInfoErrorMessage": {
-                                                                                        "type": "string",
-                                                                                        "title": "The GetInfoErrorMessage schema",
+                                                                                    "payments": {
+                                                                                        "type": "array",
+                                                                                        "title": "The payments schema",
                                                                                         "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": null
+                                                                                        "default": []
                                                                                     },
-                                                                                    "CacheVersionUsedToCallCheckout": {
-                                                                                        "type": "string",
-                                                                                        "title": "The CacheVersionUsedToCallCheckout schema",
+                                                                                    "giftCards": {
+                                                                                        "type": "array",
+                                                                                        "title": "The giftCards schema",
                                                                                         "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": "95EF7E5476DF276E679167A399FE3103_"
+                                                                                        "default": []
                                                                                     },
-                                                                                    "PaymentOptions": {
-                                                                                        "type": "object",
-                                                                                        "title": "The PaymentOptions schema",
+                                                                                    "giftCardMessages": {
+                                                                                        "type": "array",
+                                                                                        "title": "The giftCardMessages schema",
                                                                                         "description": "An explanation about the purpose of this instance.",
-                                                                                        "default": {
-                                                                                            "installmentOptions": [
-                                                                                                {
-                                                                                                    "paymentSystem": "2",
-                                                                                                    "bin": null,
-                                                                                                    "paymentName": "Visa",
-                                                                                                    "paymentGroupName": "creditCardPaymentGroup",
-                                                                                                    "value": 4200,
-                                                                                                    "installments": [
-                                                                                                        {
-                                                                                                            "count": 1,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 4200,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "count": 2,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 2100,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 2,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 2100,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "count": 3,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 1400,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 3,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 1400,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "count": 4,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 1050,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 4,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 1050,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        }
-                                                                                                    ]
-                                                                                                },
-                                                                                                {
-                                                                                                    "paymentSystem": "17",
-                                                                                                    "bin": null,
-                                                                                                    "paymentName": "Promissory",
-                                                                                                    "paymentGroupName": "promissoryPaymentGroup",
-                                                                                                    "value": 4200,
-                                                                                                    "installments": [
-                                                                                                        {
-                                                                                                            "count": 1,
-                                                                                                            "hasInterestRate": false,
-                                                                                                            "interestRate": 0,
-                                                                                                            "value": 4200,
-                                                                                                            "total": 4200,
-                                                                                                            "sellerMerchantInstallments": [
-                                                                                                                {
-                                                                                                                    "id": "MERCH",
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        }
-                                                                                                    ]
-                                                                                                }
-                                                                                            ],
-                                                                                            "paymentSystems": [
-                                                                                                {
-                                                                                                    "id": 17,
-                                                                                                    "name": "Promissory",
-                                                                                                    "groupName": "promissoryPaymentGroup",
-                                                                                                    "validator": null,
-                                                                                                    "stringId": "17",
-                                                                                                    "template": "promissoryPaymentGroup-template",
-                                                                                                    "requiresDocument": false,
-                                                                                                    "isCustom": false,
-                                                                                                    "description": null,
-                                                                                                    "requiresAuthentication": false,
-                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
-                                                                                                    "availablePayments": null
-                                                                                                },
-                                                                                                {
-                                                                                                    "id": 2,
-                                                                                                    "name": "Visa",
-                                                                                                    "groupName": "creditCardPaymentGroup",
-                                                                                                    "validator": null,
-                                                                                                    "stringId": "2",
-                                                                                                    "template": "creditCardPaymentGroup-template",
-                                                                                                    "requiresDocument": false,
-                                                                                                    "isCustom": false,
-                                                                                                    "description": null,
-                                                                                                    "requiresAuthentication": false,
-                                                                                                    "dueDate": "2021-07-01T18:43:00.0264384Z",
-                                                                                                    "availablePayments": null
-                                                                                                }
-                                                                                            ],
-                                                                                            "payments": [],
-                                                                                            "giftCards": [],
-                                                                                            "giftCardMessages": [],
-                                                                                            "availableAccounts": [],
-                                                                                            "availableTokens": []
-                                                                                        },
-                                                                                        "required": [
-                                                                                            "installmentOptions",
-                                                                                            "paymentSystems",
-                                                                                            "payments",
-                                                                                            "giftCards",
-                                                                                            "giftCardMessages",
-                                                                                            "availableAccounts",
-                                                                                            "availableTokens"
-                                                                                        ],
-                                                                                        "properties": {
-                                                                                            "installmentOptions": {
-                                                                                                "type": "array",
-                                                                                                "title": "The installmentOptions schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": [
-                                                                                                    [
-                                                                                                        {
-                                                                                                            "paymentSystem": "2",
-                                                                                                            "bin": null,
-                                                                                                            "paymentName": "Visa",
-                                                                                                            "paymentGroupName": "creditCardPaymentGroup",
-                                                                                                            "value": 4200,
-                                                                                                            "installments": [
-                                                                                                                {
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 1,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 4200,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    "count": 2,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 2100,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 2,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 2100,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    "count": 3,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 1400,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 3,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 1400,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    "count": 4,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 1050,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 4,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 1050,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "paymentSystem": "17",
-                                                                                                            "bin": null,
-                                                                                                            "paymentName": "Promissory",
-                                                                                                            "paymentGroupName": "promissoryPaymentGroup",
-                                                                                                            "value": 4200,
-                                                                                                            "installments": [
-                                                                                                                {
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 1,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 4200,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                }
-                                                                                                            ]
-                                                                                                        }
-                                                                                                    ]
-                                                                                                ],
-                                                                                                "items": {
-                                                                                                    "type": "object",
-                                                                                                    "title": "The first anyOf schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": {
-                                                                                                        "paymentSystem": "2",
-                                                                                                        "bin": null,
-                                                                                                        "paymentName": "Visa",
-                                                                                                        "paymentGroupName": "creditCardPaymentGroup",
-                                                                                                        "value": 4200,
-                                                                                                        "installments": [
-                                                                                                            {
-                                                                                                                "count": 1,
-                                                                                                                "hasInterestRate": false,
-                                                                                                                "interestRate": 0,
-                                                                                                                "value": 4200,
-                                                                                                                "total": 4200,
-                                                                                                                "sellerMerchantInstallments": [
-                                                                                                                    {
-                                                                                                                        "id": "MERCH",
-                                                                                                                        "count": 1,
-                                                                                                                        "hasInterestRate": false,
-                                                                                                                        "interestRate": 0,
-                                                                                                                        "value": 4200,
-                                                                                                                        "total": 4200
-                                                                                                                    }
-                                                                                                                ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                                "count": 2,
-                                                                                                                "hasInterestRate": false,
-                                                                                                                "interestRate": 0,
-                                                                                                                "value": 2100,
-                                                                                                                "total": 4200,
-                                                                                                                "sellerMerchantInstallments": [
-                                                                                                                    {
-                                                                                                                        "id": "MERCH",
-                                                                                                                        "count": 2,
-                                                                                                                        "hasInterestRate": false,
-                                                                                                                        "interestRate": 0,
-                                                                                                                        "value": 2100,
-                                                                                                                        "total": 4200
-                                                                                                                    }
-                                                                                                                ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                                "count": 3,
-                                                                                                                "hasInterestRate": false,
-                                                                                                                "interestRate": 0,
-                                                                                                                "value": 1400,
-                                                                                                                "total": 4200,
-                                                                                                                "sellerMerchantInstallments": [
-                                                                                                                    {
-                                                                                                                        "id": "MERCH",
-                                                                                                                        "count": 3,
-                                                                                                                        "hasInterestRate": false,
-                                                                                                                        "interestRate": 0,
-                                                                                                                        "value": 1400,
-                                                                                                                        "total": 4200
-                                                                                                                    }
-                                                                                                                ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                                "count": 4,
-                                                                                                                "hasInterestRate": false,
-                                                                                                                "interestRate": 0,
-                                                                                                                "value": 1050,
-                                                                                                                "total": 4200,
-                                                                                                                "sellerMerchantInstallments": [
-                                                                                                                    {
-                                                                                                                        "id": "MERCH",
-                                                                                                                        "count": 4,
-                                                                                                                        "hasInterestRate": false,
-                                                                                                                        "interestRate": 0,
-                                                                                                                        "value": 1050,
-                                                                                                                        "total": 4200
-                                                                                                                    }
-                                                                                                                ]
-                                                                                                            }
-                                                                                                        ]
-                                                                                                    },
-                                                                                                    "required": [
-                                                                                                        "paymentSystem",
-                                                                                                        "bin",
-                                                                                                        "paymentName",
-                                                                                                        "paymentGroupName",
-                                                                                                        "value",
-                                                                                                        "installments"
-                                                                                                    ],
-                                                                                                    "properties": {
-                                                                                                        "paymentSystem": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The paymentSystem schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "2"
-                                                                                                        },
-                                                                                                        "bin": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The bin schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": null
-                                                                                                        },
-                                                                                                        "paymentName": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The paymentName schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "Visa"
-                                                                                                        },
-                                                                                                        "paymentGroupName": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The paymentGroupName schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "creditCardPaymentGroup"
-                                                                                                        },
-                                                                                                        "value": {
-                                                                                                            "type": "integer",
-                                                                                                            "title": "The value schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": 4200
-                                                                                                        },
-                                                                                                        "installments": {
-                                                                                                            "type": "array",
-                                                                                                            "title": "The installments schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": [
-                                                                                                                {
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 1,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 4200,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    "count": 2,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 2100,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 2,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 2100,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                }
-                                                                                                            ],
-                                                                                                            "items": {
-                                                                                                                "type": "object",
-                                                                                                                "title": "The first anyOf schema",
-                                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                                "default": {
-                                                                                                                    "count": 1,
-                                                                                                                    "hasInterestRate": false,
-                                                                                                                    "interestRate": 0,
-                                                                                                                    "value": 4200,
-                                                                                                                    "total": 4200,
-                                                                                                                    "sellerMerchantInstallments": [
-                                                                                                                        {
-                                                                                                                            "id": "MERCH",
-                                                                                                                            "count": 1,
-                                                                                                                            "hasInterestRate": false,
-                                                                                                                            "interestRate": 0,
-                                                                                                                            "value": 4200,
-                                                                                                                            "total": 4200
-                                                                                                                        }
-                                                                                                                    ]
-                                                                                                                },
-                                                                                                                "required": [
-                                                                                                                    "count",
-                                                                                                                    "hasInterestRate",
-                                                                                                                    "interestRate",
-                                                                                                                    "value",
-                                                                                                                    "total",
-                                                                                                                    "sellerMerchantInstallments"
-                                                                                                                ],
-                                                                                                                "properties": {
-                                                                                                                    "count": {
-                                                                                                                        "type": "integer",
-                                                                                                                        "title": "The count schema",
-                                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                                        "default": 1
-                                                                                                                    },
-                                                                                                                    "hasInterestRate": {
-                                                                                                                        "type": "boolean",
-                                                                                                                        "title": "The hasInterestRate schema",
-                                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                                        "default": false
-                                                                                                                    },
-                                                                                                                    "interestRate": {
-                                                                                                                        "type": "integer",
-                                                                                                                        "title": "The interestRate schema",
-                                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                                        "default": 0
-                                                                                                                    },
-                                                                                                                    "value": {
-                                                                                                                        "type": "integer",
-                                                                                                                        "title": "The value schema",
-                                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                                        "default": 4200
-                                                                                                                    },
-                                                                                                                    "total": {
-                                                                                                                        "type": "integer",
-                                                                                                                        "title": "The total schema",
-                                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                                        "default": 4200
-                                                                                                                    },
-                                                                                                                    "sellerMerchantInstallments": {
-                                                                                                                        "type": "array",
-                                                                                                                        "title": "The sellerMerchantInstallments schema",
-                                                                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                                                                        "default": [
-                                                                                                                            {
-                                                                                                                                "id": "MERCH",
-                                                                                                                                "count": 1,
-                                                                                                                                "hasInterestRate": false,
-                                                                                                                                "interestRate": 0,
-                                                                                                                                "value": 4200,
-                                                                                                                                "total": 4200
-                                                                                                                            }
-                                                                                                                        ],
-                                                                                                                        "items": {
-                                                                                                                            "type": "object",
-                                                                                                                            "title": "The first anyOf schema",
-                                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                                            "default": {
-                                                                                                                                "id": "MERCH",
-                                                                                                                                "count": 1,
-                                                                                                                                "hasInterestRate": false,
-                                                                                                                                "interestRate": 0,
-                                                                                                                                "value": 4200,
-                                                                                                                                "total": 4200
-                                                                                                                            },
-                                                                                                                            "required": [
-                                                                                                                                "id",
-                                                                                                                                "count",
-                                                                                                                                "hasInterestRate",
-                                                                                                                                "interestRate",
-                                                                                                                                "value",
-                                                                                                                                "total"
-                                                                                                                            ],
-                                                                                                                            "properties": {
-                                                                                                                                "id": {
-                                                                                                                                    "type": "string",
-                                                                                                                                    "title": "The id schema",
-                                                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                                                    "default": "MERCH"
-                                                                                                                                },
-                                                                                                                                "count": {
-                                                                                                                                    "type": "integer",
-                                                                                                                                    "title": "The count schema",
-                                                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                                                    "default": 1
-                                                                                                                                },
-                                                                                                                                "hasInterestRate": {
-                                                                                                                                    "type": "boolean",
-                                                                                                                                    "title": "The hasInterestRate schema",
-                                                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                                                    "default": false
-                                                                                                                                },
-                                                                                                                                "interestRate": {
-                                                                                                                                    "type": "integer",
-                                                                                                                                    "title": "The interestRate schema",
-                                                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                                                    "default": 0
-                                                                                                                                },
-                                                                                                                                "value": {
-                                                                                                                                    "type": "integer",
-                                                                                                                                    "title": "The value schema",
-                                                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                                                    "default": 4200
-                                                                                                                                },
-                                                                                                                                "total": {
-                                                                                                                                    "type": "integer",
-                                                                                                                                    "title": "The total schema",
-                                                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                                                    "default": 4200
-                                                                                                                                }
-                                                                                                                            }
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            },
-                                                                                            "paymentSystems": {
-                                                                                                "type": "array",
-                                                                                                "title": "The paymentSystems schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": [
-                                                                                                    {
-                                                                                                        "id": 17,
-                                                                                                        "name": "Promissory",
-                                                                                                        "groupName": "promissoryPaymentGroup",
-                                                                                                        "validator": null,
-                                                                                                        "stringId": "17",
-                                                                                                        "template": "promissoryPaymentGroup-template",
-                                                                                                        "requiresDocument": false,
-                                                                                                        "isCustom": false,
-                                                                                                        "description": null,
-                                                                                                        "requiresAuthentication": false,
-                                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
-                                                                                                        "availablePayments": null
-                                                                                                    },
-                                                                                                    {
-                                                                                                        "id": 2,
-                                                                                                        "name": "Visa",
-                                                                                                        "groupName": "creditCardPaymentGroup",
-                                                                                                        "validator": null,
-                                                                                                        "stringId": "2",
-                                                                                                        "template": "creditCardPaymentGroup-template",
-                                                                                                        "requiresDocument": false,
-                                                                                                        "isCustom": false,
-                                                                                                        "description": null,
-                                                                                                        "requiresAuthentication": false,
-                                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
-                                                                                                        "availablePayments": null
-                                                                                                    }
-                                                                                                ],
-                                                                                                "items": {
-                                                                                                    "type": "object",
-                                                                                                    "title": "The first anyOf schema",
-                                                                                                    "description": "An explanation about the purpose of this instance.",
-                                                                                                    "default": {
-                                                                                                        "id": 17,
-                                                                                                        "name": "Promissory",
-                                                                                                        "groupName": "promissoryPaymentGroup",
-                                                                                                        "validator": null,
-                                                                                                        "stringId": "17",
-                                                                                                        "template": "promissoryPaymentGroup-template",
-                                                                                                        "requiresDocument": false,
-                                                                                                        "isCustom": false,
-                                                                                                        "description": null,
-                                                                                                        "requiresAuthentication": false,
-                                                                                                        "dueDate": "2021-07-01T18:43:00.0264384Z",
-                                                                                                        "availablePayments": null
-                                                                                                    },
-                                                                                                    "required": [
-                                                                                                        "id",
-                                                                                                        "name",
-                                                                                                        "groupName",
-                                                                                                        "validator",
-                                                                                                        "stringId",
-                                                                                                        "template",
-                                                                                                        "requiresDocument",
-                                                                                                        "isCustom",
-                                                                                                        "description",
-                                                                                                        "requiresAuthentication",
-                                                                                                        "dueDate",
-                                                                                                        "availablePayments"
-                                                                                                    ],
-                                                                                                    "properties": {
-                                                                                                        "id": {
-                                                                                                            "type": "integer",
-                                                                                                            "title": "The id schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": 17
-                                                                                                        },
-                                                                                                        "name": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The name schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "Promissory"
-                                                                                                        },
-                                                                                                        "groupName": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The groupName schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "promissoryPaymentGroup"
-                                                                                                        },
-                                                                                                        "validator": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The validator schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": null
-                                                                                                        },
-                                                                                                        "stringId": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The stringId schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "17"
-                                                                                                        },
-                                                                                                        "template": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The template schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "promissoryPaymentGroup-template"
-                                                                                                        },
-                                                                                                        "requiresDocument": {
-                                                                                                            "type": "boolean",
-                                                                                                            "title": "The requiresDocument schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": false
-                                                                                                        },
-                                                                                                        "isCustom": {
-                                                                                                            "type": "boolean",
-                                                                                                            "title": "The isCustom schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": false
-                                                                                                        },
-                                                                                                        "description": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The description schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": null
-                                                                                                        },
-                                                                                                        "requiresAuthentication": {
-                                                                                                            "type": "boolean",
-                                                                                                            "title": "The requiresAuthentication schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": false
-                                                                                                        },
-                                                                                                        "dueDate": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The dueDate schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": "2021-07-01T18:43:00.0264384Z"
-                                                                                                        },
-                                                                                                        "availablePayments": {
-                                                                                                            "type": "string",
-                                                                                                            "title": "The availablePayments schema",
-                                                                                                            "description": "An explanation about the purpose of this instance.",
-                                                                                                            "default": null
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            },
-                                                                                            "payments": {
-                                                                                                "type": "array",
-                                                                                                "title": "The payments schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": []
-                                                                                            },
-                                                                                            "giftCards": {
-                                                                                                "type": "array",
-                                                                                                "title": "The giftCards schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": []
-                                                                                            },
-                                                                                            "giftCardMessages": {
-                                                                                                "type": "array",
-                                                                                                "title": "The giftCardMessages schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": []
-                                                                                            },
-                                                                                            "availableAccounts": {
-                                                                                                "type": "array",
-                                                                                                "title": "The availableAccounts schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": []
-                                                                                            },
-                                                                                            "availableTokens": {
-                                                                                                "type": "array",
-                                                                                                "title": "The availableTokens schema",
-                                                                                                "description": "An explanation about the purpose of this instance.",
-                                                                                                "default": []
-                                                                                            }
-                                                                                        }
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableAccounts": {
+                                                                                        "type": "array",
+                                                                                        "title": "The availableAccounts schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": []
+                                                                                    },
+                                                                                    "availableTokens": {
+                                                                                        "type": "array",
+                                                                                        "title": "The availableTokens schema",
+                                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                                        "default": []
                                                                                     }
                                                                                 }
                                                                             }
                                                                         }
                                                                     }
-                                                                ]
+                                                                }
                                                             }
                                                         },
                                                         "Videos": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -1349,7 +1349,7 @@
                                                         "sellers": {
                                                             "type": "array",
                                                             "title": "sellers",
-                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "description": "Array of SKU sellers.",
                                                             "default": [
                                                                 [
                                                                     {
@@ -1830,7 +1830,7 @@
                                                                     "addToCartLink": {
                                                                         "type": "string",
                                                                         "title": "addToCartLink",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "description": "URL to add the product to the cart.",
                                                                         "default": "https://merch.vtexcommercestable.com.br/checkout/cart/add?sku=310118469&qty=1&seller=1&sc=1&price=4200&cv=95EF7E5476DF276E679167A399FE3103_&sc=1"
                                                                     },
                                                                     "sellerDefault": {
@@ -2092,7 +2092,7 @@
                                                                                 "default": {
                                                                                     "0": {
                                                                                         "DeliverySlaPerTypes": [],
-                                                                                        "Region": null
+                                                                                        "Region": "null"
                                                                                     }
                                                                                 },
                                                                                 "properties": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -18,7 +18,7 @@
 				"tags": [
 					"CrossSelling"
 				],
-				"summary": "ProductSearch Who Saw Also Saw",
+				"summary": "Get Product Search of *Who Saw Also Saw*",
 				"description": "Retrieves general information about other related products that the users also saw",
 				"operationId": "ProductSearchWhoSawAlsoSaw",
 				"parameters": [

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -12857,10 +12857,10 @@
 						}
 					}, {
 						"name": "_from",
-						"in": "header",
+						"in": "query",
 						"description": "Starter page range. These parameters allow the API to be paginated. Take into account that the initial and final pages cannot have a separation superior to 50 pages. Thus, it will be displayed 50 items per page.",
 						"required": false,
-						"style": "simple",
+						"style": "form",
 						"schema": {
 							"type": "string",
                             "default": "1"
@@ -12868,10 +12868,10 @@
                     },
                     {
 						"name": "_to",
-						"in": "header",
+						"in": "query",
 						"description": "Finisher page range. These parameters allow the API to be paginated. Take into account that the initial and final pages cannot have a separation superior to 50 pages. Thus, it will be displayed 50 items per page.",
 						"required": false,
-						"style": "simple",
+						"style": "form",
 						"schema": {
 							"type": "string",
                             "default": "50"
@@ -12896,7 +12896,7 @@
 						"style": "form",
 						"schema": {
 							"type": "string",
-                            "default": ""
+                            "default": "C:/1000041/1000049/"
 						}
 					},
                     {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -2129,10 +2129,9 @@
                                                                             },
                                                                             "Installments": {
                                                                                 "type": "array",
-                                                                                "title": "The Installments schema",
-                                                                                "description": "An explanation about the purpose of this instance.",
+                                                                                "title": "Installments",
+                                                                                "description": "Installments options.",
                                                                                 "default": [
-                                                                                    [
                                                                                         {
                                                                                             "Value": 42.0,
                                                                                             "InterestRate": 0.0,
@@ -2151,12 +2150,10 @@
                                                                                             "PaymentSystemGroupName": "creditCardPaymentGroup",
                                                                                             "Name": "Visa 2 vezes sem juros"
                                                                                         }
-                                                                                    ]
                                                                                 ],
                                                                                 "items": {
                                                                                     "type": "object",
-                                                                                    "title": "The first anyOf schema",
-                                                                                    "description": "An explanation about the purpose of this instance.",
+                                                                                    "title": "",
                                                                                     "default": [
                                                                                         {
                                                                                             "Value": 42.0,
@@ -2180,44 +2177,44 @@
                                                                                     "properties": {
                                                                                         "Value": {
                                                                                             "type": "number",
-                                                                                            "title": "The Value schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "Value",
+                                                                                            "description": "Value of the installment.",
                                                                                             "default": 42.0
                                                                                         },
                                                                                         "InterestRate": {
                                                                                             "type": "number",
-                                                                                            "title": "The InterestRate schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "InterestRate",
+                                                                                            "description": "Interest rate of the installment.",
                                                                                             "default": 0.0
                                                                                         },
                                                                                         "TotalValuePlusInterestRate": {
                                                                                             "type": "number",
-                                                                                            "title": "The TotalValuePlusInterestRate schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "TotalValuePlusInterestRate",
+                                                                                            "description": "Total value plus interest rate of the installment.",
                                                                                             "default": 42.0
                                                                                         },
                                                                                         "NumberOfInstallments": {
                                                                                             "type": "integer",
-                                                                                            "title": "The NumberOfInstallments schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "NumberOfInstallments",
+                                                                                            "description": "Number of the installment.",
                                                                                             "default": 1
                                                                                         },
                                                                                         "PaymentSystemName": {
                                                                                             "type": "string",
-                                                                                            "title": "The PaymentSystemName schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "PaymentSystemName",
+                                                                                            "description": "Payment system name of the installment.",
                                                                                             "default": "Visa"
                                                                                         },
                                                                                         "PaymentSystemGroupName": {
                                                                                             "type": "string",
-                                                                                            "title": "The PaymentSystemGroupName schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "PaymentSystemGroupName",
+                                                                                            "description": "Payment system group name of the installment.",
                                                                                             "default": "creditCardPaymentGroup"
                                                                                         },
                                                                                         "Name": {
                                                                                             "type": "string",
-                                                                                            "title": "The Name schema",
-                                                                                            "description": "An explanation about the purpose of this instance.",
+                                                                                            "title": "Name",
+                                                                                            "description": "Name of the installment.",
                                                                                             "default": "Visa à vista"
                                                                                         }
                                                                                     }

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19278,375 +19278,932 @@
 				"responses": {
 					"200": {
 						"description": "",
-						"headers": {
-							"Cache-Control": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "no-cache"
-									}
-								}
-							},
-							"Connection": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "keep-alive"
-									}
-								}
-							},
-							"Content-Encoding": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "gzip"
-									}
-								}
-							},
-							"Content-Length": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "553"
-									}
-								}
-							},
-							"Date": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Wed, 15 Feb 2017 15:31:27 GMT"
-									}
-								}
-							},
-							"Expires": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "-1"
-									}
-								}
-							},
-							"Pragma": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "no-cache"
-									}
-								}
-							},
-							"Server": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "nginx"
-									}
-								}
-							},
-							"Vary": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "Accept-Encoding"
-									}
-								}
-							},
-							"X-CacheServer": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "janus-apicache-nginx11"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.3.9"
-									}
-								}
-							},
-							"X-Powered-by-VTEX-Janus-Edge": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "v1.35.3"
-									}
-								}
-							},
-							"X-Track": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "stable"
-									}
-								}
-							},
-							"X-VTEX-Cache-Status-Janus-ApiCache": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "MISS"
-									}
-								}
-							},
-							"X-VTEX-Cache-Status-Janus-Edge": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "MISS"
-									}
-								}
-							},
-							"X-VTEX-Janus-Router-Backend-App": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "prtapi-v1.4.683-stable+527"
-									}
-								}
-							},
-							"no": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "-QTBJG9KGSVN"
-									}
-								}
-							},
-							"p3p": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "policyref=\"/w3c/p3p.xml\",CP=\"ADMa OUR NOR CNT NID DSP NOI COR\""
-									}
-								}
-							},
-							"powered": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "vtex"
-									}
-								}
-							},
-							"x-vtex-operation-id": {
-								"content": {
-									"text/plain": {
-										"schema": {
-											"type": "string"
-										},
-										"example": "4c21ffb0-1523-49b6-8d4a-cdac56bd6ff6"
-									}
-								}
-							}
-						},
 						"content": {
-							"application/json; charset=utf-8": {
+							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Example2"
-								},
+                                    "type": "object",
+                                    "title": "",
+                                    "required": [
+                                        "Departments",
+                                        "Brands",
+                                        "SpecificationFilters",
+                                        "CategoriesTrees",
+                                        "PriceRanges",
+                                        "Summary"
+                                    ],
+                                    "properties": {
+                                        "Departments": {
+                                            "type": "array",
+                                            "title": "Departments",
+                                            "description": "Array of general information about the categories.",
+                                            "default":  [
+                                                {
+                                                    "Quantity": 2,
+                                                    "Position": null,
+                                                    "Name": "Beers Beers Mesmo",
+                                                    "Link": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "LinkEncoded": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "Map": "c",
+                                                    "Value": "Beers-Beers-Mesmo"
+                                                },
+                                                {
+                                                    "Quantity": 2,
+                                                    "Position": null,
+                                                    "Name": "Merch Integration Category ||",
+                                                    "Link": "/Merch-Integration-Category-||/1?map=c,b",
+                                                    "LinkEncoded": "/Merch-Integration-Category-%7C%7C/1?map=c,b",
+                                                    "Map": "c",
+                                                    "Value": "Merch-Integration-Category-||"
+                                                }
+                                            ],
+                                            "items": {
+                                                "type": "object",
+                                                "title": "",
+                                                "default": {
+                                                    "Quantity": 2,
+                                                    "Position": null,
+                                                    "Name": "Beers Beers Mesmo",
+                                                    "Link": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "LinkEncoded": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "Map": "c",
+                                                    "Value": "Beers-Beers-Mesmo"
+                                                },
+                                                "required": [
+                                                    "Quantity",
+                                                    "Position",
+                                                    "Name",
+                                                    "Link",
+                                                    "LinkEncoded",
+                                                    "Map",
+                                                    "Value"
+                                                ],
+                                                "properties": {
+                                                    "Quantity": {
+                                                        "type": "integer",
+                                                        "title": "Quantity",
+                                                        "description": "Quantity of facets.",
+                                                        "default": 2
+                                                    },
+                                                    "Position": {
+                                                        "title": "Position",
+                                                        "type": "integer",
+                                                        "description": "Position of the facets.",
+                                                        "default": 1
+                                                    },
+                                                    "Name": {
+                                                        "type": "string",
+                                                        "title": "Name",
+                                                        "description": "Category name.",
+                                                        "default": "Beers Beers Mesmo"
+                                                    },
+                                                    "Link": {
+                                                        "type": "string",
+                                                        "title": "Link",
+                                                        "description": "Link of the facet.",
+                                                        "default": "/Beers-Beers-Mesmo/1?map=c,b"
+                                                    },
+                                                    "LinkEncoded": {
+                                                        "type": "string",
+                                                        "title": "LinkEncoded",
+                                                        "description": "Encoded link of the facet.",
+                                                        "default": "/Beers-Beers-Mesmo/1?map=c,b"
+                                                    },
+                                                    "Map": {
+                                                        "type": "string",
+                                                        "title": "Map",
+                                                        "description": "Mapping of the facet.",
+                                                        "default": "c"
+                                                    },
+                                                    "Value": {
+                                                        "type": "string",
+                                                        "title": "Value",
+                                                        "description": "Value of the facet.",
+                                                        "default": "Beers-Beers-Mesmo"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "Brands": {
+                                            "type": "array",
+                                            "title": "Brands",
+                                            "description": "Array of general information about the brands.",
+                                            "default": [
+                                                {
+                                                    "Quantity": 2,
+                                                    "Position": null,
+                                                    "Name": "Merch XP",
+                                                    "Link": "/1/1234600/1/Merch-XP?map=c,c,b,b",
+                                                    "LinkEncoded": "/1/1234600/1/Merch-XP?map=c,c,b,b",
+                                                    "Map": "b",
+                                                    "Value": "Merch-XP"
+                                                },
+                                                {
+                                                    "Quantity": 2,
+                                                    "Position": null,
+                                                    "Name": "Zé",
+                                                    "Link": "/1/1234600/1/Ze?map=c,c,b,b",
+                                                    "LinkEncoded": "/1/1234600/1/Ze?map=c,c,b,b",
+                                                    "Map": "b",
+                                                    "Value": "Ze"
+                                                }
+                                            ],
+                                            "items": {
+                                                "type": "object",
+                                                "default": {
+                                                    "Quantity": 2,
+                                                    "Position": null,
+                                                    "Name": "Merch XP",
+                                                    "Link": "/1/1234600/1/Merch-XP?map=c,c,b,b",
+                                                    "LinkEncoded": "/1/1234600/1/Merch-XP?map=c,c,b,b",
+                                                    "Map": "b",
+                                                    "Value": "Merch-XP"
+                                                },
+                                                "required": [
+                                                    "Quantity",
+                                                    "Position",
+                                                    "Name",
+                                                    "Link",
+                                                    "LinkEncoded",
+                                                    "Map",
+                                                    "Value"
+                                                ],
+                                                "properties": {
+                                                    "Quantity": {
+                                                        "type": "integer",
+                                                        "title": "Quantity",
+                                                        "description": "Quantity of facets.",
+                                                        "default": 2
+                                                    },
+                                                    "Position": {
+                                                        "type": "integer",
+                                                        "title": "Position",
+                                                        "description": "Position of the facet.",
+                                                        "default": 1
+                                                    },
+                                                    "Name": {
+                                                        "type": "string",
+                                                        "title": "Name",
+                                                        "description": "Brand name.",
+                                                        "default": "Merch XP"
+                                                    },
+                                                    "Link": {
+                                                        "type": "string",
+                                                        "title": "Link",
+                                                        "description": "Link of the facet.",
+                                                        "default": "/1/1234600/1/Merch-XP?map=c,c,b,b"
+                                                    },
+                                                    "LinkEncoded": {
+                                                        "type": "string",
+                                                        "title": "LinkEncoded",
+                                                        "description": "Enconded link of the facet.",
+                                                        "default": "/1/1234600/1/Merch-XP?map=c,c,b,b"
+                                                    },
+                                                    "Map": {
+                                                        "type": "string",
+                                                        "title": "Map",
+                                                        "description": "Mapping of the facet.",
+                                                        "default": "b"
+                                                    },
+                                                    "Value": {
+                                                        "type": "string",
+                                                        "title": "Value",
+                                                        "description": "Value of the facet.",
+                                                        "default": "Merch-XP"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "SpecificationFilters": {
+                                            "type": "object",
+                                            "title": "SpecificationFilters",
+                                            "description": "Object with general information of specifications.",
+                                            "default": {}
+                                        },
+                                        "CategoriesTrees": {
+                                            "type": "array",
+                                            "title": "CategoriesTrees",
+                                            "description": "Array of the category tree.",
+                                            "default": [
+                                                {
+                                                    "Id": 1,
+                                                    "Quantity": 4,
+                                                    "Position": null,
+                                                    "Name": "Beers Beers Mesmo",
+                                                    "Link": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "LinkEncoded": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "Map": "c",
+                                                    "Value": "Beers-Beers-Mesmo",
+                                                    "Children": [
+                                                        {
+                                                            "Id": 2,
+                                                            "Quantity": 1,
+                                                            "Position": null,
+                                                            "Name": "Lager Beers",
+                                                            "Link": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                            "LinkEncoded": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                            "Map": "c",
+                                                            "Value": "Lager-Beers",
+                                                            "Children": []
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "Id": 1234571,
+                                                    "Quantity": 2,
+                                                    "Position": null,
+                                                    "Name": "Jogos",
+                                                    "Link": "/Jogos/1?map=c,b",
+                                                    "LinkEncoded": "/Jogos/1?map=c,b",
+                                                    "Map": "c",
+                                                    "Value": "Jogos",
+                                                    "Children": []
+                                                }
+                                            ],
+                                            "items": {
+                                                "type": "object",
+                                                "default": {
+                                                    "Id": 1,
+                                                    "Quantity": 4,
+                                                    "Position": null,
+                                                    "Name": "Beers Beers Mesmo",
+                                                    "Link": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "LinkEncoded": "/Beers-Beers-Mesmo/1?map=c,b",
+                                                    "Map": "c",
+                                                    "Value": "Beers-Beers-Mesmo",
+                                                    "Children": [
+                                                        {
+                                                            "Id": 2,
+                                                            "Quantity": 1,
+                                                            "Position": null,
+                                                            "Name": "Lager Beers",
+                                                            "Link": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                            "LinkEncoded": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                            "Map": "c",
+                                                            "Value": "Lager-Beers",
+                                                            "Children": []
+                                                        }
+                                                    ]
+                                                },
+                                                "required": [
+                                                    "Id",
+                                                    "Quantity",
+                                                    "Position",
+                                                    "Name",
+                                                    "Link",
+                                                    "LinkEncoded",
+                                                    "Map",
+                                                    "Value",
+                                                    "Children"
+                                                ],
+                                                "properties": {
+                                                    "Id": {
+                                                        "type": "integer",
+                                                        "title": "Id",
+                                                        "description": "Category ID.",
+                                                        "default": 1
+                                                    },
+                                                    "Quantity": {
+                                                        "type": "integer",
+                                                        "title": "Quantity",
+                                                        "description": "Quantity of the facets.",
+                                                        "default": 4
+                                                    },
+                                                    "Position": {
+                                                        "type": "integer",
+                                                        "title": "Position",
+                                                        "description": "Position of the facet.",
+                                                        "default": 1
+                                                    },
+                                                    "Name": {
+                                                        "type": "string",
+                                                        "title": "Name",
+                                                        "description": "Category name.",
+                                                        "default": "Beers Beers Mesmo"
+                                                    },
+                                                    "Link": {
+                                                        "type": "string",
+                                                        "title": "Link",
+                                                        "description": "Link of the facet.",
+                                                        "default": "/Beers-Beers-Mesmo/1?map=c,b"
+                                                    },
+                                                    "LinkEncoded": {
+                                                        "type": "string",
+                                                        "title": "LinkEncoded",
+                                                        "description": "Encoded link of the facet.",
+                                                        "default": "/Beers-Beers-Mesmo/1?map=c,b"
+                                                    },
+                                                    "Map": {
+                                                        "type": "string",
+                                                        "title": "Map",
+                                                        "description": "Mapping of the facet.",
+                                                        "default": "c"
+                                                    },
+                                                    "Value": {
+                                                        "type": "string",
+                                                        "title": "Value",
+                                                        "description": "Value of the facet.",
+                                                        "default": "Beers-Beers-Mesmo"
+                                                    },
+                                                    "Children": {
+                                                        "type": "array",
+                                                        "title": "Children",
+                                                        "description": "Category children.",
+                                                        "default": [
+                                                            {
+                                                                "Id": 2,
+                                                                "Quantity": 1,
+                                                                "Position": null,
+                                                                "Name": "Lager Beers",
+                                                                "Link": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                                "LinkEncoded": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                                "Map": "c",
+                                                                "Value": "Lager-Beers",
+                                                                "Children": []
+                                                            }
+                                                        ],
+                                                        "items": {
+                                                            "type": "object",
+                                                            "default": {
+                                                                "Id": 2,
+                                                                "Quantity": 1,
+                                                                "Position": null,
+                                                                "Name": "Lager Beers",
+                                                                "Link": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                                "LinkEncoded": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                                "Map": "c",
+                                                                "Value": "Lager-Beers",
+                                                                "Children": []
+                                                            },
+                                                            "required": [
+                                                                "Id",
+                                                                "Quantity",
+                                                                "Position",
+                                                                "Name",
+                                                                "Link",
+                                                                "LinkEncoded",
+                                                                "Map",
+                                                                "Value",
+                                                                "Children"
+                                                            ],
+                                                            "properties": {
+                                                                "Id": {
+                                                                    "type": "integer",
+                                                                    "title": "Id",
+                                                                    "description": "Category ID.",
+                                                                    "default": 1
+                                                                },
+                                                                "Quantity": {
+                                                                    "type": "integer",
+                                                                    "title": "Quantity",
+                                                                    "description": "Quantity of the facets.",
+                                                                    "default": 4
+                                                                },
+                                                                "Position": {
+                                                                    "type": "integer",
+                                                                    "title": "Position",
+                                                                    "description": "Position of the facet.",
+                                                                    "default": 1
+                                                                },
+                                                                "Name": {
+                                                                    "type": "string",
+                                                                    "title": "Name",
+                                                                    "description": "Category name.",
+                                                                    "default": "Beers Beers Mesmo"
+                                                                },
+                                                                "Link": {
+                                                                    "type": "string",
+                                                                    "title": "Link",
+                                                                    "description": "Link of the facet.",
+                                                                    "default": "/Beers-Beers-Mesmo/1?map=c,b"
+                                                                },
+                                                                "LinkEncoded": {
+                                                                    "type": "string",
+                                                                    "title": "LinkEncoded",
+                                                                    "description": "Encoded link of the facet.",
+                                                                    "default": "/Beers-Beers-Mesmo/1?map=c,b"
+                                                                },
+                                                                "Map": {
+                                                                    "type": "string",
+                                                                    "title": "Map",
+                                                                    "description": "Mapping of the facet.",
+                                                                    "default": "c"
+                                                                },
+                                                                "Value": {
+                                                                    "type": "string",
+                                                                    "title": "Value",
+                                                                    "description": "Value of the facet.",
+                                                                    "default": "Beers-Beers-Mesmo"
+                                                                },
+                                                                "Children": {
+                                                                    "type": "array",
+                                                                    "title": "Children",
+                                                                    "description": "Category children.",
+                                                                    "default": [
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "PriceRanges": {
+                                            "type": "array",
+                                            "title": "PriceRanges",
+                                            "description": "Array with general information of the price ranges.",
+                                            "default": []
+                                        },
+                                        "Summary": {
+                                            "type": "object",
+                                            "title": "Summary",
+                                            "description": "Summary of the facets.",
+                                            "default": {
+                                                "Departments": {
+                                                    "DisplayedItems": 8,
+                                                    "TotalItems": 8
+                                                },
+                                                "CategoriesTrees": {
+                                                    "DisplayedItems": 13,
+                                                    "TotalItems": 13
+                                                },
+                                                "Brands": {
+                                                    "DisplayedItems": 10,
+                                                    "TotalItems": 10
+                                                },
+                                                "PriceRanges": {
+                                                    "DisplayedItems": 0,
+                                                    "TotalItems": 0
+                                                },
+                                                "SpecificationFilters": {}
+                                            },
+                                            "required": [
+                                                "Departments",
+                                                "CategoriesTrees",
+                                                "Brands",
+                                                "PriceRanges",
+                                                "SpecificationFilters"
+                                            ],
+                                            "properties": {
+                                                "Departments": {
+                                                    "type": "object",
+                                                    "title": "Departments",
+                                                    "description": "Departments' quantity of displayed and total items.",
+                                                    "default": {
+                                                        "DisplayedItems": 8,
+                                                        "TotalItems": 8
+                                                    },
+                                                    "required": [
+                                                        "DisplayedItems",
+                                                        "TotalItems"
+                                                    ],
+                                                    "properties": {
+                                                        "DisplayedItems": {
+                                                            "type": "integer",
+                                                            "title": "DisplayedItems",
+                                                            "description": "Quantity of displayed items.",
+                                                            "default": 8
+                                                        },
+                                                        "TotalItems": {
+                                                            "type": "integer",
+                                                            "title": "TotalItems",
+                                                            "description": "Quantity of total items.",
+                                                            "default": 8
+                                                        }
+                                                    }
+                                                },
+                                                "CategoriesTrees": {
+                                                    "type": "object",
+                                                    "title": "CategoriesTrees",
+                                                    "description": "Category tree's quantity of displayed and total items.",
+                                                    "default": {
+                                                        "DisplayedItems": 13,
+                                                        "TotalItems": 13
+                                                    },
+                                                    "required": [
+                                                        "DisplayedItems",
+                                                        "TotalItems"
+                                                    ],
+                                                    "properties": {
+                                                        "DisplayedItems": {
+                                                            "type": "integer",
+                                                            "title": "DisplayedItems",
+                                                            "description": "Quantity of displayed items.",
+                                                            "default": 13
+                                                        },
+                                                        "TotalItems": {
+                                                            "type": "integer",
+                                                            "title": "TotalItems",
+                                                            "description": "Quantity of total items.",
+                                                            "default": 13
+                                                        }
+                                                    }
+                                                },
+                                                "Brands": {
+                                                    "type": "object",
+                                                    "title": "Brands",
+                                                    "description": "Brands' quantity of displayed and total items.",
+                                                    "default": {
+                                                        "DisplayedItems": 10,
+                                                        "TotalItems": 10
+                                                    },
+                                                    "required": [
+                                                        "DisplayedItems",
+                                                        "TotalItems"
+                                                    ],
+                                                    "properties": {
+                                                        "DisplayedItems": {
+                                                            "type": "integer",
+                                                            "title": "DisplayedItems",
+                                                            "description": "Quantity of displayed items.",
+                                                            "default": 10
+                                                        },
+                                                        "TotalItems": {
+                                                            "type": "integer",
+                                                            "title": "TotalItems",
+                                                            "description": "Quantity of total items.",
+                                                            "default": 10
+                                                        }
+                                                    }
+                                                },
+                                                "PriceRanges": {
+                                                    "type": "object",
+                                                    "title": "PriceRanges",
+                                                    "description": "Price ranges' quantity of displayed and total items.",
+                                                    "default": {
+                                                        "DisplayedItems": 0,
+                                                        "TotalItems": 0
+                                                    },
+                                                    "required": [
+                                                        "DisplayedItems",
+                                                        "TotalItems"
+                                                    ],
+                                                    "properties": {
+                                                        "DisplayedItems": {
+                                                            "type": "integer",
+                                                            "title": "DisplayedItems",
+                                                            "description": "Quantity of displayed items.",
+                                                            "default": 0
+                                                        },
+                                                        "TotalItems": {
+                                                            "type": "integer",
+                                                            "title": "TotalItems",
+                                                            "description": "Quantity of total items.",
+                                                            "default": 0
+                                                        }
+                                                    }
+                                                },
+                                                "SpecificationFilters": {
+                                                    "type": "object",
+                                                    "title": "SpecificationFilters",
+                                                    "description": "Specification filters' quantity of displayed and total items.",
+                                                    "default": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
 								"example": {
-									"Departments": [
-										{
-											"Quantity": 20,
-											"Name": "Eletro-Eletronicos",
-											"Link": "/Eletro-Eletronicos"
-										}
-									],
-									"Brands": [
-										{
-											"Quantity": 1,
-											"Name": "Philips",
-											"Link": "/eletronicos/tv/Philips"
-										},
-										{
-											"Quantity": 5,
-											"Name": "Samsung",
-											"Link": "/eletronicos/tv/Samsung"
-										},
-										{
-											"Quantity": 6,
-											"Name": "Philco",
-											"Link": "/eletronicos/tv/Philco"
-										},
-										{
-											"Quantity": 2,
-											"Name": "AOC",
-											"Link": "/eletronicos/tv/AOC"
-										},
-										{
-											"Quantity": 1,
-											"Name": "Semp",
-											"Link": "/eletronicos/tv/Semp"
-										},
-										{
-											"Quantity": 2,
-											"Name": "Toshiba",
-											"Link": "/eletronicos/tv/Toshiba"
-										},
-										{
-											"Quantity": 3,
-											"Name": "TCL",
-											"Link": "/eletronicos/tv/TCL"
-										}
-									],
-									"SpecificationFilters": {
-										"Resolução": [
-											{
-												"Quantity": 10,
-												"Name": "Full-HD",
-												"Link": "/eletronicos/tv/Full-HD?map=c,c,specificationFilter_73"
-											},
-											{
-												"Quantity": 7,
-												"Name": "HD-Ready",
-												"Link": "/eletronicos/tv/HD-Ready?map=c,c,specificationFilter_73"
-											},
-											{
-												"Quantity": 2,
-												"Name": "Ultra-HD",
-												"Link": "/eletronicos/tv/Ultra-HD?map=c,c,specificationFilter_73"
-											}
-										],
-										"Tamanho da Tela": [
-											{
-												"Quantity": 3,
-												"Name": "Acima de 51 pol.",
-												"Link": "/eletronicos/tv/Acima de 51 pol.?map=c,c,specificationFilter_74"
-											},
-											{
-												"Quantity": 1,
-												"Name": "Até 19 pol.",
-												"Link": "/eletronicos/tv/Até 19 pol.?map=c,c,specificationFilter_74"
-											},
-											{
-												"Quantity": 2,
-												"Name": "De 20 a 29 pol.",
-												"Link": "/eletronicos/tv/De 20 a 29 pol.?map=c,c,specificationFilter_74"
-											},
-											{
-												"Quantity": 5,
-												"Name": "De 30 a 39 pol.",
-												"Link": "/eletronicos/tv/De 30 a 39 pol.?map=c,c,specificationFilter_74"
-											},
-											{
-												"Quantity": 8,
-												"Name": "De 40 a 51 pol.",
-												"Link": "/eletronicos/tv/De 40 a 51 pol.?map=c,c,specificationFilter_74"
-											}
-										],
-										"Aplicativos de TV": [
-											{
-												"Quantity": 4,
-												"Name": "Crackle",
-												"Link": "/eletronicos/tv/Crackle?map=c,c,specificationFilter_1517"
-											},
-											{
-												"Quantity": 12,
-												"Name": "NetFlix",
-												"Link": "/eletronicos/tv/NetFlix?map=c,c,specificationFilter_1517"
-											},
-											{
-												"Quantity": 4,
-												"Name": "NetMovies",
-												"Link": "/eletronicos/tv/NetMovies?map=c,c,specificationFilter_1517"
-											},
-											{
-												"Quantity": 4,
-												"Name": "Vimeo",
-												"Link": "/eletronicos/tv/Vimeo?map=c,c,specificationFilter_1517"
-											},
-											{
-												"Quantity": 13,
-												"Name": "YouTube",
-												"Link": "/eletronicos/tv/YouTube?map=c,c,specificationFilter_1517"
-											}
-										]
-									},
-									"CategoriesTrees": [
-										{
-											"Quantity": 20,
-											"Name": "Eletrônicos",
-											"Link": "/Eletronicos",
-											"Children": [
-												{
-													"Quantity": 20,
-													"Name": "TV",
-													"Link": "/Eletronicos/TV",
-													"Children": [
-														{
-															"Quantity": 6,
-															"Name": "TV LED",
-															"Link": "/Eletronicos/TV/TV-LED",
-															"Children": []
-														},
-														{
-															"Quantity": 14,
-															"Name": "Smart TV",
-															"Link": "/Eletronicos/TV/Smart-TV",
-															"Children": []
-														}
-													]
-												}
-											]
-										}
-									]
-								}
+                                    "Departments": [
+                                        {
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Beers Beers Mesmo",
+                                            "Link": "/Beers-Beers-Mesmo/1?map=c,b",
+                                            "LinkEncoded": "/Beers-Beers-Mesmo/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Beers-Beers-Mesmo"
+                                        },
+                                        {
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Merch Integration Category ||",
+                                            "Link": "/Merch-Integration-Category-||/1?map=c,b",
+                                            "LinkEncoded": "/Merch-Integration-Category-%7C%7C/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Merch-Integration-Category-||"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Jogos",
+                                            "Link": "/Jogos/1?map=c,b",
+                                            "LinkEncoded": "/Jogos/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Jogos"
+                                        },
+                                        {
+                                            "Quantity": 3,
+                                            "Position": null,
+                                            "Name": "189",
+                                            "Link": "/189/1?map=c,b",
+                                            "LinkEncoded": "/189/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "189"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Tests",
+                                            "Link": "/Tests/1?map=c,b",
+                                            "LinkEncoded": "/Tests/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Tests"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Accessories",
+                                            "Link": "/Accessories/1?map=c,b",
+                                            "LinkEncoded": "/Accessories/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Accessories"
+                                        },
+                                        {
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Bars",
+                                            "Link": "/Bars/1?map=c,b",
+                                            "LinkEncoded": "/Bars/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Bars"
+                                        },
+                                        {
+                                            "Quantity": 5,
+                                            "Position": null,
+                                            "Name": "Categoria Teste Timeout",
+                                            "Link": "/Categoria-Teste-Timeout/1?map=c,b",
+                                            "LinkEncoded": "/Categoria-Teste-Timeout/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Categoria-Teste-Timeout"
+                                        }
+                                    ],
+                                    "Brands": [
+                                        {
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Merch XP",
+                                            "Link": "/1/1234600/1/Merch-XP?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Merch-XP?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Merch-XP"
+                                        },
+                                        {
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Zé",
+                                            "Link": "/1/1234600/1/Ze?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Ze?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Ze"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Odin",
+                                            "Link": "/1/1234600/1/Odin?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Odin?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Odin"
+                                        },
+                                        {
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Hoegaarden",
+                                            "Link": "/1/1234600/1/Hoegaarden?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Hoegaarden?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Hoegaarden"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Teste marcas",
+                                            "Link": "/1/1234600/1/Teste-marcas?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Teste-marcas?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Teste-marcas"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Bitmap Bureau",
+                                            "Link": "/1/1234600/1/Bitmap-Bureau?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Bitmap-Bureau?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Bitmap-Bureau"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Sega",
+                                            "Link": "/1/1234600/1/Sega?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Sega?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Sega"
+                                        },
+                                        {
+                                            "Quantity": 3,
+                                            "Position": null,
+                                            "Name": "Technogym",
+                                            "Link": "/1/1234600/1/Technogym?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Technogym?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Technogym"
+                                        },
+                                        {
+                                            "Quantity": 3,
+                                            "Position": null,
+                                            "Name": "Aptany",
+                                            "Link": "/1/1234600/1/Aptany?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Aptany?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Aptany"
+                                        },
+                                        {
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Tectoy",
+                                            "Link": "/1/1234600/1/Tectoy?map=c,c,b,b",
+                                            "LinkEncoded": "/1/1234600/1/Tectoy?map=c,c,b,b",
+                                            "Map": "b",
+                                            "Value": "Tectoy"
+                                        }
+                                    ],
+                                    "SpecificationFilters": {},
+                                    "CategoriesTrees": [
+                                        {
+                                            "Id": 1,
+                                            "Quantity": 4,
+                                            "Position": null,
+                                            "Name": "Beers Beers Mesmo",
+                                            "Link": "/Beers-Beers-Mesmo/1?map=c,b",
+                                            "LinkEncoded": "/Beers-Beers-Mesmo/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Beers-Beers-Mesmo",
+                                            "Children": [
+                                                {
+                                                    "Id": 2,
+                                                    "Quantity": 1,
+                                                    "Position": null,
+                                                    "Name": "Lager Beers",
+                                                    "Link": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                    "LinkEncoded": "/Beers-Beers-Mesmo/Lager-Beers/1?map=c,c,b",
+                                                    "Map": "c",
+                                                    "Value": "Lager-Beers",
+                                                    "Children": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Id": 1234571,
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Jogos",
+                                            "Link": "/Jogos/1?map=c,b",
+                                            "LinkEncoded": "/Jogos/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Jogos",
+                                            "Children": []
+                                        },
+                                        {
+                                            "Id": 1234579,
+                                            "Quantity": 3,
+                                            "Position": null,
+                                            "Name": "189",
+                                            "Link": "/189/1?map=c,b",
+                                            "LinkEncoded": "/189/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "189",
+                                            "Children": []
+                                        },
+                                        {
+                                            "Id": 1234587,
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Tests",
+                                            "Link": "/Tests/1?map=c,b",
+                                            "LinkEncoded": "/Tests/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Tests",
+                                            "Children": []
+                                        },
+                                        {
+                                            "Id": 1234595,
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Accessories",
+                                            "Link": "/Accessories/1?map=c,b",
+                                            "LinkEncoded": "/Accessories/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Accessories",
+                                            "Children": [
+                                                {
+                                                    "Id": 1234596,
+                                                    "Quantity": 1,
+                                                    "Position": null,
+                                                    "Name": "Foam rollers",
+                                                    "Link": "/Accessories/Foam-rollers/1?map=c,c,b",
+                                                    "LinkEncoded": "/Accessories/Foam-rollers/1?map=c,c,b",
+                                                    "Map": "c",
+                                                    "Value": "Foam-rollers",
+                                                    "Children": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Id": 1234597,
+                                            "Quantity": 2,
+                                            "Position": null,
+                                            "Name": "Bars",
+                                            "Link": "/Bars/1?map=c,b",
+                                            "LinkEncoded": "/Bars/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Bars",
+                                            "Children": [
+                                                {
+                                                    "Id": 1234598,
+                                                    "Quantity": 1,
+                                                    "Position": null,
+                                                    "Name": "Training Bars",
+                                                    "Link": "/Bars/Training-Bars/1?map=c,c,b",
+                                                    "LinkEncoded": "/Bars/Training-Bars/1?map=c,c,b",
+                                                    "Map": "c",
+                                                    "Value": "Training-Bars",
+                                                    "Children": []
+                                                },
+                                                {
+                                                    "Id": 1234599,
+                                                    "Quantity": 1,
+                                                    "Position": null,
+                                                    "Name": "Curl Bars",
+                                                    "Link": "/Bars/Curl-Bars/1?map=c,c,b",
+                                                    "LinkEncoded": "/Bars/Curl-Bars/1?map=c,c,b",
+                                                    "Map": "c",
+                                                    "Value": "Curl-Bars",
+                                                    "Children": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Id": 15,
+                                            "Quantity": 1,
+                                            "Position": null,
+                                            "Name": "Coronas",
+                                            "Link": "/Coronas/1?map=c,b",
+                                            "LinkEncoded": "/Coronas/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Coronas",
+                                            "Children": [
+                                                {
+                                                    "Id": 13,
+                                                    "Quantity": 1,
+                                                    "Position": null,
+                                                    "Name": "não tem limite!",
+                                                    "Link": "/Coronas/nao-tem-limite-/1?map=c,c,b",
+                                                    "LinkEncoded": "/Coronas/nao-tem-limite-/1?map=c,c,b",
+                                                    "Map": "c",
+                                                    "Value": "nao-tem-limite-",
+                                                    "Children": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Id": 4,
+                                            "Quantity": 4,
+                                            "Position": null,
+                                            "Name": "Merch Integration Category ||",
+                                            "Link": "/Merch-Integration-Category-||/1?map=c,b",
+                                            "LinkEncoded": "/Merch-Integration-Category-%7C%7C/1?map=c,b",
+                                            "Map": "c",
+                                            "Value": "Merch-Integration-Category-||",
+                                            "Children": []
+                                        }
+                                    ],
+                                    "PriceRanges": [],
+                                    "Summary": {
+                                        "Departments": {
+                                            "DisplayedItems": 8,
+                                            "TotalItems": 8
+                                        },
+                                        "CategoriesTrees": {
+                                            "DisplayedItems": 13,
+                                            "TotalItems": 13
+                                        },
+                                        "Brands": {
+                                            "DisplayedItems": 10,
+                                            "TotalItems": 10
+                                        },
+                                        "PriceRanges": {
+                                            "DisplayedItems": 0,
+                                            "TotalItems": 0
+                                        },
+                                        "SpecificationFilters": {}
+                                    }
+                                }
 							}
 						}
 					}
-				},
-				"deprecated": false,
-				"servers": [
-					{
-						"url": "http://example.com/.{environment}.com.br",
-						"variables": {
-							"environment": {
-								"default": "DefaultParameterValue"
-							}
-						}
-					}
-				]
+				}
 			}
 		},
 		"/api/catalog_system/pub/facets/search/{categoryName}/{specificationValue}": {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -1214,40 +1214,35 @@
                                                         },
                                                         "unitMultiplier": {
                                                             "type": "number",
-                                                            "title": "The unitMultiplier schema",
-                                                            "description": "An explanation about the purpose of this instance.",
-                                                            "default": [
-                                                                1.0
-                                                            ]
+                                                            "title": "unitMultiplier",
+                                                            "description": "numerical unit that multiplies the selected quantity of the product when it is inserted in the cart.",
+                                                            "default": 1.0
                                                         },
                                                         "modalType": {
                                                             "type": "string",
-                                                            "title": "The modalType schema",
-                                                            "description": "An explanation about the purpose of this instance.",
-                                                            "default": ""
+                                                            "title": "modalType",
+                                                            "description": "Modal Type.",
+                                                            "default": "Modal Type test"
                                                         },
                                                         "isKit": {
                                                             "type": "boolean",
-                                                            "title": "The isKit schema",
+                                                            "title": "isKit",
                                                             "description": "An explanation about the purpose of this instance.",
                                                             "default": true
                                                         },
                                                         "kitItems": {
                                                             "type": "array",
-                                                            "title": "The kitItems schema",
-                                                            "description": "An explanation about the purpose of this instance.",
+                                                            "title": "kitItems",
+                                                            "description": "Array with information of SKUs components from a Kit.",
                                                             "default": [
-                                                                [
                                                                     {
                                                                         "itemId": "310118466",
                                                                         "amount": 6
                                                                     }
-                                                                ]
-                                                            ],
+                                                                ],
                                                             "items": {
                                                                 "type": "object",
-                                                                "title": "The first anyOf schema",
-                                                                "description": "An explanation about the purpose of this instance.",
+                                                                "title": "",
                                                                 "default": {
                                                                     "itemId": "310118466",
                                                                     "amount": 6
@@ -1259,19 +1254,17 @@
                                                                 "properties": {
                                                                     "itemId": {
                                                                         "type": "string",
-                                                                        "title": "The itemId schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
+                                                                        "title": "itemId",
+                                                                        "description": "SKU kit component ID.",
                                                                         "default": [
                                                                             "310118466"
                                                                         ]
                                                                     },
                                                                     "amount": {
                                                                         "type": "integer",
-                                                                        "title": "The amount schema",
-                                                                        "description": "An explanation about the purpose of this instance.",
-                                                                        "default": [
-                                                                            6
-                                                                        ]
+                                                                        "title": "amount",
+                                                                        "description": "Amount of the SKU component in the kit.",
+                                                                        "default": 6
                                                                     }
                                                                 }
                                                             }

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -19141,7 +19141,7 @@
 						"style": "simple",
 						"schema": {
 							"type": "string",
-                            "default": "1"
+                            "default": "3"
 						}
 					},
                     {

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -9371,7 +9371,7 @@
 				],
 				"summary": "Get Product Search of Show Together",
 				"description": "Retrieves general information about the products that are show together with the product in question.",
-				"operationId": "ProductSearchAccessories",
+				"operationId": "ProductSearchShowTogether",
 				"parameters": [
                     {
                         "name": "accountName",

--- a/VTEX - Search API.json
+++ b/VTEX - Search API.json
@@ -12810,8 +12810,8 @@
 				"tags": [
 					"Search"
 				],
-				"summary": "ProductSearch Filtered and Ordered",
-				"description": "",
+				"summary": "Search for Products with Filter, Order and Pagination",
+                "description": "Retrives general information about the store products. This information can be filtered and ordered by a number of options. It also can be pagineted, filtered and ordered.",
 				"operationId": "ProductSearchFilteredandOrdered",
 				"parameters": [
                     {
@@ -12854,6 +12854,60 @@
 						"schema": {
 							"type": "string",
 							"example": "application/json"
+						}
+					}, {
+						"name": "_from",
+						"in": "header",
+						"description": "Starter page range. These parameters allow the API to be paginated. Take into account that the initial and final pages cannot have a separation superior to 50 pages. Thus, it will be displayed 50 items per page.",
+						"required": false,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+                            "default": "1"
+						}
+                    },
+                    {
+						"name": "_to",
+						"in": "header",
+						"description": "Finisher page range. These parameters allow the API to be paginated. Take into account that the initial and final pages cannot have a separation superior to 50 pages. Thus, it will be displayed 50 items per page.",
+						"required": false,
+						"style": "simple",
+						"schema": {
+							"type": "string",
+                            "default": "50"
+						}
+					},
+                    {
+						"name": "ft",
+						"in": "query",
+						"description": "Filter by full text. The form is`ft={searchWord}`",
+						"required": false,
+						"style": "form",
+						"schema": {
+							"type": "string",
+                            "default": "television"
+						}
+					},
+                    {
+						"name": "fq",
+						"in": "query",
+						"description": "General filter. It can be by category (`fq=C:/{a}/{b}`), by specification (`fq=specificationFilter_{a}:{b}`),  by price range (`fq=P:[{a} TO {b}]`), by collection (`fq=productClusterIds:{{productClusterId}}`), by product ID (`fq=productId:{{productId}}`),  by SKU ID (`fq=skuId:{{skuId}}`), by Reference ID (`fq=alternateIds_RefId:{{referenceId}}`), by EAN13 (`fq=alternateIds_Ean:{{ean13}}`), by availability at a specific sales channel (`fq=isAvailablePerSalesChannel_{{sc}}:{{bool}}`), by available at a specific seller (`fq=sellerId:{{sellerId}}`)",
+						"required": false,
+						"style": "form",
+						"schema": {
+							"type": "string",
+                            "default": ""
+						}
+					},
+                    {
+						"name": "O",
+						"in": "query",
+						"description": "Sorting method. It can be by Price (`O=OrderByPriceDESC` or `O=OrderByPriceASC`), by Top Selling Products (`O=OrderByTopSaleDESC`), by Best Reviews (`O=OrderByReviewRateDESC`), by Name (`O=OrderByNameASC` or `O=OrderByNameDESC`), by Release Date (`O=OrderByReleaseDateDESC`), by Best Discounts (`O=OrderByBestDiscountDESC`), by Score (`O=OrderByScoreDESC`)",
+						"required": false,
+						"style": "form",
+						"schema": {
+							"type": "string",
+                            "default": "OrderByNameASC"
 						}
 					}
 				],


### PR DESCRIPTION
#### Types of changes
- [X] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Atualização geral da Search API

[Preview](https://preview.readme.io/ProductSearchWhoSawAlsoSaw?url=https%3A%2F%2Fraw.githubusercontent.com%2Fvtex%2Fopenapi-schemas%2FEDU-3990-Add-IsAvailable-flag-on-Search-docs%2FVTEX+-+Search+API.json)

[EDU-3990](https://vtex-dev.atlassian.net/browse/EDU-3990)
