### PR TITLE
Removing `alternativeKey` param from 3 endpoints

### DIFF
--- a/VTEX - Profile System.json
+++ b/VTEX - Profile System.json
@@ -219,8 +219,8 @@
             },
             "delete": {
                 "tags": ["Profiles"],
-                "summary": "Deletes client profile",
-                "description": "Delete a client profile by `profileId`. ",
+                "summary": "Delete client profile",
+                "description": "Delete a client profile by `profileId`.",
                 "operationId": "DeleteClientProfile",
                 "parameters": [
                     {
@@ -231,9 +231,6 @@
                     },
                     {
                         "$ref": "#/components/parameters/profileId"
-                    },
-                    {
-                        "$ref": "#/components/parameters/alternativeKey"
                     }
                 ],
                 "responses": {
@@ -320,9 +317,6 @@
                     },
                     {
                         "$ref": "#/components/parameters/profileVersionId"
-                    },
-                    {
-                        "$ref": "#/components/parameters/alternativeKey"
                     }
                 ],
                 "responses": {
@@ -381,9 +375,6 @@
                     },
                     {
                         "$ref": "#/components/parameters/reason"
-                    },
-                    {
-                        "$ref": "#/components/parameters/alternativeKey"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
The endpoints `Delete client profile`, `Get client profile by version`, and `Get unmasked client profile by version` do not support the query param `alternativeKey`, so I am removing that from the doc.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
