### PR TITLE
Correct gift card hub credentials

### DIFF
--- a/VTEX - GiftCard Hub API.json
+++ b/VTEX - GiftCard Hub API.json
@@ -76,25 +76,25 @@
 						}
 					},
 				{
-					"name": "X-PROVIDER-API-AppKey",
+					"name": "X-VTEX-API-AppKey",
 					"in": "header",
-					"description": "The AppKey configured by the merchant (optional configuration)",
+                    "description": "VTEX API AppKey",
 					"required": true,
 					"style": "simple",
 					"schema": {
 						"type": "string",
-						"default": "{{X-PROVIDER-API-AppKey}}"
+						"default": "{{X-VTEX-API-AppKey}}"
 					}
 				},
 				{
-					"name": "X-PROVIDER-API-AppToken",
+					"name": "X-VTEX-API-AppToken",
 					"in": "header",
-					"description": "The AppToken configured by the merchant (optional configuration)",
+					"description": "VTEX API AppToken",
 					"required": true,
 					"style": "simple",
 					"schema": {
 						"type": "string",
-						"default": "{{X-PROVIDER-API-AppToken}}"
+						"default": "{{X-VTEX-API-AppToken}}"
 					}
 				}
 				],
@@ -167,25 +167,25 @@
 						}
 					},
 				{
-					"name": "X-PROVIDER-API-AppKey",
+					"name": "X-VTEX-API-AppKey",
 					"in": "header",
-					"description": "The AppKey configured by the merchant (optional configuration)",
+					"description": "VTEX API AppKey",
 					"required": true,
 					"style": "simple",
 					"schema": {
 						"type": "string",
-						"default": "{{X-PROVIDER-API-AppKey}}"
+						"default": "{{X-VTEX-API-AppKey}}"
 					}
 				},
 				{
-					"name": "X-PROVIDER-API-AppToken",
+					"name": "X-VTEX-API-AppToken",
 					"in": "header",
-					"description": "The AppToken configured by the merchant (optional configuration)",
+					"description": "VTEX API AppToken",
 					"required": true,
 					"style": "simple",
 					"schema": {
 						"type": "string",
-						"default": "{{X-PROVIDER-API-AppToken}}"
+						"default": "{{X-VTEX-API-AppToken}}"
 					}
 				},
 					{
@@ -271,25 +271,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -387,25 +387,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -491,25 +491,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -613,25 +613,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -762,25 +762,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -874,25 +874,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -984,25 +984,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -1162,25 +1162,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -1285,25 +1285,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -1408,25 +1408,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -1667,25 +1667,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{
@@ -1788,25 +1788,25 @@
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppKey",
+						"name": "X-VTEX-API-AppKey",
 						"in": "header",
-						"description": "The AppKey configured by the merchant (optional configuration)",
+						"description": "VTEX API AppKey",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppKey}}"
+							"default": "{{X-VTEX-API-AppKey}}"
 						}
 					},
 					{
-						"name": "X-PROVIDER-API-AppToken",
+						"name": "X-VTEX-API-AppToken",
 						"in": "header",
-						"description": "The AppToken configured by the merchant (optional configuration)",
+						"description": "VTEX API AppToken",
 						"required": true,
 						"style": "simple",
 						"schema": {
 							"type": "string",
-							"default": "{{X-PROVIDER-API-AppToken}}"
+							"default": "{{X-VTEX-API-AppToken}}"
 						}
 					},
 					{

--- a/VTEX - GiftCard Hub API.json
+++ b/VTEX - GiftCard Hub API.json
@@ -1888,17 +1888,29 @@
 				"type": "object",
 				"properties": {
 					"serviceUrl": {
-						"type": "string"
+						"type": "string",
+                        "description": "URL from the provider"
 					},
 					"oauthProvider": {
-						"type": "string"
+						"type": "string",
+                        "description": "Provider's authentication"
 					},
 					"preAuthEnabled": {
-						"type": "boolean"
+						"type": "boolean",
+                        "description": "Related to the pre-authorization that can happen on the transaction generated through the provider"
 					},
 					"cancelEnabled": {
-						"type": "boolean"
-					}
+						"type": "boolean",
+                        "description": "It says if it is possible to cancel the transaction, generated through the provider"
+					},
+                    "appKey": {
+                        "type": "string",
+                        "description": "Credential provided by the merchant that VTEX will use for identification"
+                    },
+                    "appToken": {
+                        "type": "string",
+                        "description": "Credential provided by the merchant that VTEX will use for identification"
+                    }
 				},
 				"default": {
 					"serviceUrl": "https://api.vtex.com.br/example",


### PR DESCRIPTION
#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Modifications for the issue [EDU-5514](https://vtex-dev.atlassian.net/browse/EDU-5514) Feedback #1660:
- Changed `X-PROVIDER-API` headers to `X-VTEX-API` and their description, since the authorization credentials are used by VTEX, and not by the provider.
- Added `appkey` and `apptoken` body parameters of **Create/Update GiftCard Provider by ID** endpoint
- Added description to body parameters of **Create/Update GiftCard Provider by ID** endpoint