### PR TITLE
Updating orders endpoints for PII

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -25,9 +25,7 @@
     "paths": {
         "/api/oms/pvt/orders/{orderId}": {
             "get": {
-                "tags": [
-                    "Orders"
-                ],
+                "tags": ["Orders"],
                 "summary": "Get order",
                 "description": "Retrieves order details by searching a specific order ID or sequence number.\n\r\n\r> The `View order` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).\r\n\r\n> 📘 Onboarding guide \r\n>\r\n> Check the new [Orders onboarding guide](https://developers.vtex.com/vtex-rest-api/docs/orders-overview). We created this guide to improve the onboarding experience for developers at VTEX. It assembles all documentation on our Developer Portal about Orders and is organized by focusing on the developer's journey.\r\n\r\n",
                 "operationId": "GetOrder",
@@ -244,27 +242,27 @@
                                                     "priceValidUntil": {
                                                         "type": "string",
                                                         "description": "Price expiration date and time.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "tax": {
                                                         "type": "integer",
                                                         "description": "Tax value in cents.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "price": {
                                                         "type": "integer",
                                                         "description": "Price in cents.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "listPrice": {
                                                         "type": "integer",
                                                         "description": "List price in cents.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "manualPrice": {
                                                         "type": "integer",
                                                         "description": "Manual price in cents.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "manualPriceAppliedBy": {
                                                         "type": "string",
@@ -273,17 +271,17 @@
                                                     "sellingPrice": {
                                                         "type": "integer",
                                                         "description": "Selling price in cents. Note that this field may be subject to rounding discrepancies. We recommend retrieving data from the `priceDefinition` data structure instead.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "rewardValue": {
                                                         "type": "integer",
                                                         "description": "Reward value in cents.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "isGift": {
                                                         "type": "boolean",
                                                         "description": "Indicates whether item is a gift.",
-                                                        "nullable":true
+                                                        "nullable": true
                                                     },
                                                     "additionalInfo": {
                                                         "type": "object",
@@ -292,30 +290,29 @@
                                                             "dimension": {
                                                                 "type": "object",
                                                                 "description": "Dimension of the item.",
-                                                                "properties": 
-                                                                                {
-                                                                                    "cubicweight":{
-                                                                                        "type": "number",
-                                                                                        "description": "The item's cubic weight."
-                                                                                        },
-                                                                                    "height": {
-                                                                                        "type": "number",
-                                                                                        "description": "The item's height."
-                                                                                        },
-                                                                                    "length": {
-                                                                                            "type": "number",
-                                                                                            "description": "The item's length."
-                                                                                        },
-                                                                                    "weight": {
-                                                                                            "type": "number",
-                                                                                            "description": "The item's weight."
-                                                                                        },
-                                                                                    "width": {
-                                                                                            "type": "number",
-                                                                                            "description": "The item's width."
-                                                                                        }
-                                                                                }
-                                                                            },
+                                                                "properties": {
+                                                                    "cubicweight": {
+                                                                        "type": "number",
+                                                                        "description": "The item's cubic weight."
+                                                                    },
+                                                                    "height": {
+                                                                        "type": "number",
+                                                                        "description": "The item's height."
+                                                                    },
+                                                                    "length": {
+                                                                        "type": "number",
+                                                                        "description": "The item's length."
+                                                                    },
+                                                                    "weight": {
+                                                                        "type": "number",
+                                                                        "description": "The item's weight."
+                                                                    },
+                                                                    "width": {
+                                                                        "type": "number",
+                                                                        "description": "The item's width."
+                                                                    }
+                                                                }
+                                                            },
                                                             "brandName": {
                                                                 "type": "string",
                                                                 "description": "Brand name."
@@ -957,9 +954,7 @@
                                                             "polygonName": null
                                                         }
                                                     ],
-                                                    "shipsTo": [
-                                                        "BRA"
-                                                    ],
+                                                    "shipsTo": ["BRA"],
                                                     "deliveryIds": [
                                                         {
                                                             "courierId": "197a56f",
@@ -1334,9 +1329,7 @@
                                                         "polygonName": null
                                                     }
                                                 ],
-                                                "shipsTo": [
-                                                    "BRA"
-                                                ],
+                                                "shipsTo": ["BRA"],
                                                 "deliveryIds": [
                                                     {
                                                         "courierId": "197a56f",
@@ -1492,9 +1485,7 @@
         },
         "/api/oms/pvt/orders": {
             "get": {
-                "tags": [
-                    "Orders"
-                ],
+                "tags": ["Orders"],
                 "summary": "List orders",
                 "description": "Retrieves a list of orders according to the filters described below.\n\r\n\r> This should **not** be used for integrations. Use the [orders Feed or hook](https://developers.vtex.com/vtex-rest-api/docs/feed-v3-1) for this purpose.\n\r\n\rThis endpoint returns only orders that already have been indexed, which takes approximately four minutes. Because of this, the data retrieved may present inconsistencies. To get live up-to-date information and [build order integrations](https://developers.vtex.com/vtex-rest-api/docs/erp-integration-set-up-order-integration) use the [orders Feed or hook](https://developers.vtex.com/vtex-rest-api/docs/feed-v3-1).\n\r\n> 📘 Onboarding guide \r\n>\r\n> Check the new [Orders onboarding guide](https://developers.vtex.com/vtex-rest-api/docs/orders-overview). We created this guide to improve the onboarding experience for developers at VTEX. It assembles all documentation on our Developer Portal about Orders and is organized by focusing on the developer's journey.\r\n\r\n",
                 "operationId": "ListOrders",
@@ -2218,9 +2209,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/start-handling": {
             "post": {
-                "tags": [
-                    "Orders"
-                ],
+                "tags": ["Orders"],
                 "summary": "Start handling order",
                 "description": "Change the status of an order to indicate that is is in `handling`.\n\r\n\r> Expect a `status 204` response with no content in case of a successful request. The store must validate this response to retry the call if the responses differs from the 204 code, making this flow the store's responsibility. This endpoint can also respond with `status 500`. \n\r\n\r> The `Change order workflow status` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).",
                 "operationId": "StartHandling",
@@ -2370,9 +2359,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/cancel": {
             "post": {
-                "tags": [
-                    "Orders"
-                ],
+                "tags": ["Orders"],
                 "summary": "Cancel order",
                 "description": "You should use this endpoint to cancel an order by its order identification number (the `orderId`).\n\nA common scenario is one where the seller has a problem with the order fulfillment and needs to request the order cancellation to the marketplace. To do this, the seller would need to make this request, passing the `orderId` in the URL.\n\nYou should expect a response with the date when the notification was received, the orderId, and a receipt protocol code.\n\nBe aware that if the order status is already `Invoiced`, the order can only be canceled if—before using this request—you send a return invoice through the [Order Invoice Notification endpoint](https://developers.vtex.com/reference/invoice#invoicenotification).\n\r\n\r> The `Cancel order` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).",
                 "operationId": "CancelOrder",
@@ -2471,9 +2458,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/changes": {
             "post": {
-                "tags": [
-                    "Orders"
-                ],
+                "tags": ["Orders"],
                 "summary": "Register change on order",
                 "description": "\r\n> ℹ️ Timeout settings\r\n>\r\n> This is a synchronous API, which means the application requests data and waits until a value is returned. This behavior can cause timeout errors; to avoid them, we recommend setting the timeout in 20 seconds.\r\n\r\n This request allows [changing an order](https://help.vtex.com/en/tutorial/changing-items-from-a-completed-order--tutorials_190) by:\n\r- Adding items to an order\n\r- Removing items from an order\n\r- Applying discounts to the total value of the order\n\r- Incrementing the total value of the order. \n\nIn those scenarios of order changes, it is possible to insert a [Partial invoice](https://help.vtex.com/en/tracks/orders--2xkTisx4SXOWXQel8Jg8sa/q9GPspTb9cHlMeAZfdEUe). The total value of the order will be updated after the insertion of the invoice, even when there is a partial invoice scenario. The updated value is settled by VTEX's Payment Gateway. The reimbursement for the shopper is automatic. \n\r\n\rThis action can only be done for orders in these status:\n\r- `handling`\n\r- `waiting-for-fulfillment` \n\r\n\r> The `Change order` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).",
                 "operationId": "RegisterChange",
@@ -2564,9 +2549,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/interactions": {
             "post": {
-                "tags": [
-                    "Orders"
-                ],
+                "tags": ["Orders"],
                 "summary": "Add log in orders",
                 "description": "Add a Log in Interactions Order Array.",
                 "operationId": "AddLog",
@@ -2629,9 +2612,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/invoice": {
             "post": {
-                "tags": [
-                    "Invoice"
-                ],
+                "tags": ["Invoice"],
                 "summary": "Order invoice notification",
                 "description": "Entering the [invoice in the order](https://help.vtex.com/en/tracks/orders--2xkTisx4SXOWXQel8Jg8sa/2WgQrlHTyVo4hLjhUs1LMT) is a required step for its [status](https://help.vtex.com/en/tutorial/order-flow-and-status--tutorials_196#order-status-details) to change to Invoiced - a sign that the order has been successfully completed. Remember that once an order is read as invoiced by the system, this status cannot be changed. \n\nThe total value of the order will be updated after the insertion of the invoice, even when there's a [Partial invoice](https://help.vtex.com/en/tracks/orders--2xkTisx4SXOWXQel8Jg8sa/q9GPspTb9cHlMeAZfdEUe) scenario. The updated value is settled by VTEX's Payment Gateway. The reimbursement for the shopper is automatic. \n\nWe strongly recommend that you always send the object of the invoiced items. With this practice, rounding errors will be avoided. \n\nWhen returning items, an input invoice must be sent through this call. For that, the `type` field should be filled in with `input`. \n\nIt is not allowed to use the same `invoiceNumber` in more than one request to the Order Invoice Notification endpoint.\n\nFor marketplace integrations: once the order is invoiced, the seller should use this request to send the invoice information to the marketplace. Be aware that this endpoint is also used by the seller to send the order tracking information. This, however, should be done in a separate moment, once the seller has the tracking information.  \n\r\n\r> The `Notify invoice` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).\n\r\n\r> 📘 Onboarding guide \r\n>\r\n> Check the new [Orders onboarding guide](https://developers.vtex.com/vtex-rest-api/docs/orders-overview). We created this guide to improve the onboarding experience for developers at VTEX. It assembles all documentation on our Developer Portal about Orders and is organized by focusing on the developer's journey.\r\n\r\n",
                 "operationId": "InvoiceNotification",
@@ -2736,9 +2717,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/invoice/{invoiceNumber}": {
             "patch": {
-                "tags": [
-                    "Invoice"
-                ],
+                "tags": ["Invoice"],
                 "summary": "Update order's partial invoice (send tracking number)",
                 "description": "Update a given order, adding its tracking number to its [Partial invoice](https://help.vtex.com/en/tracks/pedidos--2xkTisx4SXOWXQel8Jg8sa/q9GPspTb9cHlMeAZfdEUe).\n\r\n\rAfter using this call to add a tracking number to an order, you can use the [Update order tracking status](https://developers.vtex.com/vtex-rest-api/reference/tracking#updatetrackingstatus) API request to add tracking events.\n\r\n\r> The `Notify invoice` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc).",
                 "operationId": "Updatepartialinvoice.SendTrackingNumber",
@@ -2825,9 +2804,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/invoice/{invoiceNumber}/tracking": {
             "put": {
-                "tags": [
-                    "Tracking"
-                ],
+                "tags": ["Tracking"],
                 "summary": "Update order tracking status",
                 "description": "Sends a tracking event to an order that already has a tracking number registered to its invoice.\n\r\n\rThis endpoint is not meant to send tracking number and URL to the invoice. If you wish to send tracking number and URL to an order, use the [Update order's partial invoice API request](https://developers.vtex.com/vtex-rest-api/reference/invoice#updatepartialinvoicesendtrackingnumber). You can also learn more about [Partial invoice](https://help.vtex.com/en/tracks/pedidos--2xkTisx4SXOWXQel8Jg8sa/q9GPspTb9cHlMeAZfdEUe) scenarios. \n\r\n\r> The `Notify invoice` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).",
                 "operationId": "UpdateTrackingStatus",
@@ -3038,9 +3015,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/conversation-message": {
             "get": {
-                "tags": [
-                    "Conversation"
-                ],
+                "tags": ["Conversation"],
                 "summary": "Retrieve order conversation",
                 "description": "Lists all order conversations by Order ID. For example: in case you need to get details from the conversation in the Order {{v5025004rjc-09}}, you will have to replace the variables {{orderId}} for {{v5025004rjc-09}}.",
                 "operationId": "GetConversation",
@@ -3076,6 +3051,9 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "$ref": "#/components/parameters/reason"
                     }
                 ],
                 "responses": {
@@ -3280,9 +3258,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/payment-transaction": {
             "get": {
-                "tags": [
-                    "Payment"
-                ],
+                "tags": ["Payment"],
                 "summary": "Retrieve payment transaction",
                 "description": "Retrieves transaction details by order ID. All events in the transaction will be registered in this call's response body. \n\nIn scenarios of [order changes](https://developers.vtex.com/vtex-rest-api/reference/registerchange), it is possible to insert a [Partial invoice](https://help.vtex.com/en/tracks/pedidos--2xkTisx4SXOWXQel8Jg8sa/q9GPspTb9cHlMeAZfdEUe). The total value of the order will be updated after the insertion of the invoice, even when there is a [Partial invoice](https://help.vtex.com/en/tracks/pedidos--2xkTisx4SXOWXQel8Jg8sa/q9GPspTb9cHlMeAZfdEUe) scenario. The updated value is settled by VTEX's Payment Gateway. The reimbursement for the shopper is automatic.",
                 "operationId": "GetPaymenttransaction",
@@ -3374,9 +3350,7 @@
         },
         "/api/oms/pvt/orders/{orderId}/payments/{paymentId}/payment-notification": {
             "post": {
-                "tags": [
-                    "Payment"
-                ],
+                "tags": ["Payment"],
                 "summary": "Send payment notification",
                 "description": "Send a payment notification of a given order, by order ID.\n\r\n\r> The `Notify payment` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).",
                 "operationId": "SendPaymentNotification",
@@ -3434,9 +3408,7 @@
         },
         "/api/oms/pvt/feed/orders/status": {
             "get": {
-                "tags": [
-                    "Feed v2 (deprecated)"
-                ],
+                "tags": ["Feed v2 (deprecated)"],
                 "summary": "Get feed order status",
                 "description": "Get feed order status (deprecated)",
                 "operationId": "Getfeedorderstatus",
@@ -3487,9 +3459,7 @@
         },
         "/api/orders/feed/config": {
             "get": {
-                "tags": [
-                    "Feed v3"
-                ],
+                "tags": ["Feed v3"],
                 "summary": "Get feed configuration",
                 "description": "The Orders Feed v3 is the best way to create order integrations. Below you can find details on the configuration API specification, and to know more see our [Feed v3 guide](https://developers.vtex.com/vtex-rest-api/docs/orders-feed) and our [order integration guide](https://developers.vtex.com/vtex-rest-api/docs/erp-integration-set-up-order-integration).\n\r\n> 📘 Onboarding guide \r\n>\r\n> Check the new [Orders onboarding guide](https://developers.vtex.com/vtex-rest-api/docs/orders-overview). We created this guide to improve the onboarding experience for developers at VTEX. It assembles all documentation on our Developer Portal about Orders and is organized by focusing on the developer's journey.\r\n\r\n",
                 "operationId": "GetFeedConfiguration",
@@ -3593,9 +3563,7 @@
                 "deprecated": false
             },
             "post": {
-                "tags": [
-                    "Feed v3"
-                ],
+                "tags": ["Feed v3"],
                 "summary": "Create or update feed configuration",
                 "description": "The Orders Feed v3 is the best way to create order integrations. Below you can find details on the configuration API specification, and to know more see our [Feed v3 guide](https://developers.vtex.com/vtex-rest-api/docs/orders-feed) and our [order integration guide](https://developers.vtex.com/vtex-rest-api/docs/erp-integration-set-up-order-integration)\n\r\n\rThere are two types of filtering that can be used. The `FromWorkflow` type filters orders by status, whereas the `FromOrders` type uses JSONata expressions to filter orders according to any property in the orders JSON document. This enables stores to filter delivered orders and orders in which products have been added or removed, for example. To learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [Test JSONata expression](https://developers.vtex.com/vtex-developer-docs/reference/test-jsonata-expression) endpoint.",
                 "operationId": "FeedConfiguration",
@@ -3630,17 +3598,16 @@
                             "schema": {
                                 "$ref": "#/components/schemas/FeedConfigurationRequest"
                             },
-                            "example": 
-                                {
-                                    "filter": {
-                                        "type": "FromOrders",
-                                        "expression": "value > 100",
-                                        "disableSingleFire": false
-                                    },
-                                    "queue": {
-                                        "visibilityTimeoutInSeconds": 250,
-                                        "MessageRetentionPeriodInSeconds": 345600
-                                    }
+                            "example": {
+                                "filter": {
+                                    "type": "FromOrders",
+                                    "expression": "value > 100",
+                                    "disableSingleFire": false
+                                },
+                                "queue": {
+                                    "visibilityTimeoutInSeconds": 250,
+                                    "MessageRetentionPeriodInSeconds": 345600
+                                }
                             }
                         }
                     },
@@ -3661,9 +3628,7 @@
                 "deprecated": false
             },
             "delete": {
-                "tags": [
-                    "Feed v3"
-                ],
+                "tags": ["Feed v3"],
                 "summary": "Delete feed configuration",
                 "description": "Deletes the configuration set up in Feed v3.",
                 "operationId": "FeedConfigurationDelete",
@@ -3708,9 +3673,7 @@
         },
         "/api/orders/feed": {
             "get": {
-                "tags": [
-                    "Feed v3"
-                ],
+                "tags": ["Feed v3"],
                 "summary": "Retrieve feed items",
                 "description": "Retrieve items from feed queue.",
                 "operationId": "Getfeedorderstatus1",
@@ -3780,9 +3743,7 @@
                 "deprecated": false
             },
             "post": {
-                "tags": [
-                    "Feed v3"
-                ],
+                "tags": ["Feed v3"],
                 "summary": "Commit feed items",
                 "description": "Commit items in the feed queue.",
                 "operationId": "Commititemfeedorderstatus",
@@ -3843,9 +3804,7 @@
         },
         "/api/orders/hook/config": {
             "get": {
-                "tags": [
-                    "Order hook"
-                ],
+                "tags": ["Order hook"],
                 "summary": "Get hook configuration",
                 "description": "Retrieves a given hook's configuration details.\n\r\n\rLearn more with the [orders hook guide](https://developers.vtex.com/vtex-rest-api/docs/orders-feed#hook).\r\n\r\n> 📘 Onboarding guide \r\n>\r\n> Check the new [Orders onboarding guide](https://developers.vtex.com/vtex-rest-api/docs/orders-overview). We created this guide to improve the onboarding experience for developers at VTEX. It assembles all documentation on our Developer Portal about Orders and is organized by focusing on the developer's journey.\r\n\r\n",
                 "operationId": "GetHookConfiguration",
@@ -3882,9 +3841,7 @@
                 "deprecated": false
             },
             "post": {
-                "tags": [
-                    "Order hook"
-                ],
+                "tags": ["Order hook"],
                 "summary": "Create or update hook configuration",
                 "description": "Configures filtering rules applied to orders hook. Learn more with the [orders hook guide](https://developers.vtex.com/vtex-rest-api/docs/orders-feed#hook).\n\r\n\rThere are two types of filtering that can be used: \n\r\n\r - `FromWorkflow`: filters orders by status.\n\r\n\r - `FromOrders`: uses JSONata expressions to filter orders according to any property in the orders JSON document.\n\r\n\r This enables stores to filter delivered orders and orders in which products have been added or removed, for example.\n\r\n\rTo learn more, access the [JSONata documentation](https://docs.jsonata.org/overview.html) and test filtering JSONata expressions with our [expressions API](https://developers.vtex.com/vtex-rest-api/reference/feed-v3#testjsonataexpression).",
                 "operationId": "HookConfiguration",
@@ -3919,22 +3876,21 @@
                             "schema": {
                                 "$ref": "#/components/schemas/HookConfigurationRequest"
                             },
-                            "example": 
-                                {
-                                    "filter": {
-                                        "type": "FromOrders",
-                                        "expression": "value > 100",
-                                        "disableSingleFire": false
-                                    },
-                                    "hook": {
-                                        "url": "https://endpoint.example/path",
-                                        "headers": {
-                                            "key": "value"
-                                        }
+                            "example": {
+                                "filter": {
+                                    "type": "FromOrders",
+                                    "expression": "value > 100",
+                                    "disableSingleFire": false
+                                },
+                                "hook": {
+                                    "url": "https://endpoint.example/path",
+                                    "headers": {
+                                        "key": "value"
                                     }
                                 }
-                          }
-                      },
+                            }
+                        }
+                    },
                     "required": true
                 },
                 "responses": {
@@ -3964,9 +3920,7 @@
                 "deprecated": false
             },
             "delete": {
-                "tags": [
-                    "Order hook"
-                ],
+                "tags": ["Order hook"],
                 "summary": "Delete hook configuration",
                 "description": "Deletes a given hook configuration.\n\r\n\rLearn more with the [orders hook guide](https://developers.vtex.com/vtex-rest-api/docs/orders-feed#hook).",
                 "operationId": "DeleteHookConfiguration",
@@ -4011,9 +3965,7 @@
         },
         "/api/oms/pvt/admin/reports/completed": {
             "get": {
-                "tags": [
-                    "Export order report"
-                ],
+                "tags": ["Export order report"],
                 "summary": "Export order report with status 'Completed'",
                 "description": "Retrieves a list of all order reports that are 'completed', by 'accountName'.",
                 "operationId": "StatusCompleted",
@@ -4203,9 +4155,7 @@
         },
         "/api/oms/pvt/admin/reports/inprogress": {
             "get": {
-                "tags": [
-                    "Export order report"
-                ],
+                "tags": ["Export order report"],
                 "summary": "Export order report with status 'In Progress'",
                 "description": "Retrieves a list of all order reports that are 'in progress', by 'accountName'.",
                 "operationId": "StatusInProgress",
@@ -4385,9 +4335,7 @@
         },
         "/api/oms/user/orders": {
             "get": {
-                "tags": [
-                    "User orders"
-                ],
+                "tags": ["User orders"],
                 "summary": "Retrieve user's orders",
                 "description": "Lists all orders from a given client, filtering by their email.",
                 "operationId": "Userorderslist",
@@ -4903,9 +4851,7 @@
         },
         "/api/oms/user/orders/{orderId}": {
             "get": {
-                "tags": [
-                    "User orders"
-                ],
+                "tags": ["User orders"],
                 "summary": "Retrieve user order details",
                 "description": "Lists all details from a user's order, through client's perspective.",
                 "operationId": "Userorderdetails",
@@ -5186,9 +5132,7 @@
                                                         "polygonName": null
                                                     }
                                                 ],
-                                                "shipsTo": [
-                                                    "BRA"
-                                                ],
+                                                "shipsTo": ["BRA"],
                                                 "deliveryIds": [
                                                     {
                                                         "courierId": "197a56f",
@@ -5344,9 +5288,7 @@
         },
         "/api/orders/expressions/jsonata": {
             "post": {
-                "tags": [
-                    "Feed v3"
-                ],
+                "tags": ["Feed v3"],
                 "summary": "Test JSONata expression",
                 "description": "This endpoint allows you to test a JSON document with a JSONata expression, returning `true` if the document meets the criteria posed in the expression or `false` if it does not.\n\r\n\rSince JSONata expressions can be used to filter order updates in the [Orders API feed and hook](https://developers.vtex.com/vtex-developer-docs/reference/feed-v3), this endpoint can be used to test an expression’s results before configuring the [feed](https://developers.vtex.com/vtex-developer-docs/reference/feed-v3#feedconfiguration) or [hook](https://developers.vtex.com/vtex-developer-docs/reference/order-hook#hookconfiguration).\n\r\n\rLearn more about how to use JSONata expressions, in the [JSONata documentation](https://docs.jsonata.org/overview.html).",
                 "operationId": "TestJSONataExpression",
@@ -5406,9 +5348,7 @@
         },
         "/api/checkout/pvt/configuration/window-to-change-seller": {
             "get": {
-                "tags": [
-                    "Change seller"
-                ],
+                "tags": ["Change seller"],
                 "summary": "Get window to change seller",
                 "description": "Retrieves a marketplace’s window to change seller, that is, the period when it is possible to choose another seller to fulfill a given order after the original seller has canceled it.\n\r\n\rThe default period for this window is of 2 days, but it can be configured by the request Update window to change seller.",
                 "operationId": "GetWindowToChangeSeller",
@@ -5457,9 +5397,7 @@
                 "deprecated": false
             },
             "post": {
-                "tags": [
-                    "Change seller"
-                ],
+                "tags": ["Change seller"],
                 "summary": "Update window to change seller",
                 "description": "Updates a marketplace’s window to change seller, that is, the period when it is possible to choose another seller to fulfill a given order after the original seller has canceled it.\n\r\n\rIt is possible to check the current window using the request Get window to change seller.",
                 "operationId": "UpdateWindowToChangeSeller",
@@ -5493,9 +5431,7 @@
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "required": [
-                                    "waitingTime"
-                                ],
+                                "required": ["waitingTime"],
                                 "properties": {
                                     "waitingTime": {
                                         "type": "integer",
@@ -5522,12 +5458,8 @@
     },
     "security": [
         {
-            "appKey": [
-                "{{appKey}}"
-            ],
-            "appToken": [
-                "{{appToken}}"
-            ]
+            "appKey": ["{{appKey}}"],
+            "appToken": ["{{appToken}}"]
         }
     ],
     "components": {
@@ -5745,7 +5677,7 @@
                     },
                     "openTextField": {
                         "type": "string",
-                        "description":"This field must be filled in using the following format: {\r\n    \"fieldExample\": \"ValueExample\"\r\n  }",
+                        "description": "This field must be filled in using the following format: {\r\n    \"fieldExample\": \"ValueExample\"\r\n  }",
                         "nullable": true
                     },
                     "roundingError": {
@@ -6016,9 +5948,7 @@
                                         "polygonName": null
                                     }
                                 ],
-                                "shipsTo": [
-                                    "BRA"
-                                ],
+                                "shipsTo": ["BRA"],
                                 "deliveryIds": [
                                     {
                                         "courierId": "197a56f",
@@ -6168,11 +6098,7 @@
             },
             "Total": {
                 "title": "Total",
-                "required": [
-                    "id",
-                    "name",
-                    "value"
-                ],
+                "required": ["id", "name", "value"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -6455,10 +6381,7 @@
             },
             "ItemAttachment": {
                 "title": "ItemAttachment",
-                "required": [
-                    "content",
-                    "name"
-                ],
+                "required": ["content", "name"],
                 "type": "object",
                 "properties": {
                     "content": {
@@ -6670,10 +6593,7 @@
             },
             "RatesAndBenefitsData": {
                 "title": "RatesAndBenefitsData",
-                "required": [
-                    "id",
-                    "rateAndBenefitsIdentifiers"
-                ],
+                "required": ["id", "rateAndBenefitsIdentifiers"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -6823,9 +6743,7 @@
                                     "polygonName": null
                                 }
                             ],
-                            "shipsTo": [
-                                "BRA"
-                            ],
+                            "shipsTo": ["BRA"],
                             "deliveryIds": [
                                 {
                                     "courierId": "197a56f",
@@ -7117,9 +7035,7 @@
                             "polygonName": null
                         }
                     ],
-                    "shipsTo": [
-                        "BRA"
-                    ],
+                    "shipsTo": ["BRA"],
                     "deliveryIds": [
                         {
                             "courierId": "197a56f",
@@ -7357,9 +7273,7 @@
             },
             "PaymentData": {
                 "title": "PaymentData",
-                "required": [
-                    "transactions"
-                ],
+                "required": ["transactions"],
                 "type": "object",
                 "properties": {
                     "transactions": {
@@ -7602,9 +7516,7 @@
             },
             "PackageAttachment": {
                 "title": "PackageAttachment",
-                "required": [
-                    "packages"
-                ],
+                "required": ["packages"],
                 "type": "object",
                 "properties": {
                     "packages": {
@@ -7621,11 +7533,7 @@
             },
             "Seller": {
                 "title": "Seller",
-                "required": [
-                    "id",
-                    "name",
-                    "logo"
-                ],
+                "required": ["id", "name", "logo"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -7646,10 +7554,7 @@
             },
             "ChangesAttachment": {
                 "title": "ChangesAttachment",
-                "required": [
-                    "id",
-                    "changesData"
-                ],
+                "required": ["id", "changesData"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -7791,11 +7696,7 @@
             },
             "Receipt": {
                 "title": "Receipt",
-                "required": [
-                    "date",
-                    "orderId",
-                    "receipt"
-                ],
+                "required": ["date", "orderId", "receipt"],
                 "type": "object",
                 "properties": {
                     "date": {
@@ -7900,11 +7801,7 @@
             },
             "Marketplace": {
                 "title": "Marketplace",
-                "required": [
-                    "baseURL",
-                    "isCertified",
-                    "name"
-                ],
+                "required": ["baseURL", "isCertified", "name"],
                 "type": "object",
                 "properties": {
                     "baseURL": {
@@ -7926,12 +7823,7 @@
             },
             "ListOrders": {
                 "title": "ListOrders",
-                "required": [
-                    "list",
-                    "facets",
-                    "paging",
-                    "stats"
-                ],
+                "required": ["list", "facets", "paging", "stats"],
                 "type": "object",
                 "properties": {
                     "list": {
@@ -8644,12 +8536,7 @@
             },
             "Paging": {
                 "title": "Paging",
-                "required": [
-                    "total",
-                    "pages",
-                    "currentPage",
-                    "perPage"
-                ],
+                "required": ["total", "pages", "currentPage", "perPage"],
                 "type": "object",
                 "properties": {
                     "total": {
@@ -8678,9 +8565,7 @@
             },
             "Stats": {
                 "title": "Stats",
-                "required": [
-                    "stats"
-                ],
+                "required": ["stats"],
                 "type": "object",
                 "properties": {
                     "stats": {
@@ -8792,10 +8677,7 @@
             },
             "Stats1": {
                 "title": "Stats1",
-                "required": [
-                    "totalValue",
-                    "totalItems"
-                ],
+                "required": ["totalValue", "totalItems"],
                 "type": "object",
                 "properties": {
                     "totalValue": {
@@ -9007,10 +8889,7 @@
             },
             "Facets": {
                 "title": "Facets",
-                "required": [
-                    "origin",
-                    "currencyCode"
-                ],
+                "required": ["origin", "currencyCode"],
                 "type": "object",
                 "properties": {
                     "origin": {
@@ -9062,10 +8941,7 @@
             },
             "Origin": {
                 "title": "Origin",
-                "required": [
-                    "Fulfillment",
-                    "Marketplace"
-                ],
+                "required": ["Fulfillment", "Marketplace"],
                 "type": "object",
                 "properties": {
                     "Fulfillment": {
@@ -9226,9 +9102,7 @@
             },
             "CurrencyCode": {
                 "title": "CurrencyCode",
-                "required": [
-                    "BRL"
-                ],
+                "required": ["BRL"],
                 "type": "object",
                 "properties": {
                     "BRL": {
@@ -9412,10 +9286,7 @@
             },
             "Facets1": {
                 "title": "Facets1",
-                "required": [
-                    "origin",
-                    "currencyCode"
-                ],
+                "required": ["origin", "currencyCode"],
                 "type": "object",
                 "properties": {
                     "origin": {
@@ -9467,10 +9338,7 @@
             },
             "Origin1": {
                 "title": "Origin1",
-                "required": [
-                    "Fulfillment",
-                    "Marketplace"
-                ],
+                "required": ["Fulfillment", "Marketplace"],
                 "type": "object",
                 "properties": {
                     "Fulfillment": {
@@ -9633,9 +9501,7 @@
             },
             "CurrencyCode1": {
                 "title": "CurrencyCode1",
-                "required": [
-                    "BRL"
-                ],
+                "required": ["BRL"],
                 "type": "object",
                 "properties": {
                     "BRL": {
@@ -9755,11 +9621,7 @@
                         "description": "List of items that should be removed from the order.",
                         "items": {
                             "type": "object",
-                            "required": [
-                                "id",
-                                "price",
-                                "quantity"
-                            ],
+                            "required": ["id", "price", "quantity"],
                             "properties": {
                                 "id": {
                                     "type": "string",
@@ -9786,11 +9648,7 @@
                         "description": "List of items that should be added to the order.",
                         "items": {
                             "type": "object",
-                            "required": [
-                                "id",
-                                "price",
-                                "quantity"
-                            ],
+                            "required": ["id", "price", "quantity"],
                             "properties": {
                                 "id": {
                                     "type": "string",
@@ -9859,10 +9717,7 @@
             },
             "AddLogRequest": {
                 "title": "AddLogRequest",
-                "required": [
-                    "source",
-                    "message"
-                ],
+                "required": ["source", "message"],
                 "type": "object",
                 "properties": {
                     "source": {
@@ -9895,7 +9750,7 @@
                     "issuanceDate": {
                         "type": "string",
                         "description": "Issuance date of the invoice. You must add date and time in this field.",
-                        "example":"2019-01-31T18:25:43-05:00"
+                        "example": "2019-01-31T18:25:43-05:00"
                     },
                     "invoiceNumber": {
                         "type": "string",
@@ -9974,11 +9829,7 @@
             },
             "Item1": {
                 "title": "Item1",
-                "required": [
-                    "id",
-                    "price",
-                    "quantity"
-                ],
+                "required": ["id", "price", "quantity"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -10047,11 +9898,7 @@
             },
             "Updatepartialinvoice.SendTrackingNumber": {
                 "title": "Updatepartialinvoice.SendTrackingNumber",
-                "required": [
-                    "date",
-                    "orderId",
-                    "receipt"
-                ],
+                "required": ["date", "orderId", "receipt"],
                 "type": "object",
                 "properties": {
                     "date": {
@@ -10072,11 +9919,7 @@
             },
             "UpdateTrackingStatusRequest": {
                 "title": "UpdateTrackingStatusRequest",
-                "required": [
-                    "isDelivered",
-                    "deliveredDate",
-                    "events"
-                ],
+                "required": ["isDelivered", "deliveredDate", "events"],
                 "type": "object",
                 "properties": {
                     "isDelivered": {
@@ -10117,12 +9960,7 @@
             },
             "Event": {
                 "title": "Event",
-                "required": [
-                    "city",
-                    "state",
-                    "description",
-                    "date"
-                ],
+                "required": ["city", "state", "description", "date"],
                 "type": "object",
                 "properties": {
                     "city": {
@@ -10147,11 +9985,7 @@
             },
             "UpdateTrackingStatus": {
                 "title": "UpdateTrackingStatus",
-                "required": [
-                    "date",
-                    "orderId",
-                    "receipt"
-                ],
+                "required": ["date", "orderId", "receipt"],
                 "type": "object",
                 "properties": {
                     "date": {
@@ -10554,12 +10388,7 @@
             },
             "ConnectorResponses": {
                 "title": "ConnectorResponses",
-                "required": [
-                    "Tid",
-                    "ReturnCode",
-                    "Message",
-                    "authId"
-                ],
+                "required": ["Tid", "ReturnCode", "Message", "authId"],
                 "type": "object",
                 "properties": {
                     "Tid": {
@@ -10586,9 +10415,7 @@
             },
             "ConfirmitemfeedorderstatusRequest": {
                 "title": "ConfirmitemfeedorderstatusRequest",
-                "required": [
-                    "commitToken"
-                ],
+                "required": ["commitToken"],
                 "type": "object",
                 "properties": {
                     "commitToken": {
@@ -10651,9 +10478,7 @@
             },
             "CommititemfeedorderstatusRequest": {
                 "title": "CommititemfeedorderstatusRequest",
-                "required": [
-                    "handles"
-                ],
+                "required": ["handles"],
                 "type": "object",
                 "properties": {
                     "handles": {
@@ -10672,10 +10497,7 @@
             },
             "FeedConfigurationRequest": {
                 "title": "FeedConfigurationRequest",
-                "required": [
-                    "filter",
-                    "queue"
-                ],
+                "required": ["filter", "queue"],
                 "type": "object",
                 "properties": {
                     "filter": {
@@ -10688,9 +10510,7 @@
             },
             "FeedFilter": {
                 "title": "Filter",
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -10718,9 +10538,7 @@
             },
             "HookFilter": {
                 "title": "Filter",
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -10770,45 +10588,38 @@
             },
             "HookConfigurationRequest": {
                 "title": "HookConfigurationRequest",
-                "required": [
-                    "filter",
-                    "hook"
-                ],
+                "required": ["filter", "hook"],
                 "type": "object",
                 "properties": {
-                      "filter": {
+                    "filter": {
                         "$ref": "#/components/schemas/HookFilter"
-                      },
-                      "hook": {
+                    },
+                    "hook": {
                         "$ref": "#/components/schemas/Hook"
-                      }
+                    }
                 },
-                "example":
-                    {
-                        "filter": {
-                            "type": "FromWorkflow",
-                            "status": [
-                                "order-completed",
-                                "handling",
-                                "ready-for-handling",
-                                "waiting-ffmt-authorization",
-                                "cancel"
-                            ]
-                        },
-                        "hook": {
-                            "url": "https://endpoint.example/path",
-                            "headers": {
-                                "key": "value"
-                            }
+                "example": {
+                    "filter": {
+                        "type": "FromWorkflow",
+                        "status": [
+                            "order-completed",
+                            "handling",
+                            "ready-for-handling",
+                            "waiting-ffmt-authorization",
+                            "cancel"
+                        ]
+                    },
+                    "hook": {
+                        "url": "https://endpoint.example/path",
+                        "headers": {
+                            "key": "value"
                         }
-                    }    
+                    }
+                }
             },
             "Hook": {
                 "title": "Hook",
-                "required": [
-                    "url",
-                    "headers"
-                ],
+                "required": ["url", "headers"],
                 "type": "object",
                 "properties": {
                     "url": {
@@ -10827,9 +10638,7 @@
             },
             "Headers": {
                 "title": "Headers",
-                "required": [
-                    "key"
-                ],
+                "required": ["key"],
                 "type": "object",
                 "properties": {
                     "key": {
@@ -10890,10 +10699,7 @@
             },
             "Origin2": {
                 "title": "Origin2",
-                "required": [
-                    "Account",
-                    "Key"
-                ],
+                "required": ["Account", "Key"],
                 "type": "object",
                 "properties": {
                     "Account": {
@@ -11096,12 +10902,7 @@
             },
             "Userorderslist": {
                 "title": "Userorderslist",
-                "required": [
-                    "list",
-                    "facets",
-                    "paging",
-                    "stats"
-                ],
+                "required": ["list", "facets", "paging", "stats"],
                 "type": "object",
                 "properties": {
                     "list": {
@@ -11782,9 +11583,7 @@
             },
             "Stats2": {
                 "title": "Stats2",
-                "required": [
-                    "stats"
-                ],
+                "required": ["stats"],
                 "type": "object",
                 "properties": {
                     "stats": {
@@ -11820,10 +11619,7 @@
             },
             "Stats3": {
                 "title": "Stats3",
-                "required": [
-                    "totalValue",
-                    "totalItems"
-                ],
+                "required": ["totalValue", "totalItems"],
                 "type": "object",
                 "properties": {
                     "totalValue": {
@@ -12157,7 +11953,7 @@
                     },
                     "openTextField": {
                         "type": "string",
-                        "description":"This field must be filled in using the following format: {\r\n    \"fieldExample\": \"ValueExample\"\r\n  }",
+                        "description": "This field must be filled in using the following format: {\r\n    \"fieldExample\": \"ValueExample\"\r\n  }",
                         "nullable": true
                     },
                     "roundingError": {
@@ -12424,9 +12220,7 @@
                                         "polygonName": null
                                     }
                                 ],
-                                "shipsTo": [
-                                    "BRA"
-                                ],
+                                "shipsTo": ["BRA"],
                                 "deliveryIds": [
                                     {
                                         "courierId": "197a56f",
@@ -12576,10 +12370,7 @@
             },
             "TestJSONataExpression": {
                 "type": "object",
-                "required": [
-                    "Expression",
-                    "Document"
-                ],
+                "required": ["Expression", "Document"],
                 "properties": {
                     "Expression": {
                         "type": "string",
@@ -12589,6 +12380,19 @@
                         "type": "string",
                         "description": "JSON document to be evaluated by the expression."
                     }
+                }
+            }
+        },
+        "parameters": {
+            "reason": {
+                "name": "reason",
+                "in": "query",
+                "description": "This parameter is relevant only for PII-compliant accounts. When sending requests to this endpoint, PII-compliant accounts can use this parameter to declare the reason for requesting unmasked data. Otherwise this endpoint will return masked PII data.",
+                "required": false,
+                "style": "form",
+                "schema": {
+                    "type": "string",
+                    "example": "data-validation"
                 }
             }
         }

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -2211,7 +2211,7 @@
             "post": {
                 "tags": ["Orders"],
                 "summary": "Start handling order",
-                "description": "Change the status of an order to indicate that is is in `handling`.\n\r\n\r> Expect a `status 204` response with no content in case of a successful request. The store must validate this response to retry the call if the responses differs from the 204 code, making this flow the store's responsibility. This endpoint can also respond with `status 500`. \n\r\n\r> The `Change order workflow status` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).",
+                "description": "Changes the status of an order to indicate that it is in `handling`.\n\r\n\r> Expect a `status 204` response with no content in case of a successful request. The store must validate this response to retry the call if the response differs from the `204` code, making this flow the store's responsibility. This endpoint can also respond with `status 500`. \n\r\n\r> The `Change order workflow status` resource is needed to use this API request. This is included in `OMS - Full access` and `IntegrationProfile - Fulfillment Oms`, among other default roles available in the Admin. Learn more about the [License manager roles and resources](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#).",
                 "operationId": "StartHandling",
                 "parameters": [
                     {

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -12387,7 +12387,7 @@
             "reason": {
                 "name": "reason",
                 "in": "query",
-                "description": "This parameter is relevant only for PII-compliant accounts. When sending requests to this endpoint, PII-compliant accounts can use this parameter to declare the reason for requesting unmasked data. Otherwise this endpoint will return masked PII data.",
+                "description": "This parameter is relevant only for PII-compliant accounts. When sending requests to this endpoint, PII-compliant accounts can use this parameter to declare the reason for requesting unmasked data. Otherwise, this endpoint will return masked PII data.",
                 "required": false,
                 "style": "form",
                 "schema": {

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -5677,7 +5677,7 @@
                     },
                     "openTextField": {
                         "type": "string",
-                        "description": "This field must be filled in using the following format: {\r\n    \"fieldExample\": \"ValueExample\"\r\n  }",
+                        "description": "This field must be filled in using the following format: \n\r```\n\r{\r\n    \"fieldExample\": \"ValueExample\"\r\n  }\n\r```\n\r",
                         "nullable": true
                     },
                     "roundingError": {
@@ -11953,7 +11953,7 @@
                     },
                     "openTextField": {
                         "type": "string",
-                        "description": "This field must be filled in using the following format: {\r\n    \"fieldExample\": \"ValueExample\"\r\n  }",
+                        "description": "This field must be filled in using the following format: \n\r```\n\r{\r\n    \"fieldExample\": \"ValueExample\"\r\n  }\n\r```\n\r",
                         "nullable": true
                     },
                     "roundingError": {

--- a/VTEX - VTEX Do API.json
+++ b/VTEX - VTEX Do API.json
@@ -25,9 +25,7 @@
     "paths": {
         "/notes": {
             "post": {
-                "tags": [
-                    "Note"
-                ],
+                "tags": ["Note"],
                 "summary": "Create Note",
                 "description": "Creates new note in VTEX Do. Beware of these limitations:\n\r> Maximum number of notes for any single order: 30\n\r> Maximum number of characters in a note's description: 2000",
                 "operationId": "NewNote",
@@ -60,11 +58,7 @@
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "required": [
-                                    "target",
-                                    "domain",
-                                    "description"
-                                ],
+                                "required": ["target", "domain", "description"],
                                 "properties": {
                                     "target": {
                                         "type": "object",
@@ -134,9 +128,7 @@
                 "deprecated": false
             },
             "get": {
-                "tags": [
-                    "Note"
-                ],
+                "tags": ["Note"],
                 "summary": "Get Notes by orderId",
                 "description": "Retrieves notes related to a specific `orderId`.",
                 "operationId": "GetNotesbyorderId",
@@ -199,6 +191,9 @@
                             "type": "string",
                             "example": "application/json"
                         }
+                    },
+                    {
+                        "$ref": "#/components/parameters/reason"
                     }
                 ],
                 "responses": {
@@ -217,9 +212,7 @@
         },
         "/notes/{noteId}": {
             "get": {
-                "tags": [
-                    "Note"
-                ],
+                "tags": ["Note"],
                 "summary": "Retrieve Note",
                 "description": "Retrieves a given note in VTEX Do, filtering by `noteId`.",
                 "operationId": "GetNote",
@@ -256,6 +249,9 @@
                             "type": "string",
                             "example": "654321cba"
                         }
+                    },
+                    {
+                        "$ref": "#/components/parameters/reason"
                     }
                 ],
                 "responses": {
@@ -274,9 +270,7 @@
         },
         "/tasks": {
             "post": {
-                "tags": [
-                    "Task"
-                ],
+                "tags": ["Task"],
                 "summary": "Create Task",
                 "description": "Creates a new task in VTEX Do.",
                 "operationId": "NewTask",
@@ -358,9 +352,7 @@
                 "deprecated": false
             },
             "get": {
-                "tags": [
-                    "Task"
-                ],
+                "tags": ["Task"],
                 "summary": "List tasks",
                 "description": "There are four options of filtering your list of tasks. It is possible to filter them by: assignees, filtering by their emails and status; targets, filtering by the `targetId` and `status`; paged tasks, filtering by `page`, `perPage` and `status`; and context, filtering by `context`, `page`, `perPage`, and `status`.",
                 "operationId": "Listtasksbyassignee",
@@ -476,9 +468,7 @@
         },
         "/tasks/{taskId}": {
             "get": {
-                "tags": [
-                    "Task"
-                ],
+                "tags": ["Task"],
                 "summary": "Retrieve Task",
                 "description": "Retrieves a give task, filtering by `taskId`.",
                 "operationId": "GetTask",
@@ -531,9 +521,7 @@
                 "deprecated": false
             },
             "put": {
-                "tags": [
-                    "Task"
-                ],
+                "tags": ["Task"],
                 "summary": "Update Task",
                 "description": "Updates a given task's status, for example, filtering by `taskId`.",
                 "operationId": "EditTask",
@@ -602,9 +590,7 @@
         },
         "/tasks/{taskId}/comments": {
             "post": {
-                "tags": [
-                    "Task"
-                ],
+                "tags": ["Task"],
                 "summary": "Add Comment on a Task",
                 "description": "Adds a comment to a given task, filtering by `taskId`.",
                 "operationId": "AddComment",
@@ -676,11 +662,7 @@
         "schemas": {
             "NewNoteRequest": {
                 "type": "object",
-                "required": [
-                    "target",
-                    "domain",
-                    "description"
-                ],
+                "required": ["target", "domain", "description"],
                 "properties": {
                     "target": {
                         "type": "object",
@@ -707,11 +689,7 @@
             },
             "Target": {
                 "title": "Target",
-                "required": [
-                    "id",
-                    "type",
-                    "url"
-                ],
+                "required": ["id", "type", "url"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -822,11 +800,7 @@
             },
             "Assignee": {
                 "title": "Assignee",
-                "required": [
-                    "id",
-                    "name",
-                    "email"
-                ],
+                "required": ["id", "name", "email"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -849,11 +823,7 @@
             },
             "Follower": {
                 "title": "Follower",
-                "required": [
-                    "id",
-                    "name",
-                    "email"
-                ],
+                "required": ["id", "name", "email"],
                 "type": "object",
                 "properties": {
                     "id": {
@@ -876,9 +846,7 @@
             },
             "AddCommentRequest": {
                 "title": "AddCommentRequest",
-                "required": [
-                    "text"
-                ],
+                "required": ["text"],
                 "type": "object",
                 "properties": {
                     "text": {
@@ -891,9 +859,7 @@
             },
             "EditTaskRequest": {
                 "title": "EditTaskRequest",
-                "required": [
-                    "status"
-                ],
+                "required": ["status"],
                 "type": "object",
                 "properties": {
                     "status": {
@@ -915,6 +881,19 @@
                 "type": "apiKey",
                 "in": "header",
                 "name": "X-VTEX-API-AppToken"
+            }
+        },
+        "parameters": {
+            "reason": {
+                "name": "reason",
+                "in": "query",
+                "description": "This parameter is relevant only for PII-compliant accounts. When sending requests to this endpoint, PII-compliant accounts can use this parameter to declare the reason for requesting unmasked data. Otherwise this endpoint will return masked PII data.",
+                "required": false,
+                "style": "form",
+                "schema": {
+                    "type": "string",
+                    "example": "data-validation"
+                }
             }
         }
     },

--- a/VTEX - VTEX Do API.json
+++ b/VTEX - VTEX Do API.json
@@ -887,7 +887,7 @@
             "reason": {
                 "name": "reason",
                 "in": "query",
-                "description": "This parameter is relevant only for PII-compliant accounts. When sending requests to this endpoint, PII-compliant accounts can use this parameter to declare the reason for requesting unmasked data. Otherwise this endpoint will return masked PII data.",
+                "description": "This parameter is relevant only for PII-compliant accounts. When sending requests to this endpoint, PII-compliant accounts can use this parameter to declare the reason for requesting unmasked data. Otherwise, this endpoint will return masked PII data.",
                 "required": false,
                 "style": "form",
                 "schema": {


### PR DESCRIPTION
This PR adds the parameter `reason` to 3 orders endpoints that were previously not available for PII-compliant accounts. Now they need this parameter in order to retrieve unmasked information.

#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

