### PR TITLE
Add Catalog API response bodies: subcollection + collection

### DIFF
--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -8898,7 +8898,7 @@
                     "SKU Subcollection"
                 ],
                 "summary": "Add SKU to Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single SKU to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"SkuId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"SkuId\": 1\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single SKU to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"SkuId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"SkuId\": 1\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -8991,7 +8991,7 @@
                     "SKU Subcollection"
                 ],
                 "summary": "Delete SKU from Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes an SKU from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes an SKU from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -11495,7 +11495,7 @@
                     "Category Subcollection"
                 ],
                 "summary": "Associate Category to Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Category to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CategoryId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"CategoryId\": 1\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Category to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CategoryId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"CategoryId\": 1\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -11589,7 +11589,7 @@
                     "Category Subcollection"
                 ],
                 "summary": "Delete Category from Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Category from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Category from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -12682,7 +12682,7 @@
                     "Brand Subcollection"
                 ],
                 "summary": "Associate Brand to Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Brand to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"BrandId\": 2000000\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"BrandId\": 2000000\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Brand to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"BrandId\": 2000000\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"BrandId\": 2000000\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -12775,7 +12775,7 @@
                     "Brand Subcollection"
                 ],
                 "summary": "Delete Brand from Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Brand from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Brand from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -13810,7 +13810,7 @@
                     "Collection"
                 ],
                 "summary": "Get Collection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves general information of a Collection.\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves general information of a Collection.\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -13920,7 +13920,7 @@
                     "Collection"
                 ],
                 "summary": "Update Collection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"Name\": \"Winter\",\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\"\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"Name\": \"Winter\",\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\"\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14080,7 +14080,7 @@
                     "Collection"
                 ],
                 "summary": "Delete Collection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously existing Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously existing Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14128,7 +14128,7 @@
                     "Collection"
                 ],
                 "summary": "Create Collection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"Name\": \"Winter\",\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\"\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"Name\": \"Winter\",\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\"\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14280,7 +14280,7 @@
                     "Subcollection"
                 ],
                 "summary": "Get Subcollection by Collection ID",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves all Subcollections given a Collection ID. A Subcollection is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n[\r\n    {\r\n        \"Id\": 12,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Subcollection\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": true\r\n    },\r\n    {\r\n        \"Id\": 13,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Test\",\r\n        \"Type\": \"Exclusive\",\r\n        \"PreSale\": true,\r\n        \"Release\": false\r\n    },\r\n    {\r\n        \"Id\": 14,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"asdfghj\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": false\r\n    }\r\n]\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves all Subcollections given a Collection ID. A Subcollection is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n[\r\n    {\r\n        \"Id\": 12,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Subcollection\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": true\r\n    },\r\n    {\r\n        \"Id\": 13,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Test\",\r\n        \"Type\": \"Exclusive\",\r\n        \"PreSale\": true,\r\n        \"Release\": false\r\n    },\r\n    {\r\n        \"Id\": 14,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"asdfghj\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": false\r\n    }\r\n]\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14383,7 +14383,7 @@
                     "Subcollection"
                 ],
                 "summary": "Get Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves information about a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves information about a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14471,7 +14471,7 @@
                     "Subcollection"
                 ],
                 "summary": "Update Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n\r\n## Request or response body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n\r\n## Request or response body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14609,7 +14609,7 @@
                     "Subcollection"
                 ],
                 "summary": "Delete Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14657,7 +14657,7 @@
                     "Subcollection"
                 ],
                 "summary": "Create Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection. A Subcollection can be either “Exclusive” (all the products contained in it will not be used) or “Inclusive” (all the products contained in it will be used).\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection. A Subcollection can be either “Exclusive” (all the products contained in it will not be used) or “Inclusive” (all the products contained in it will be used).\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14787,7 +14787,7 @@
                     "Subcollection"
                 ],
                 "summary": "Reposition SKU on the Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nEdits the position of an SKU that already exists in the Subcollection,  which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n     \"skuId\": 1,\r\n     \"position\": 1,\r\n     \"subCollectionId\": 17\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nEdits the position of an SKU that already exists in the Subcollection,  which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n     \"skuId\": 1,\r\n     \"position\": 1,\r\n     \"subCollectionId\": 17\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -8893,78 +8893,12 @@
             }
         },
         "/api/catalog/pvt/subcollection/{subCollectionId}/stockkeepingunit": {
-            "get": {
-                "tags": [
-                    "SKU Subcollection"
-                ],
-                "summary": "Get Subcollection's SKUs",
-                "description": "Retrieves all SKUs from a Subcollection.",
-                "parameters": [
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Type of the content being sent.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "subCollectionId",
-                        "in": "path",
-                        "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
-                        "schema": {
-                            "type": "integer",
-                            "example": 1
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "required": true,
-                        "description": "Page number.",
-                        "schema": {
-                            "type": "integer",
-                            "example": 1
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "required": true,
-                        "description": "Number of items in a page.",
-                        "schema": {
-                            "type": "integer",
-                            "example": 50
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            },
             "post": {
                 "tags": [
                     "SKU Subcollection"
                 ],
-                "summary": "Associate SubCollection to SKU",
-                "description": "Associates a SubCollection to a single SKU.",
+                "summary": "Add SKU to Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single SKU to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -8992,18 +8926,13 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 1
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -9019,11 +8948,16 @@
                                         "type": "integer",
                                         "title": "SkuId",
                                         "description": "Unique identifier of an SKU.",
-                                        "example": 0
+                                        "example": 1
                                     }
                                 }
                             }
                         }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -9033,8 +8967,8 @@
                 "tags": [
                     "SKU Subcollection"
                 ],
-                "summary": "Delete SKU SubCollection",
-                "description": "Deletes an SKU from a SubCollection.",
+                "summary": "Delete SKU Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes an SKU from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -9062,7 +8996,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 1
@@ -11566,7 +11500,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 1
@@ -11636,7 +11570,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 1
@@ -12729,7 +12663,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 1
@@ -12799,7 +12733,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 1
@@ -14215,7 +14149,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 17
@@ -14303,7 +14237,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 17
@@ -14441,7 +14375,7 @@
                         "name": "subCollectionId",
                         "in": "path",
                         "required": true,
-                        "description": "Subcollection’s unique numerical identifier.",
+                        "description": "Subcollection’s unique numerical identifier, which can be obtained by placing a request to [Get Subcollection by Collection ID](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid).",
                         "schema": {
                             "type": "integer",
                             "example": 1

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -8990,7 +8990,7 @@
                 "tags": [
                     "SKU Subcollection"
                 ],
-                "summary": "Delete SKU Subcollection",
+                "summary": "Delete SKU from Subcollection",
                 "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes an SKU from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -13810,7 +13810,7 @@
                     "Collection"
                 ],
                 "summary": "Get Collection",
-                "description": "Retrieves general information of a Collection.",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves general information of a Collection.\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -13847,7 +13847,71 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "Id": {
+                                            "type": "integer",
+                                            "title": "Id",
+                                            "description": "Collection ID.",
+                                            "example": 150
+                                        },
+                                        "Name": {
+                                            "type": "string",
+                                            "title": "Name",
+                                            "description": "Collection Name.",
+                                            "example": "Test"
+                                        },
+                                        "Description": {
+                                            "type": "string",
+                                            "title": "Description",
+                                            "description": "Collection description.",
+                                            "example": "Winter outfits.",
+                                            "nullable": true
+                                        },
+                                        "Searchable": {
+                                            "type": "boolean",
+                                            "title": "Searchable",
+                                            "description": "Defines if the Collection is searchable or not.",
+                                            "example": true
+                                        },
+                                        "Highlight": {
+                                            "type": "boolean",
+                                            "title": "Highlight",
+                                            "description": "Defines if the Collection is highlighted or not.",
+                                            "example": false
+                                        },
+                                        "DateFrom": {
+                                            "type": "string",
+                                            "title": "DateFrom",
+                                            "description": "Initial value date for the Collection.",
+                                            "example": "2017-09-27T10:47:00"
+                                        },
+                                        "DateTo": {
+                                            "type": "string",
+                                            "title": "DateTo",
+                                            "description": "Final value date for the Collection.",
+                                            "example": "2017-09-27T10:47:00"
+                                        },
+                                        "TotalProducts": {
+                                            "type": "integer",
+                                            "title": "TotalProducts",
+                                            "description": "Total quantity of products in the collection.",
+                                            "example": 150
+                                        },
+                                        "Type": {
+                                            "type": "string",
+                                            "title": "Type",
+                                            "description": "Type of collection.",
+                                            "example": "Manual"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -13856,7 +13920,7 @@
                     "Collection"
                 ],
                 "summary": "Update Collection",
-                "description": "Updates a previously created Collection.",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"Name\": \"Winter\",\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\"\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -13891,11 +13955,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -13945,6 +14004,75 @@
                             }
                         }
                     }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "Id": {
+                                            "type": "integer",
+                                            "title": "Id",
+                                            "description": "Collection ID.",
+                                            "example": 150
+                                        },
+                                        "Name": {
+                                            "type": "string",
+                                            "title": "Name",
+                                            "description": "Collection Name.",
+                                            "example": "Test"
+                                        },
+                                        "Description": {
+                                            "type": "string",
+                                            "title": "Description",
+                                            "description": "Collection description.",
+                                            "example": "Winter outfits.",
+                                            "nullable": true
+                                        },
+                                        "Searchable": {
+                                            "type": "boolean",
+                                            "title": "Searchable",
+                                            "description": "Defines if the Collection is searchable or not.",
+                                            "example": true
+                                        },
+                                        "Highlight": {
+                                            "type": "boolean",
+                                            "title": "Highlight",
+                                            "description": "Defines if the Collection is highlighted or not.",
+                                            "example": false
+                                        },
+                                        "DateFrom": {
+                                            "type": "string",
+                                            "title": "DateFrom",
+                                            "description": "Initial value date for the Collection.",
+                                            "example": "2017-09-27T10:47:00"
+                                        },
+                                        "DateTo": {
+                                            "type": "string",
+                                            "title": "DateTo",
+                                            "description": "Final value date for the Collection.",
+                                            "example": "2017-09-27T10:47:00"
+                                        },
+                                        "TotalProducts": {
+                                            "type": "integer",
+                                            "title": "TotalProducts",
+                                            "description": "Total quantity of products in the collection.",
+                                            "example": 150
+                                        },
+                                        "Type": {
+                                            "type": "string",
+                                            "title": "Type",
+                                            "description": "Type of collection.",
+                                            "example": "Manual"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "delete": {
@@ -13952,7 +14080,7 @@
                     "Collection"
                 ],
                 "summary": "Delete Collection",
-                "description": "Deletes a previously existing Collection.",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously existing Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14000,7 +14128,7 @@
                     "Collection"
                 ],
                 "summary": "Create Collection",
-                "description": "Creates a new Collection.",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"Name\": \"Winter\",\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\"\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 159,\r\n    \"Name\": \"Winter\",\r\n    \"Description\": null,\r\n    \"Searchable\": false,\r\n    \"Highlight\": false,\r\n    \"DateFrom\": \"2021-09-27T10:47:00\",\r\n    \"DateTo\": \"2027-09-27T10:47:00\",\r\n    \"TotalProducts\": 0,\r\n    \"Type\": \"Manual\"\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14025,11 +14153,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -14074,6 +14197,75 @@
                                         "title": "DateTo",
                                         "description": "Final value date for the Collection.",
                                         "example": "2017-09-27T10:47:00"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "Id": {
+                                            "type": "integer",
+                                            "title": "Id",
+                                            "description": "Collection ID.",
+                                            "example": 150
+                                        },
+                                        "Name": {
+                                            "type": "string",
+                                            "title": "Name",
+                                            "description": "Collection Name.",
+                                            "example": "Test"
+                                        },
+                                        "Description": {
+                                            "type": "string",
+                                            "title": "Description",
+                                            "description": "Collection description.",
+                                            "example": "Winter outfits.",
+                                            "nullable": true
+                                        },
+                                        "Searchable": {
+                                            "type": "boolean",
+                                            "title": "Searchable",
+                                            "description": "Defines if the Collection is searchable or not.",
+                                            "example": true
+                                        },
+                                        "Highlight": {
+                                            "type": "boolean",
+                                            "title": "Highlight",
+                                            "description": "Defines if the Collection is highlighted or not.",
+                                            "example": false
+                                        },
+                                        "DateFrom": {
+                                            "type": "string",
+                                            "title": "DateFrom",
+                                            "description": "Initial value date for the Collection.",
+                                            "example": "2017-09-27T10:47:00"
+                                        },
+                                        "DateTo": {
+                                            "type": "string",
+                                            "title": "DateTo",
+                                            "description": "Final value date for the Collection.",
+                                            "example": "2017-09-27T10:47:00"
+                                        },
+                                        "TotalProducts": {
+                                            "type": "integer",
+                                            "title": "TotalProducts",
+                                            "description": "Total quantity of products in the collection.",
+                                            "example": 150
+                                        },
+                                        "Type": {
+                                            "type": "string",
+                                            "title": "Type",
+                                            "description": "Type of collection.",
+                                            "example": "Manual"
+                                        }
                                     }
                                 }
                             }

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -12657,8 +12657,8 @@
                 "tags": [
                     "Brand Subcollection"
                 ],
