### PR TITLE
Remove List Payment Methods endpoint reference

### DIFF
--- a/VTEX - Payment Provider Protocol.json
+++ b/VTEX - Payment Provider Protocol.json
@@ -314,7 +314,7 @@
                                     "paymentMethod": {
                                         "type": "string",
                                         "title": "paymentMethod",
-                                        "description": "The payment method chosen for this payment. It must be one of the available payment methods offered by the provider, which can be obtained from the [List Payment Methods endpoint](https://developers.vtex.com/vtex-rest-api/reference/paymentmethods) or [List Payment Provider Manifest endpoint](https://developers.vtex.com/vtex-rest-api/reference/manifest-1).",
+                                        "description": "The payment method chosen for this payment. It must be one of the available payment methods offered by the provider, which can be obtained from the [List Payment Provider Manifest endpoint](https://developers.vtex.com/docs/api-reference/payment-provider-protocol#get-/manifest).",
                                         "example": "Diners",
                                         "pattern": "^(.*)$"
                                     },


### PR DESCRIPTION
#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [X] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [X] No, but I am going to.

PR was created to remove reference to the "List Payment Methods" endpoint, which is being deprecated (EDU-9843).
