### PR TITLE
Update VTEX - Marketplace Protocol.json

### DIFF
--- a/VTEX - Marketplace Protocol.json
+++ b/VTEX - Marketplace Protocol.json
@@ -2607,7 +2607,7 @@
                             "allowsRemap"
                         ],
                         "type": "object",
-                        "description": "",
+                        "description": "Refers to the `allowsRemap` property.",
                         "items": {
                             "type": "object",
                             "properties": {

--- a/VTEX - Marketplace Protocol.json
+++ b/VTEX - Marketplace Protocol.json
@@ -2606,7 +2606,7 @@
                         "required": [
                             "allowsRemap"
                         ],
-                        "type": "array",
+                        "type": "object",
                         "description": "",
                         "items": {
                             "type": "object",
@@ -2614,11 +2614,6 @@
                                 "allowsRemap": {
                                     "type": "boolean",
                                     "description": "Allows rempaping categories in case the marketplace or seller tree is altered. If marked as `true`, all trees will be remapped.",
-                                    "example": false
-                                },
-                                "allowsRemapParent": {
-                                    "type": "boolean",
-                                    "description": "Allows rempaping parent categories in case the marketplace or seller tree is altered. If marked as `true`, all trees will be remapped",
                                     "example": false
                                 }
                             }


### PR DESCRIPTION
The "properties" object is not an array; and the "allowsRemapParent" property doesn't exist.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [x] No, but I am going to.

Accordingly to the product team, the "properties" object is not an array. And the "allowsRemapParent" property doesn't exist.