-                "summary": "Associate SubCollection to Brand",
-                "description": "Associates a SubCollection to a single Brand.",
+                "summary": "Associate Brand to Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Brand to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"BrandId\": 2000000\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"BrandId\": 2000000\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -12693,11 +12693,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -12713,7 +12708,35 @@
                                         "type": "integer",
                                         "title": "BrandId",
                                         "description": "Unique identifier of a Brand.",
-                                        "example": 0
+                                        "example": 2000000
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "SubCollectionId": {
+                                            "type": "integer",
+                                            "description": "Subcollection’s unique numerical identifier.",
+                                            "example": 17
+                                        },
+                                        "BrandId": {
+                                            "type": "integer",
+                                            "description": "Unique identifier of the Brand.",
+                                            "example": 2000000
+                                        }
+                                    },
+                                    "example": {
+                                        "SubCollectionId": 17,
+                                        "BrandId": 2000000
                                     }
                                 }
                             }
@@ -12727,8 +12750,8 @@
                 "tags": [
                     "Brand Subcollection"
                 ],
-                "summary": "Delete Brand SubCollection",
-                "description": "Deletes a Brand from a SubCollection.",
+                "summary": "Delete Brand from Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Brand from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -2834,7 +2834,7 @@
                                         },
                                         "CubicWeight": {
                                             "type": "number",
-                                            "description": "[Cubic Weight](https://help.vtex.com/tutorial/understanding-the-cubic-weight-factor--tutorials_128)."
+                                            "description": "[Cubic Weight](https://help.vtex.com/en/tutorial/understanding-the-cubic-weight-factor--tutorials_128)."
                                         },
                                         "IsKit": {
                                             "type": "boolean",
@@ -8898,7 +8898,7 @@
                     "SKU Subcollection"
                 ],
                 "summary": "Add SKU to Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single SKU to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"SkuId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"SkuId\": 1\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single SKU to a Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"SkuId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"SkuId\": 1\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -8991,7 +8991,7 @@
                     "SKU Subcollection"
                 ],
                 "summary": "Delete SKU from Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes an SKU from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes an SKU from a Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -11495,7 +11495,7 @@
                     "Category Subcollection"
                 ],
                 "summary": "Associate Category to Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Category to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CategoryId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"CategoryId\": 1\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Category to a Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CategoryId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"CategoryId\": 1\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -11589,7 +11589,7 @@
                     "Category Subcollection"
                 ],
                 "summary": "Delete Category from Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Category from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Category from a Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -12682,7 +12682,7 @@
                     "Brand Subcollection"
                 ],
                 "summary": "Associate Brand to Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Brand to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"BrandId\": 2000000\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"BrandId\": 2000000\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Brand to a Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"BrandId\": 2000000\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"BrandId\": 2000000\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -12775,7 +12775,7 @@
                     "Brand Subcollection"
                 ],
                 "summary": "Delete Brand from Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Brand from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Brand from a Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14280,7 +14280,7 @@
                     "Subcollection"
                 ],
                 "summary": "Get Subcollection by Collection ID",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves all Subcollections given a Collection ID. A Subcollection is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n[\r\n    {\r\n        \"Id\": 12,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Subcollection\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": true\r\n    },\r\n    {\r\n        \"Id\": 13,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Test\",\r\n        \"Type\": \"Exclusive\",\r\n        \"PreSale\": true,\r\n        \"Release\": false\r\n    },\r\n    {\r\n        \"Id\": 14,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"asdfghj\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": false\r\n    }\r\n]\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves all Subcollections given a Collection ID. A Subcollection is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n[\r\n    {\r\n        \"Id\": 12,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Subcollection\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": true\r\n    },\r\n    {\r\n        \"Id\": 13,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Test\",\r\n        \"Type\": \"Exclusive\",\r\n        \"PreSale\": true,\r\n        \"Release\": false\r\n    },\r\n    {\r\n        \"Id\": 14,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"asdfghj\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": false\r\n    }\r\n]\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14383,7 +14383,7 @@
                     "Subcollection"
                 ],
                 "summary": "Get Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves information about a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves information about a Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14471,7 +14471,7 @@
                     "Subcollection"
                 ],
                 "summary": "Update Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n\r\n## Request or response body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n\r\n## Request or response body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14609,7 +14609,7 @@
                     "Subcollection"
                 ],
                 "summary": "Delete Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously created Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14657,7 +14657,7 @@
                     "Subcollection"
                 ],
                 "summary": "Create Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection. A Subcollection can be either “Exclusive” (all the products contained in it will not be used) or “Inclusive” (all the products contained in it will be used).\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Subcollection, which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection. A Subcollection can be either “Exclusive” (all the products contained in it will not be used) or “Inclusive” (all the products contained in it will be used).\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14787,7 +14787,7 @@
                     "Subcollection"
                 ],
                 "summary": "Reposition SKU on the Subcollection",
