### PR TITLE
Added `clearAddressIfPostalCodeNotFound` property

### DIFF
--- a/VTEX - Checkout API.json
+++ b/VTEX - Checkout API.json
@@ -6663,6 +6663,11 @@
                             "schema": {
                                 "type": "object",
                                 "properties": {
+                                    "clearAddressIfPostalCodeNotFound": {
+                                        "type": "boolean",
+                                        "description": "This field should be sent as `false` to prevent the address information from being filled in automatically based on the `postalCode` information.",
+                                        "example": false
+                                    },
                                     "selectedAddresses": {
                                         "type": "array",
                                         "description": "List of objects with addresses information.",


### PR DESCRIPTION
#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [X] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [X] No, but I am going to.

Added `clearAddressIfPostalCodeNotFound` property to the "Add shipping address and select delivery option" endpoint [EDU-8781]

[EDU-8781]: https://vtex-dev.atlassian.net/browse/EDU-8781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