### PR TITLE
Master data v2/correcting client and address paths 28072022

### DIFF
--- a/VTEX - Master Data API - v2.json
+++ b/VTEX - Master Data API - v2.json
@@ -27,7 +27,7 @@
             "post": {
                 "tags": ["Documents"],
                 "summary": "Create new document",
-                "description": "This request allows you to create a new document corresponding to a given data entity. For example, you can create a new customer profile or address.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to create.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a new customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/CL\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nFor a new address, the data entity is `AD` and the request would look like this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
+                "description": "This request allows you to create a new document corresponding to a given data entity. For example, you can create a new customer profile or address.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to create.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a new customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nFor a new address, the data entity is `AD` and the request would look like this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
                 "operationId": "Createnewdocument",
                 "parameters": [
                     {
@@ -63,7 +63,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -74,7 +74,7 @@
             "patch": {
                 "tags": ["Documents"],
                 "summary": "Create partial document",
-                "description": "This request allows you to partially update a document corresponding to a given data entity.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/CL\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
+                "description": "This request allows you to partially update a document corresponding to a given data entity.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
                 "operationId": "Createorupdatepartialdocument",
                 "parameters": [
                     {
@@ -111,7 +111,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -120,7 +120,7 @@
                 "deprecated": false
             }
         },
-        "/api/dataentities/CL/documents": {
+        "/api/dataentities/Client/documents": {
             "post": {
                 "tags": ["Customer profiles"],
                 "summary": "Create new customer profile",
@@ -157,7 +157,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -166,7 +166,7 @@
                 "deprecated": false
             }
         },
-        "/api/dataentities/CL/documents/{id}": {
+        "/api/dataentities/Client/documents/{id}": {
             "patch": {
                 "tags": ["Customer profiles"],
                 "summary": "Update customer profile",
@@ -206,7 +206,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -240,7 +240,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -422,7 +422,7 @@
             "put": {
                 "tags": ["Documents"],
                 "summary": "Update entire document",
-                "description": "Update an existing document corresponding to a given data entity. For example, you can update a customer profile or address.\r\n\r\n> You can use this request to update documents in any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update an existing customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/CL\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nTo update an address, the data entity is `AD` and the request would look like this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
+                "description": "Update an existing document corresponding to a given data entity. For example, you can update a customer profile or address.\r\n\r\n> You can use this request to update documents in any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update an existing customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nTo update an address, the data entity is `AD` and the request would look like this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
                 "operationId": "Updateentiredocument",
                 "parameters": [
                     {
@@ -461,7 +461,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -472,7 +472,7 @@
             "patch": {
                 "tags": ["Documents"],
                 "summary": "Update partial document",
-                "description": "This request allows you to partially update a document corresponding to a given data entity. For example, you can update some fields of a customer profile or address.\r\n\r\n> You can use this request to update documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/CL\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
+                "description": "This request allows you to partially update a document corresponding to a given data entity. For example, you can update some fields of a customer profile or address.\r\n\r\n> You can use this request to update documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
                 "operationId": "Updatepartialdocument",
                 "parameters": [
                     {
@@ -511,7 +511,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -551,7 +551,7 @@
             "get": {
                 "tags": ["Search"],
                 "summary": "Search documents",
-                "description": "Retrieves documents' information, while choosing which fields will be returned and filtering documents by specific fields.\r\n\r\n> The response header `REST-Content-Range` indicates the total amount of results for that specific search. For example, it may return `resources 0-100/136108`, which indicates it has returned results from 0 to 100 of a total 136108.\r\n\r\nBelow you can see some query examples and learn more about each query parameter.\r\n\r\n## Query examples\r\n\r\n### Simple filter\r\n\r\n```\r\n\/dataentities\/CL\/search?email=my@email.com\r\n```\r\n\r\n### Complex filter\r\n\r\n```\r\n\/dataentities\/CL\/search?_where=(firstName=Jon OR lastName=Smith) OR (createdIn between 2001-01-01 AND 2016-01-01)\r\n```\r\n\r\n### Date Range\r\n\r\n```\r\n\/dataentities\/CL\/search?_where=createdIn between 2001-01-01 AND 2016-01-01\r\n```\r\n\r\n### Range numeric fields\r\n\r\n```\r\n\/dataentities\/CL\/search?_where=age between 18 AND 25\r\n```\r\n\r\n### Partial filter\r\n\r\n```\r\n\/dataentities\/CL\/search?firstName=*Maria*\r\n```\r\n\r\n### Filter for null values\r\n\r\n```\r\n\/dataentities\/CL\/search?_where=firstName is null\r\n```\r\n\r\n### Filter for non-null values\r\n\r\n```\r\n\/dataentities\/CL\/search?_where=firstName is not null\r\n```\r\n\r\n### Filter for difference\r\n```\r\n\/dataentities\/CL\/search?_where=firstName<>maria\r\n```\r\n\r\n### Filter greater than or less than\r\n```\r\n\/dataentities\/CL\/search?_where=number>5\r\n\/dataentities\/CL\/search?_where=date<2001-01-01\r\n```",
+                "description": "Retrieves documents' information, while choosing which fields will be returned and filtering documents by specific fields.\r\n\r\n> The response header `REST-Content-Range` indicates the total amount of results for that specific search. For example, it may return `resources 0-100/136108`, which indicates it has returned results from 0 to 100 of a total 136108.\r\n\r\nBelow you can see some query examples and learn more about each query parameter.\r\n\r\n## Query examples\r\n\r\n### Simple filter\r\n\r\n```\r\n\/dataentities\/Client\/search?email=my@email.com\r\n```\r\n\r\n### Complex filter\r\n\r\n```\r\n\/dataentities\/Client\/search?_where=(firstName=Jon OR lastName=Smith) OR (createdIn between 2001-01-01 AND 2016-01-01)\r\n```\r\n\r\n### Date Range\r\n\r\n```\r\n\/dataentities\/Client\/search?_where=createdIn between 2001-01-01 AND 2016-01-01\r\n```\r\n\r\n### Range numeric fields\r\n\r\n```\r\n\/dataentities\/Client\/search?_where=age between 18 AND 25\r\n```\r\n\r\n### Partial filter\r\n\r\n```\r\n\/dataentities\/Client\/search?firstName=*Maria*\r\n```\r\n\r\n### Filter for null values\r\n\r\n```\r\n\/dataentities\/Client\/search?_where=firstName is null\r\n```\r\n\r\n### Filter for non-null values\r\n\r\n```\r\n\/dataentities\/Client\/search?_where=firstName is not null\r\n```\r\n\r\n### Filter for difference\r\n```\r\n\/dataentities\/Client\/search?_where=firstName<>maria\r\n```\r\n\r\n### Filter greater than or less than\r\n```\r\n\/dataentities\/Client\/search?_where=number>5\r\n\/dataentities\/Client\/search?_where=date<2001-01-01\r\n```",
                 "operationId": "Searchdocuments",
                 "parameters": [
                     {
@@ -594,7 +594,7 @@
             "get": {
                 "tags": ["Scroll"],
                 "summary": "Scroll documents",
-                "description": "In the first request, the `X-VTEX-MD-TOKEN` token will be returned in the header. This token must be passed to the next request in the query string `_token` parameter. The token has a timeout of 10 minutes, which refreshes after each request.\r\n\r\nAfter the token is obtained it is no longer necessary to send the filter or document size per page parameters. You only need to resend the token until the document collection is empty.\r\n\r\n## Request examples\r\n\r\nFirst request:\r\n```\r\n\/dataentities\/CL\/scroll?isCluster=true&_size=250&_fields=email,firstName\r\n```\r\n\r\nRetrieve the token in the header `X-VTEX-MD-TOKEN` from the first request's response and use it to make the next requests.\r\n\r\nSubsequent requests:\r\n```\r\n\/dataentities\/CL\/scroll?_token={tokenValueExample}\r\n```",
+                "description": "In the first request, the `X-VTEX-MD-TOKEN` token will be returned in the header. This token must be passed to the next request in the query string `_token` parameter. The token has a timeout of 10 minutes, which refreshes after each request.\r\n\r\nAfter the token is obtained it is no longer necessary to send the filter or document size per page parameters. You only need to resend the token until the document collection is empty.\r\n\r\n## Request examples\r\n\r\nFirst request:\r\n```\r\n\/dataentities\/Client\/scroll?isCluster=true&_size=250&_fields=email,firstName\r\n```\r\n\r\nRetrieve the token in the header `X-VTEX-MD-TOKEN` from the first request's response and use it to make the next requests.\r\n\r\nSubsequent requests:\r\n```\r\n\/dataentities\/Client\/scroll?_token={tokenValueExample}\r\n```",
                 "operationId": "Scrolldocuments",
                 "parameters": [
                     {
@@ -1059,7 +1059,7 @@
                                 },
                                 "example": {
                                     "Id": "CL-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/CL/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Client/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }

--- a/VTEX - Master Data API - v2.json
+++ b/VTEX - Master Data API - v2.json
@@ -27,7 +27,7 @@
             "post": {
                 "tags": ["Documents"],
                 "summary": "Create new document",
-                "description": "This request allows you to create a new document corresponding to a given data entity. For example, you can create a new customer profile or address.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to create.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a new customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nFor a new address, the data entity is `AD` and the request would look like this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
+                "description": "This request allows you to create a new document corresponding to a given data entity. For example, you can create a new customer profile or address.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to create.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a new customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nFor a new address, the data entity is `AD` and the request would look like this:\r\n\r\nPOST\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Address\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
                 "operationId": "Createnewdocument",
                 "parameters": [
                     {
@@ -74,7 +74,7 @@
             "patch": {
                 "tags": ["Documents"],
                 "summary": "Create partial document",
-                "description": "This request allows you to partially update a document corresponding to a given data entity.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
+                "description": "This request allows you to partially update a document corresponding to a given data entity.\r\n\r\n> You can use this request to create documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to create a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Address\/documents\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
                 "operationId": "Createorupdatepartialdocument",
                 "parameters": [
                     {
@@ -249,7 +249,7 @@
                 "deprecated": false
             }
         },
-        "/api/dataentities/AD/documents": {
+        "/api/dataentities/Address/documents": {
             "post": {
                 "tags": ["Addresses"],
                 "summary": "Create new customer address",
@@ -286,7 +286,7 @@
                                 },
                                 "example": {
                                     "Id": "AD-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/AD/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Address/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -295,7 +295,7 @@
                 "deprecated": false
             }
         },
-        "/api/dataentities/AD/documents/{id}": {
+        "/api/dataentities/Address/documents/{id}": {
             "patch": {
                 "tags": ["Addresses"],
                 "summary": "Update customer address",
@@ -335,7 +335,7 @@
                                 },
                                 "example": {
                                     "Id": "AD-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/AD/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Address/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -369,7 +369,7 @@
                                 },
                                 "example": {
                                     "Id": "AD-b818cbda-e489-11e6-94f4-0ac138d2d42e",
-                                    "Href": "http://api.vtex.com/my-store-name/dataentities/AD/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
+                                    "Href": "http://api.vtex.com/my-store-name/dataentities/Address/documents/b818cbda-e489-11e6-94f4-0ac138d2d42e"
                                 }
                             }
                         }
@@ -422,7 +422,7 @@
             "put": {
                 "tags": ["Documents"],
                 "summary": "Update entire document",
-                "description": "Update an existing document corresponding to a given data entity. For example, you can update a customer profile or address.\r\n\r\n> You can use this request to update documents in any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update an existing customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nTo update an address, the data entity is `AD` and the request would look like this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
+                "description": "Update an existing document corresponding to a given data entity. For example, you can update a customer profile or address.\r\n\r\n> You can use this request to update documents in any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update an existing customer profile, choose the `CL` data entity and send a request similar to this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"email\": \"clark.kent@examplemail.com\",\r\n    \"firstName\": \"Clark\",\r\n    \"lastName\": \"Kent\",\r\n    \"phone\": \"+12025550195\",\r\n    \"documentType\": \"CPF\",\r\n    \"document\": \"12345678900\"\r\n    \"isCorporate\": false,\r\n    \"isNewsletterOptIn\": false,\r\n    \"localeDefault\": \"en-US\"\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nTo update an address, the data entity is `AD` and the request would look like this:\r\n\r\nPUT\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Address\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"addressName\": \"My House\",\r\n    \"addressType\": \"residential\",\r\n    \"city\": \"Metropolis\",\r\n    \"complement\": \"\",\r\n    \"country\": \"USA\",\r\n    \"postalCode\": \"11375\",\r\n    \"receiverName\": \"Clark Kent\",\r\n    \"reference\": null,\r\n    \"state\": \"MP\",\r\n    \"street\": \"Baker Street\",\r\n    \"neighborhood\": \"Upper east side\",\r\n    \"number\": \"21\",\r\n    \"userId\": \"7e03m794-a33a-11e9-84rt6-0adfa64s5a8e\"\r\n}\r\n```",
                 "operationId": "Updateentiredocument",
                 "parameters": [
                     {
@@ -472,7 +472,7 @@
             "patch": {
                 "tags": ["Documents"],
                 "summary": "Update partial document",
-                "description": "This request allows you to partially update a document corresponding to a given data entity. For example, you can update some fields of a customer profile or address.\r\n\r\n> You can use this request to update documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/AD\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
+                "description": "This request allows you to partially update a document corresponding to a given data entity. For example, you can update some fields of a customer profile or address.\r\n\r\n> You can use this request to update documents for any given data entity. Because of this, you are not restricted to using the fields exemplified below in your requests. But you should be aware of the fields allowed or required for each document you wish to update.\r\n\r\n## Example use cases\r\n\r\n### Client profile\r\n\r\nIn order to update a customer profile's `phone` and `isNewsletterOptIn` fields, choose the `CL` data entity and send a request similar to this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Client\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"phone\": \"+12025550195\",\r\n    \"isNewsletterOptIn\": false\r\n }\r\n```\r\n\r\n### Client address\r\n\r\nIn order to update the `receiverName` of an existing address, the data entity is `AD` and the request would look like this:\r\n\r\nPATCH\r\n```\r\nhttps:\/\/examplestore.vtexcommercestable.com.br\/api\/dataentities\/Address\/documents\/123456789abc\r\n```\r\n\r\nRequest body\r\n```json\r\n{\r\n    \"receiverName\": \"Lois Lane\"\r\n}\r\n```",
                 "operationId": "Updatepartialdocument",
                 "parameters": [
                     {


### PR DESCRIPTION
#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

Changing data entity acronyms in paths for data entity names to avoid ambiguity with v1 API reference/concepts. All changes consist in one of the following:

- `/CL` -> `/Client`
- `/AD` -> `/Address`