-                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nEdits the position of an SKU that already exists in the Subcollection,  which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n     \"skuId\": 1,\r\n     \"position\": 1,\r\n     \"subCollectionId\": 17\r\n}\r\n```",
+                "description": " >⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nEdits the position of an SKU that already exists in the Subcollection,  which is a [Group](https://help.vtex.com/en/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n     \"skuId\": 1,\r\n     \"position\": 1,\r\n     \"subCollectionId\": 17\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -11494,8 +11494,8 @@
                 "tags": [
                     "Category Subcollection"
                 ],
-                "summary": "Associate SubCollection to Category",
-                "description": "Associates a SubCollection to a single Category.",
+                "summary": "Associate Category to Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single Category to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CategoryId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"CategoryId\": 1\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -11530,11 +11530,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -11543,7 +11538,7 @@
                                 "type": "object",
                                 "title": "Request body",
                                 "required": [
-                                    "SkuId"
+                                    "CategoryId"
                                 ],
                                 "properties": {
                                     "CategoryId": {
@@ -11551,6 +11546,35 @@
                                         "title": "CategoryId",
                                         "description": "Unique identifier of a Category.",
                                         "example": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "SubCollectionId": {
+                                            "type": "integer",
+                                            "description": "Subcollection’s unique numerical identifier.",
+                                            "example": 17
+                                        },
+                                        "CategoryId": {
+                                            "type": "integer",
+                                            "title": "CategoryId",
+                                            "description": "Unique identifier of the Category.",
+                                            "example": 1
+                                        }
+                                    },
+                                    "example": {
+                                        "SubCollectionId": 17,
+                                        "CategoryId": 1
                                     }
                                 }
                             }
