### PR TITLE
Removing all blank titles from the Catalog API Seller Portal

### DIFF
--- a/VTEX - Catalog API Seller Portal.json
+++ b/VTEX - Catalog API Seller Portal.json
@@ -162,7 +162,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": [
                                         "status",
                                         "name",
@@ -222,8 +221,7 @@
                                             "description": "Product's Categories unique identifier numbers. It can have multiples IDs for each Category and Subcategories.",
                                             "example": ["732"],
                                             "items": {
-                                                "type": "string",
-                                                "title": ""
+                                                "type": "string"
                                             }
                                         },
                                         "categoryNames": {
@@ -232,8 +230,7 @@
                                             "description": "Names of the product's categories, displayed in a path format.",
                                             "example": ["/Men/Acessories/"],
                                             "items": {
-                                                "type": "string",
-                                                "title": ""
+                                                "type": "string"
                                             }
                                         },
                                         "specs": {
@@ -252,7 +249,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": ["name", "values"],
                                                 "properties": {
                                                     "name": {
@@ -270,8 +266,7 @@
                                                             "White"
                                                         ],
                                                         "items": {
-                                                            "type": "string",
-                                                            "title": ""
+                                                            "type": "string"
                                                         }
                                                     }
                                                 }
@@ -292,7 +287,6 @@
                                                 }
                                             ],
                                             "items": {
-                                                "title": "",
                                                 "required": ["name", "value"],
                                                 "properties": {
                                                     "name": {
@@ -329,7 +323,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": ["id", "url"],
                                                 "properties": {
                                                     "id": {
@@ -409,7 +402,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": [
                                                     "id",
                                                     "isActive",
@@ -507,7 +499,6 @@
                                                         ],
                                                         "items": {
                                                             "type": "object",
-                                                            "title": "",
                                                             "required": [
                                                                 "name",
                                                                 "value"
@@ -710,7 +701,6 @@
                             },
                             "schema": {
                                 "type": "object",
-                                "title": "",
                                 "required": [
                                     "status",
                                     "name",
@@ -760,8 +750,7 @@
                                         "description": "Product's Categories unique identifier numbers. It can have multiples IDs for each Category and Subcategories.",
                                         "example": ["732"],
                                         "items": {
-                                            "type": "string",
-                                            "title": ""
+                                            "type": "string"
                                         }
                                     },
                                     "specs": {
@@ -780,7 +769,6 @@
                                         ],
                                         "items": {
                                             "type": "object",
-                                            "title": "",
                                             "required": ["name", "values"],
                                             "properties": {
                                                 "name": {
@@ -798,8 +786,7 @@
                                                         "White"
                                                     ],
                                                     "items": {
-                                                        "type": "string",
-                                                        "title": ""
+                                                        "type": "string"
                                                     }
                                                 }
                                             }
@@ -820,7 +807,6 @@
                                             }
                                         ],
                                         "items": {
-                                            "title": "",
                                             "required": ["name", "value"],
                                             "properties": {
                                                 "name": {
@@ -871,7 +857,6 @@
                                         ],
                                         "items": {
                                             "type": "object",
-                                            "title": "",
                                             "required": ["id", "url"],
                                             "properties": {
                                                 "id": {
@@ -953,7 +938,6 @@
                                         ],
                                         "items": {
                                             "type": "object",
-                                            "title": "",
                                             "required": [
                                                 "isActive",
                                                 "weight",
@@ -1056,7 +1040,6 @@
                                                     ],
                                                     "items": {
                                                         "type": "object",
-                                                        "title": "",
                                                         "required": [
                                                             "name",
                                                             "value"
@@ -1161,7 +1144,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": [
                                         "productId",
                                         "createdAt",
@@ -1241,7 +1223,6 @@
                             },
                             "schema": {
                                 "type": "object",
-                                "title": "",
                                 "required": ["productId", "description"],
                                 "properties": {
                                     "productId": {
@@ -1407,7 +1388,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": [
                                         "status",
                                         "name",
@@ -1467,8 +1447,7 @@
                                             "description": "Product's Categories unique identifier numbers. It can have multiples IDs for each Category and Subcategories.",
                                             "example": ["732"],
                                             "items": {
-                                                "type": "string",
-                                                "title": ""
+                                                "type": "string"
                                             }
                                         },
                                         "categoryNames": {
@@ -1477,8 +1456,7 @@
                                             "description": "Names of the product's categories, displayed in a path format.",
                                             "example": ["/Men/Acessories/"],
                                             "items": {
-                                                "type": "string",
-                                                "title": ""
+                                                "type": "string"
                                             }
                                         },
                                         "specs": {
@@ -1497,7 +1475,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": ["name", "values"],
                                                 "properties": {
                                                     "name": {
@@ -1515,8 +1492,7 @@
                                                             "White"
                                                         ],
                                                         "items": {
-                                                            "type": "string",
-                                                            "title": ""
+                                                            "type": "string"
                                                         }
                                                     }
                                                 }
@@ -1537,7 +1513,6 @@
                                                 }
                                             ],
                                             "items": {
-                                                "title": "",
                                                 "required": ["name", "value"],
                                                 "properties": {
                                                     "name": {
@@ -1574,7 +1549,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": ["id", "url"],
                                                 "properties": {
                                                     "id": {
@@ -1654,7 +1628,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": [
                                                     "id",
                                                     "isActive",
@@ -1752,7 +1725,6 @@
                                                         ],
                                                         "items": {
                                                             "type": "object",
-                                                            "title": "",
                                                             "required": [
                                                                 "name",
                                                                 "value"
@@ -1942,7 +1914,6 @@
                             },
                             "schema": {
                                 "type": "object",
-                                "title": "",
                                 "required": [
                                     "status",
                                     "name",
@@ -1986,8 +1957,7 @@
                                         "description": "Product's Categories unique identifier numbers. It can have multiples IDs for each Category and Subcategories.",
                                         "example": ["732"],
                                         "items": {
-                                            "type": "string",
-                                            "title": ""
+                                            "type": "string"
                                         }
                                     },
                                     "specs": {
@@ -2006,7 +1976,6 @@
                                         ],
                                         "items": {
                                             "type": "object",
-                                            "title": "",
                                             "required": ["name", "values"],
                                             "properties": {
                                                 "name": {
@@ -2024,8 +1993,7 @@
                                                         "White"
                                                     ],
                                                     "items": {
-                                                        "type": "string",
-                                                        "title": ""
+                                                        "type": "string"
                                                     }
                                                 }
                                             }
@@ -2046,7 +2014,6 @@
                                             }
                                         ],
                                         "items": {
-                                            "title": "",
                                             "required": ["name", "value"],
                                             "properties": {
                                                 "name": {
@@ -2083,7 +2050,6 @@
                                         ],
                                         "items": {
                                             "type": "object",
-                                            "title": "",
                                             "required": ["id", "url"],
                                             "properties": {
                                                 "id": {
@@ -2165,7 +2131,6 @@
                                         ],
                                         "items": {
                                             "type": "object",
-                                            "title": "",
                                             "required": [
                                                 "name",
                                                 "isActive",
@@ -2263,7 +2228,6 @@
                                                     ],
                                                     "items": {
                                                         "type": "object",
-                                                        "title": "",
                                                         "required": [
                                                             "name",
                                                             "value"
@@ -2417,7 +2381,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": [
                                         "status",
                                         "name",
@@ -2477,8 +2440,7 @@
                                             "description": "Product's Categories unique identifier numbers. It can have multiples IDs for each Category and Subcategories.",
                                             "example": ["732"],
                                             "items": {
-                                                "type": "string",
-                                                "title": ""
+                                                "type": "string"
                                             }
                                         },
                                         "categoryNames": {
@@ -2487,8 +2449,7 @@
                                             "description": "Names of the product's categories, displayed in a path format.",
                                             "example": ["/Men/Acessories/"],
                                             "items": {
-                                                "type": "string",
-                                                "title": ""
+                                                "type": "string"
                                             }
                                         },
                                         "specs": {
@@ -2507,7 +2468,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": ["name", "values"],
                                                 "properties": {
                                                     "name": {
@@ -2525,8 +2485,7 @@
                                                             "White"
                                                         ],
                                                         "items": {
-                                                            "type": "string",
-                                                            "title": ""
+                                                            "type": "string"
                                                         }
                                                     }
                                                 }
@@ -2547,7 +2506,6 @@
                                                 }
                                             ],
                                             "items": {
-                                                "title": "",
                                                 "required": ["name", "value"],
                                                 "properties": {
                                                     "name": {
@@ -2584,7 +2542,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": ["id", "url"],
                                                 "properties": {
                                                     "id": {
@@ -2666,7 +2623,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": [
                                                     "id",
                                                     "isActive",
@@ -2770,7 +2726,6 @@
                                                         ],
                                                         "items": {
                                                             "type": "object",
-                                                            "title": "",
                                                             "required": [
                                                                 "name",
                                                                 "value"
@@ -2945,14 +2900,12 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "properties": {
                                         "data": {
                                             "type": "array",
                                             "description": "List with information about the SKU.",
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "properties": {
                                                     "id": {
                                                         "type": "string",
@@ -3065,7 +3018,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "properties": {
                                         "data": {
                                             "type": "array",
@@ -3223,7 +3175,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": ["data", "_metadata"],
                                     "properties": {
                                         "data": {
@@ -3232,7 +3183,6 @@
                                             "description": "List with information about the store's brands.",
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "example": {
                                                     "id": "863",
                                                     "name": "Zwilling",
@@ -3371,7 +3321,6 @@
                             },
                             "schema": {
                                 "type": "object",
-                                "title": "",
                                 "required": ["name", "isActive"],
                                 "properties": {
                                     "name": {
@@ -3405,7 +3354,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "properties": {
                                         "id": {
                                             "type": "string",
@@ -3499,7 +3447,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "example": {
                                         "id": "863",
                                         "name": "Zwilling",
@@ -3594,7 +3541,6 @@
                             },
                             "schema": {
                                 "type": "object",
-                                "title": "",
                                 "required": ["id", "name", "isActive"],
                                 "properties": {
                                     "id": {
@@ -3735,7 +3681,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": ["roots"],
                                     "properties": {
                                         "roots": {
@@ -3762,7 +3707,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "required": [
                                                     "value",
                                                     "children"
@@ -3818,7 +3762,6 @@
                                                         ],
                                                         "items": {
                                                             "type": "object",
-                                                            "title": "",
                                                             "example": {
                                                                 "value": {
                                                                     "id": "2",
@@ -3979,7 +3922,6 @@
                             },
                             "schema": {
                                 "type": "object",
-                                "title": "",
                                 "required": ["roots"],
                                 "properties": {
                                     "roots": {
@@ -4006,7 +3948,6 @@
                                         ],
                                         "items": {
                                             "type": "object",
-                                            "title": "",
                                             "required": ["value", "children"],
                                             "properties": {
                                                 "value": {
@@ -4059,7 +4000,6 @@
                                                     ],
                                                     "items": {
                                                         "type": "object",
-                                                        "title": "",
                                                         "example": {
                                                             "value": {
                                                                 "id": "2",
@@ -4186,7 +4126,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": ["value", "children"],
                                     "properties": {
                                         "value": {
@@ -4239,7 +4178,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "example": {
                                                     "value": {
                                                         "id": "2",
@@ -4331,7 +4269,6 @@
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "title": "",
                                 "required": ["parentId", "Name"],
                                 "properties": {
                                     "parentId": {
@@ -4379,7 +4316,6 @@
                                 },
                                 "schema": {
                                     "type": "object",
-                                    "title": "",
                                     "required": ["value", "children"],
                                     "properties": {
                                         "value": {
@@ -4432,7 +4368,6 @@
                                             ],
                                             "items": {
                                                 "type": "object",
-                                                "title": "",
                                                 "example": {
                                                     "value": {
                                                         "id": "2",


### PR DESCRIPTION
Removing all blank titles from the Catalog API Seller Portal OpenAPI spec.

Blank titles are an issue for automatic SDK generation using [Swagger Codegen](https://swagger.io/tools/swagger-codegen/). Removing them makes generation possible and makes the OpenAPI spec "cleaner". This PR is meant to test the impacts of this change in dev portal rendering.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
