### PR TITLE
Removing `onBehalfOf` parameter from all endpoints

### DIFF
--- a/VTEX - Profile System.json
+++ b/VTEX - Profile System.json
@@ -264,9 +264,6 @@
                         "$ref": "#/components/parameters/reason"
                     },
                     {
-                        "$ref": "#/components/parameters/onBehalfOf"
-                    },
-                    {
                         "$ref": "#/components/parameters/alternateKey"
                     }
                 ],
@@ -384,9 +381,6 @@
                     },
                     {
                         "$ref": "#/components/parameters/reason"
-                    },
-                    {
-                        "$ref": "#/components/parameters/onBehalfOf"
                     },
                     {
                         "$ref": "#/components/parameters/alternateKey"
@@ -810,9 +804,6 @@
                         "$ref": "#/components/parameters/reason"
                     },
                     {
-                        "$ref": "#/components/parameters/onBehalfOf"
-                    },
-                    {
                         "$ref": "#/components/parameters/alternateKey"
                     }
                 ],
@@ -939,9 +930,6 @@
                     },
                     {
                         "$ref": "#/components/parameters/reason"
-                    },
-                    {
-                        "$ref": "#/components/parameters/onBehalfOf"
                     },
                     {
                         "$ref": "#/components/parameters/alternateKey"
@@ -1136,9 +1124,6 @@
                     },
                     {
                         "$ref": "#/components/parameters/reason"
-                    },
-                    {
-                        "$ref": "#/components/parameters/onBehalfOf"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
The `onBehalfOf` query parameter is not meant for external use. I removed it from all endpoints' reference but kept it in the components section, in case we need to use it in the future.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