@@ -11564,8 +11588,8 @@
                 "tags": [
                     "Category Subcollection"
                 ],
-                "summary": "Delete Category SubCollection",
-                "description": "Deletes a Category from a SubCollection.",
+                "summary": "Delete Category from Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a Category from a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -12701,7 +12725,7 @@
                                 "type": "object",
                                 "title": "Request body",
                                 "required": [
-                                    "SkuId"
+                                    "BrandId"
                                 ],
                                 "properties": {
                                     "BrandId": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -8898,7 +8898,7 @@
                     "SKU Subcollection"
                 ],
                 "summary": "Add SKU to Subcollection",
-                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single SKU to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nAssociates a single SKU to a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"SkuId\": 1\r\n}\r\n```\r\n\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"SubCollectionId\": 17,\r\n    \"SkuId\": 1\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -8957,7 +8957,30 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "SubCollectionId": {
+                                            "type": "integer",
+                                            "description": "Subcollection’s unique numerical identifier.",
+                                            "example": 17
+                                        },
+                                        "SkuId": {
+                                            "type": "integer",
+                                            "description": "Unique identifier of the SKU.",
+                                            "example": 1
+                                        }
+                                    },
+                                    "example": {
+                                        "SubCollectionId": 17,
+                                        "SkuId": 1
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -14088,7 +14088,7 @@
                     "Subcollection"
                 ],
                 "summary": "Get Subcollection by Collection ID",
