### PR TITLE
Updated Create SKU example (again)

### DIFF
--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -3522,13 +3522,14 @@
                                     "EstimatedDateArrival": {
                                         "title": "EstimatedDateArrival",
                                         "type": "string",
-                                        "description": "To add the product as pre-sale, enter the product estimated arrival date. You must take into consideration both the launch date and the freight calculation for the arrival date.",
-                                        "example": "2020-02-25T15:51:29.2614605"
+                                        "nullable": true,
+                                        "description": "To add the product as pre-sale, enter the product estimated arrival date in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format. You must take into consideration both the launch date and the freight calculation for the arrival date.",
+                                        "example": null
                                     },
                                     "ManufacturerCode": {
                                         "type": "string",
                                         "title": "ManufacturerCode",
-                                        "description": "Provided by the manufacturers to identify their product. This field should be completed if the product has a specific manufacturer’s code.",
+                                        "description": "Provided by the manufacturers to identify their product. This field should be filled in if the product has a specific manufacturer’s code.",
                                         "example": "123"
                                     },
                                     "CommercialConditionId": {
@@ -3552,8 +3553,9 @@
                                     "ModalType": {
                                         "title": "ModalType",
                                         "type": "string",
-                                        "description": "Links an unusual type of product to a carrier specialized in delivering it. To learn more about this feature, read our articles [How the modal works](https://help.vtex.com/en/tutorial/how-does-the-modal-work--tutorials_125) and [Setting up modal for carriers](https://help.vtex.com/en/tutorial/configure-modal--3jhLqxuPhuiq24UoykCcqy).",
-                                        "example": ""
+                                        "nullable": true,
+                                        "description": "Links an unusual type of product to a carrier specialized in delivering it. This field should be filled in with the name of the modal (e.g. \"Chemicals\" or \"Refrigerated products\"). To learn more about this feature, read our articles [How the modal works](https://help.vtex.com/en/tutorial/how-does-the-modal-work--tutorials_125) and [Setting up modal for carriers](https://help.vtex.com/en/tutorial/configure-modal--3jhLqxuPhuiq24UoykCcqy).",
+                                        "example": null
                                     },
                                     "KitItensSellApart": {
                                         "type": "boolean",


### PR DESCRIPTION
Changed ModalType and EstimatedDateArrival to nullable and updated examples in Create SKU endpoint. Also added more details in the request body description for these fields.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.
- [x] No, this is not necessary in this case.
