### PR TITLE
Fix Marketplace Protocol response example

### DIFF
--- a/VTEX - Marketplace Protocol - External Seller Fulfillment.json
+++ b/VTEX - Marketplace Protocol - External Seller Fulfillment.json
@@ -1151,7 +1151,7 @@
                             "application/json": {
                                 "examples": {
                                     "response": {
-                                        "value": {
+                                        "value": [{
                                             "marketplaceOrderId": "959311095",
                                             "marketplaceServicesEndpoint": "https://marketplaceservicesendpoint/",
                                             "marketplacePaymentValue": 11080,
@@ -1228,7 +1228,7 @@
                                                 "utmiCampaign": "artscase for iphone 5"
                                             },
                                             "paymentData": null
-                                        }
+                                        }]
                                     }
                                 }
                             }

--- a/VTEX - Marketplace Protocol - External Seller Fulfillment.json
+++ b/VTEX - Marketplace Protocol - External Seller Fulfillment.json
@@ -1151,84 +1151,86 @@
                             "application/json": {
                                 "examples": {
                                     "response": {
-                                        "value": [{
-                                            "marketplaceOrderId": "959311095",
-                                            "marketplaceServicesEndpoint": "https://marketplaceservicesendpoint/",
-                                            "marketplacePaymentValue": 11080,
-                                            "items": [
-                                                {
-                                                    "id": "2002495",
-                                                    "quantity": 1,
-                                                    "Seller": "1",
-                                                    "commission": 0,
-                                                    "freightCommission": 0,
-                                                    "price": 9990,
-                                                    "bundleItems": [],
-                                                    "itemAttachment": {
-                                                        "name": null,
-                                                        "content": {}
-                                                    },
-                                                    "attachments": [],
-                                                    "priceTags": [],
-                                                    "measurementUnit": null,
-                                                    "unitMultiplier": 0,
-                                                    "isGift": false
-                                                }
-                                            ],
-                                            "clientProfileData": {
-                                                "email": "32172239852@gmail.com.br",
-                                                "firstName": "John",
-                                                "lastName": "Smith",
-                                                "documentType": null,
-                                                "document": "3244239851",
-                                                "phone": "399271258",
-                                                "corporateName": null,
-                                                "tradeName": null,
-                                                "corporateDocument": null,
-                                                "stateInscription": null,
-                                                "corporatePhone": null,
-                                                "isCorporate": false,
-                                                "userProfileId": null
-                                            },
-                                            "shippingData": {
-                                                "address": {
-                                                    "addressType": "Residencial",
-                                                    "receiverName": "John Smith",
-                                                    "addressId": "Home",
-                                                    "postalCode": "13476103",
-                                                    "city": "Americana",
-                                                    "state": "SP",
-                                                    "country": "BRA",
-                                                    "street": "JOÃO DAMÁZIO GOMES",
-                                                    "number": "311",
-                                                    "neighborhood": "SÃO JOSÉ",
-                                                    "complement": null,
-                                                    "reference": "Bairro Praia Azul / Posto de Saúde 17",
-                                                    "geoCoordinates": []
-                                                },
-                                                "logisticsInfo": [
+                                        "value": [
+                                            {
+                                                "marketplaceOrderId": "959311095",
+                                                "marketplaceServicesEndpoint": "https://marketplaceservicesendpoint/",
+                                                "marketplacePaymentValue": 11080,
+                                                "items": [
                                                     {
-                                                        "itemIndex": 0,
-                                                        "selectedSla": "Regular",
-                                                        "lockTTL": "8d",
-                                                        "shippingEstimate": "7d",
-                                                        "price": 1090,
-                                                        "deliveryWindow": null
+                                                        "id": "2002495",
+                                                        "quantity": 1,
+                                                        "Seller": "1",
+                                                        "commission": 0,
+                                                        "freightCommission": 0,
+                                                        "price": 9990,
+                                                        "bundleItems": [],
+                                                        "itemAttachment": {
+                                                            "name": null,
+                                                            "content": {}
+                                                        },
+                                                        "attachments": [],
+                                                        "priceTags": [],
+                                                        "measurementUnit": null,
+                                                        "unitMultiplier": 0,
+                                                        "isGift": false
                                                     }
                                                 ],
-                                                "updateStatus": "updated"
-                                            },
-                                            "openTextField": null,
-                                            "marketingData": {
-                                                "utmSource": "buscape",
-                                                "utmMedium": "",
-                                                "utmCampaign": "freeshipping",
-                                                "utmiPage": "_",
-                                                "utmiPart": "BuscaFullText",
-                                                "utmiCampaign": "artscase for iphone 5"
-                                            },
-                                            "paymentData": null
-                                        }]
+                                                "clientProfileData": {
+                                                    "email": "32172239852@gmail.com.br",
+                                                    "firstName": "John",
+                                                    "lastName": "Smith",
+                                                    "documentType": null,
+                                                    "document": "3244239851",
+                                                    "phone": "399271258",
+                                                    "corporateName": null,
+                                                    "tradeName": null,
+                                                    "corporateDocument": null,
+                                                    "stateInscription": null,
+                                                    "corporatePhone": null,
+                                                    "isCorporate": false,
+                                                    "userProfileId": null
+                                                },
+                                                "shippingData": {
+                                                    "address": {
+                                                        "addressType": "Residencial",
+                                                        "receiverName": "John Smith",
+                                                        "addressId": "Home",
+                                                        "postalCode": "13476103",
+                                                        "city": "Americana",
+                                                        "state": "SP",
+                                                        "country": "BRA",
+                                                        "street": "JOÃO DAMÁZIO GOMES",
+                                                        "number": "311",
+                                                        "neighborhood": "SÃO JOSÉ",
+                                                        "complement": null,
+                                                        "reference": "Bairro Praia Azul / Posto de Saúde 17",
+                                                        "geoCoordinates": []
+                                                    },
+                                                    "logisticsInfo": [
+                                                        {
+                                                            "itemIndex": 0,
+                                                            "selectedSla": "Regular",
+                                                            "lockTTL": "8d",
+                                                            "shippingEstimate": "7d",
+                                                            "price": 1090,
+                                                            "deliveryWindow": null
+                                                        }
+                                                    ],
+                                                    "updateStatus": "updated"
+                                                },
+                                                "openTextField": null,
+                                                "marketingData": {
+                                                    "utmSource": "buscape",
+                                                    "utmMedium": "",
+                                                    "utmCampaign": "freeshipping",
+                                                    "utmiPage": "_",
+                                                    "utmiPart": "BuscaFullText",
+                                                    "utmiCampaign": "artscase for iphone 5"
+                                                },
+                                                "paymentData": null
+                                            }
+                                        ]
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixing the response example to an array as requested in [EDU-9665](https://vtex-dev.atlassian.net/browse/EDU-9665). This is only a quick fix of the reported case. In the following weeks, @anabaarbosa will add the full response schemas as part of [EDU-9523 Update Marketplace Protocol responses in openapi](https://vtex-dev.atlassian.net/browse/EDU-9523).

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [x] No, but I am going to.


[EDU-9665]: https://vtex-dev.atlassian.net/browse/EDU-9665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