-                "description": "Retrieves all Subcollections by its Collection ID.",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves all Subcollections given a Collection ID. A Subcollection is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n[\r\n    {\r\n        \"Id\": 12,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Subcollection\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": true\r\n    },\r\n    {\r\n        \"Id\": 13,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"Test\",\r\n        \"Type\": \"Exclusive\",\r\n        \"PreSale\": true,\r\n        \"Release\": false\r\n    },\r\n    {\r\n        \"Id\": 14,\r\n        \"CollectionId\": 149,\r\n        \"Name\": \"asdfghj\",\r\n        \"Type\": \"Inclusive\",\r\n        \"PreSale\": false,\r\n        \"Release\": false\r\n    }\r\n]\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14154,7 +14154,7 @@
                                         "properties": {
                                             "Id": {
                                                 "type": "integer",
-                                                "description": "SubCollection ID."
+                                                "description": "Subcollection ID."
                                             },
                                             "CollectionId": {
                                                 "type": "integer",
@@ -14162,7 +14162,7 @@
                                             },
                                             "Name": {
                                                 "type": "string",
-                                                "description": "SubCollection Name."
+                                                "description": "Subcollection Name."
                                             },
                                             "Type": {
                                                 "type": "string",
@@ -14190,8 +14190,8 @@
                 "tags": [
                     "Subcollection"
                 ],
-                "summary": "Get SubCollection",
-                "description": "Retrieves information about a SubCollection.",
+                "summary": "Get Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nRetrieves information about a Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14245,7 +14245,7 @@
                                     "properties": {
                                         "Id": {
                                             "type": "integer",
-                                            "description": "SubCollection ID."
+                                            "description": "Subcollection ID."
                                         },
                                         "CollectionId": {
                                             "type": "integer",
@@ -14253,7 +14253,7 @@
                                         },
                                         "Name": {
                                             "type": "string",
-                                            "description": "SubCollection Name."
+                                            "description": "Subcollection Name."
                                         },
                                         "Type": {
                                             "type": "string",
@@ -14278,8 +14278,8 @@
                 "tags": [
                     "Subcollection"
                 ],
-                "summary": "Update SubCollection",
-                "description": "Updates a previously SubCollection.",
+                "summary": "Update Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nUpdates a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n\r\n## Request or response body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14314,53 +14314,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "Id": 17,
-                                    "CollectionId": 151,
-                                    "Name": "group 1",
-                                    "Type": "Inclusive",
-                                    "PreSale": false,
-                                    "Release": false
-                                },
-                                "schema": {
-                                    "type": "object",
-                                    "title": "",
-                                    "properties": {
-                                        "Id": {
-                                            "type": "integer",
-                                            "description": "SubCollection ID."
-                                        },
-                                        "CollectionId": {
-                                            "type": "integer",
-                                            "description": "Collection ID."
-                                        },
-                                        "Name": {
-                                            "type": "string",
-                                            "description": "SubCollection Name."
-                                        },
-                                        "Type": {
-                                            "type": "string",
-                                            "description": "Either `“Exclusive”` (all the products contained in it will not be used) or `“Inclusive”` (all the products contained in it will be used)."
-                                        },
-                                        "PreSale": {
-                                            "type": "boolean",
-                                            "description": "Defines if the collection is on PreSale."
-                                        },
-                                        "Release": {
-                                            "type": "boolean",
-                                            "description": "Defines if the collection is a new released one."
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -14379,13 +14332,13 @@
                                     "CollectionId": {
                                         "type": "integer",
                                         "title": "CollectionId",
-                                        "description": "SubCollection ID.",
+                                        "description": "Collection ID.",
                                         "example": 17
                                     },
                                     "Name": {
                                         "type": "string",
                                         "title": "Name",
-                                        "description": "SubCollection Name.",
+                                        "description": "Subcollection Name.",
                                         "example": "group 1"
                                     },
                                     "Type": {
@@ -14410,14 +14363,61 @@
                             }
                         }
                     }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "Id": 17,
+                                    "CollectionId": 151,
+                                    "Name": "group 1",
+                                    "Type": "Inclusive",
+                                    "PreSale": false,
+                                    "Release": false
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "title": "",
+                                    "properties": {
+                                        "Id": {
+                                            "type": "integer",
+                                            "description": "Subcollection ID."
+                                        },
+                                        "CollectionId": {
+                                            "type": "integer",
+                                            "description": "Collection ID."
+                                        },
+                                        "Name": {
+                                            "type": "string",
+                                            "description": "Subcollection Name."
+                                        },
+                                        "Type": {
+                                            "type": "string",
+                                            "description": "Either `“Exclusive”` (all the products contained in it will not be used) or `“Inclusive”` (all the products contained in it will be used)."
+                                        },
+                                        "PreSale": {
+                                            "type": "boolean",
+                                            "description": "Defines if the collection is on PreSale."
+                                        },
+                                        "Release": {
+                                            "type": "boolean",
+                                            "description": "Defines if the collection is a new released one."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "delete": {
                 "tags": [
                     "Subcollection"
                 ],
-                "summary": "Delete SubCollection",
-                "description": "Deletes a previously created SubCollection.",
+                "summary": "Delete Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nDeletes a previously created Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14464,8 +14464,8 @@
                 "tags": [
                     "Subcollection"
                 ],
-                "summary": "Create SubCollection",
-                "description": "Creates a new SubCollection inclusion or exclusion under a Collection.",
+                "summary": "Create Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nCreates a new Subcollection, which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection. A Subcollection can be either “Exclusive” (all the products contained in it will not be used) or “Inclusive” (all the products contained in it will be used).\r\n## Request body example\r\n\r\n```json\r\n{\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```\r\n## Response body example\r\n\r\n```json\r\n{\r\n    \"Id\": 13,\r\n    \"CollectionId\": 149,\r\n    \"Name\": \"Test\",\r\n    \"Type\": \"Exclusive\",\r\n    \"PreSale\": true,\r\n    \"Release\": false\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14490,53 +14490,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "Id": 17,
-                                    "CollectionId": 151,
-                                    "Name": "group 1",
-                                    "Type": "Inclusive",
-                                    "PreSale": false,
-                                    "Release": false
-                                },
-                                "schema": {
-                                    "type": "object",
-                                    "title": "",
-                                    "properties": {
-                                        "Id": {
-                                            "type": "integer",
-                                            "description": "SubCollection ID."
-                                        },
-                                        "CollectionId": {
-                                            "type": "integer",
-                                            "description": "Collection ID."
-                                        },
-                                        "Name": {
-                                            "type": "string",
-                                            "description": "SubCollection Name."
-                                        },
-                                        "Type": {
-                                            "type": "string",
-                                            "description": "Either `“Exclusive”` (all the products contained in it will not be used) or `“Inclusive”` (all the products contained in it will be used)."
-                                        },
-                                        "PreSale": {
-                                            "type": "boolean",
-                                            "description": "Defines if the collection is on PreSale."
-                                        },
-                                        "Release": {
-                                            "type": "boolean",
-                                            "description": "Defines if the collection is a new released one."
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -14586,6 +14539,53 @@
                             }
                         }
                     }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "Id": 17,
+                                    "CollectionId": 151,
+                                    "Name": "group 1",
+                                    "Type": "Inclusive",
+                                    "PreSale": false,
+                                    "Release": false
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "title": "",
+                                    "properties": {
+                                        "Id": {
+                                            "type": "integer",
+                                            "description": "Subcollection ID."
+                                        },
+                                        "CollectionId": {
+                                            "type": "integer",
+                                            "description": "Collection ID."
+                                        },
+                                        "Name": {
+                                            "type": "string",
+                                            "description": "Subcollection Name."
+                                        },
+                                        "Type": {
+                                            "type": "string",
+                                            "description": "Either `“Exclusive”` (all the products contained in it will not be used) or `“Inclusive”` (all the products contained in it will be used)."
+                                        },
+                                        "PreSale": {
+                                            "type": "boolean",
+                                            "description": "Defines if the collection is on PreSale."
+                                        },
+                                        "Release": {
+                                            "type": "boolean",
+                                            "description": "Defines if the collection is a new released one."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -14594,8 +14594,8 @@
                 "tags": [
                     "Subcollection"
                 ],
-                "summary": "Reposition SKU on the SubCollection",
-                "description": "Edits an SKU position that already exists in the subcollection.",
+                "summary": "Reposition SKU on the Subcollection",
+                "description": "> ⚠️ There are two ways to configure collections, through Legacy CMS Portal or using the Beta Collection module. This endpoint is compatible with [collections configured through the Legacy CMS Portal](https://help.vtex.com/en/tutorial/adding-collections-cms--2YBy6P6X0NFRpkD2ZBxF6L).\n\nEdits the position of an SKU that already exists in the Subcollection,  which is a [Group](https://help.vtex.com/tutorial/creating-a-product-collection--tutorials_244#creation-of-groups-by-department-category-or-sub-category) within a  Collection.\r\n## Request body example\r\n\r\n```json\r\n{\r\n     \"skuId\": 1,\r\n     \"position\": 1,\r\n     \"subCollectionId\": 17\r\n}\r\n```",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -14630,11 +14630,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
                 "requestBody": {
                     "description": "",
                     "content": {
@@ -14666,6 +14661,11 @@
                                 }
                             }
                         }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }


### PR DESCRIPTION
Reviewing and adding responses to:
- [SKU Subcollection](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-sku) 
- [Category Subcollection](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-post-subcollection-category)
- [Brand Subcollection](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-post-subcollection-brand)
- [Collection](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-collection)
- [Subcollection](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-get-subcollection-collectionid)

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [x] No, but I am going to.
