### PR TITLE
EDU-10245 | Seller commissions path fix

### DIFF
--- a/PostmanCollections/VTEX - Marketplace APIs.json
+++ b/PostmanCollections/VTEX - Marketplace APIs.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "244e1997-5c49-4137-905c-94004407125b"
+    "postman_id": "a6963abf-6720-475d-ab33-ab7c14b67c63"
   },
   "item": [
     {
-      "id": "030549ea-90fc-4592-b1af-35ad1bc78d49",
+      "id": "6721fba4-961a-46c3-a707-8e0306d7c080",
       "name": "Sellers",
       "description": {
         "content": "Get sellers' data",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "2b3174ad-e324-4676-b718-c6a866f189e1",
+          "id": "1656cca3-5d00-4570-9e8b-897147f9e603",
           "name": "Configure Seller Account",
           "request": {
             "name": "Configure Seller Account",
@@ -75,7 +75,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "664981ca-2318-4ea2-99a7-d75ff2b72f5e",
+              "id": "09ccdc16-5a18-4fff-84e9-11050d7bbc20",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -166,7 +166,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7cc2678a-2555-4897-9320-5c9924a92a67",
+                "id": "9f07ccb6-af43-46a5-b473-4d23507a5c6d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/seller-register/pvt/sellers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -179,7 +179,7 @@
           }
         },
         {
-          "id": "83f2b4c8-e45b-4632-b810-c60030c1d8d1",
+          "id": "d7fc54fd-c213-47c8-b35c-605d6856ab85",
           "name": "List Sellers",
           "request": {
             "name": "List Sellers",
@@ -327,7 +327,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2ccf76d4-6e21-45e2-aeb9-f7a10efdcc5e",
+              "id": "80cf3678-f814-4d55-bd15-1fcf19465429",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -455,7 +455,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eae3008a-bb9e-43e8-a598-7ea9f04e1bac",
+                "id": "2b86147b-ccc0-4cc4-9a2c-386bebfc3c9b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/seller-register/pvt/sellers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -468,7 +468,7 @@
           }
         },
         {
-          "id": "1331b595-0278-4c19-9354-3e32f747836b",
+          "id": "0ff9f1d5-900f-4d74-a890-8c9f2092765c",
           "name": "Update Seller by Seller ID",
           "request": {
             "name": "Update Seller by Seller ID",
@@ -542,7 +542,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "853d23ce-ffd9-454c-adab-ce5a3293b75f",
+              "id": "328c6f30-db42-4ca7-93d3-f27e4a75a644",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -644,7 +644,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b04eafd5-082a-461c-bc49-e415a1fe6508",
+                "id": "e66bf781-2bc4-44fc-8a64-c09c60eac631",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/seller-register/pvt/sellers/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -657,7 +657,7 @@
           }
         },
         {
-          "id": "4ee56381-5742-45f3-99b6-33c9b24ee49e",
+          "id": "d5b9f394-b4f5-43ac-accb-bd12c393fc6a",
           "name": "Get Seller data by ID",
           "request": {
             "name": "Get Seller data by ID",
@@ -726,7 +726,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b04092d7-b0ed-4ef4-9677-db3c63b277fe",
+              "id": "b08ce7e4-8e3f-4266-afbf-971a00410013",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -825,7 +825,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "99ee5609-0087-45b7-8244-8e1ae45da745",
+                "id": "de7284f6-6630-4708-8ef7-39fca8e17bd8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/seller-register/pvt/sellers/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -841,7 +841,7 @@
       "event": []
     },
     {
-      "id": "70f35e25-5a41-43cc-925d-d41f61b31ca2",
+      "id": "2adb3dde-e614-414e-9c26-3ab5a0a91e27",
       "name": "Seller Invite",
       "description": {
         "content": "Used to invite sellers and configure their accounts",
@@ -849,7 +849,7 @@
       },
       "item": [
         {
-          "id": "ca53cfa8-c86b-4239-ab42-1a115cc78ecf",
+          "id": "90f9d01e-78ab-4032-b0af-5abc3df05616",
           "name": "Invite Seller Lead",
           "request": {
             "name": "Invite Seller Lead",
@@ -912,7 +912,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bd883334-0778-4e04-883a-27c025fd950d",
+              "id": "70434500-13c2-4977-8feb-0257ca891fab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1003,7 +1003,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a876d4fd-0d53-457d-9809-1635e052b64b",
+                "id": "7f14ea4e-bc6d-4093-9b7c-479caac31570",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/seller-register/pvt/seller-leads - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1016,7 +1016,7 @@
           }
         },
         {
-          "id": "f3064f4b-bd76-43dc-99f1-8be9463dc74d",
+          "id": "f7810ec2-741d-48ad-8f7f-5de705ae7c0b",
           "name": "List Seller Leads",
           "request": {
             "name": "List Seller Leads",
@@ -1086,7 +1086,7 @@
                     "type": "text/plain"
                   },
                   "key": "orderBy",
-                  "value": "qui laboris in sit"
+                  "value": "in esse cillum sunt"
                 }
               ],
               "variable": [
@@ -1119,7 +1119,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1205641d-5109-4f86-b1d6-bac0597bfa42",
+              "id": "276ff324-0bd3-4c70-87e4-53e34d7f5d39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1154,7 +1154,7 @@
                     },
                     {
                       "key": "orderBy",
-                      "value": "qui laboris in sit"
+                      "value": "in esse cillum sunt"
                     }
                   ],
                   "variable": [
@@ -1227,7 +1227,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be6f90b9-615f-456e-b94c-db518ba48cf5",
+                "id": "eb2b0074-e170-4557-830f-56e618e6816c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/seller-register/pvt/seller-leads - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1240,7 +1240,7 @@
           }
         },
         {
-          "id": "1381a8f8-a09c-49b7-8d01-6841b3db1ab9",
+          "id": "9dc43e19-d6b2-42e4-a125-0cfe82664433",
           "name": "Accept Seller Lead",
           "request": {
             "name": "Accept Seller Lead",
@@ -1287,7 +1287,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "qui laboris in sit",
+                  "value": "in esse cillum sunt",
                   "key": "sellerLeadId"
                 }
               ]
@@ -1314,7 +1314,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "23fe751c-f7c2-4ebb-b115-494d63db578f",
+              "id": "73704b87-c015-4962-aeb5-5c18546b661d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1356,7 +1356,7 @@
                         "type": "text/plain"
                       },
                       "type": "any",
-                      "value": "qui laboris in sit",
+                      "value": "in esse cillum sunt",
                       "key": "sellerLeadId"
                     }
                   ]
@@ -1416,7 +1416,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d6feb620-f2f1-45ab-b490-9403f6380c87",
+                "id": "3adc3a7d-c50e-4e83-9c5d-c9893d563927",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/seller-register/pvt/seller-leads/:sellerLeadId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1429,7 +1429,7 @@
           }
         },
         {
-          "id": "27cdc327-940b-4f21-bed6-7547f209e8b9",
+          "id": "fc8e505f-7b85-4cf3-b306-3e086ed723e5",
           "name": "Get Seller Lead's Data by Id",
           "request": {
             "name": "Get Seller Lead's Data by Id",
@@ -1476,7 +1476,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "qui laboris in sit",
+                  "value": "in esse cillum sunt",
                   "key": "sellerLeadId"
                 }
               ]
@@ -1488,7 +1488,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f9e79b57-834c-43c5-bc87-2111d2e7c0b7",
+              "id": "574877e6-c4e7-430b-86c6-13e5352405fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1530,7 +1530,7 @@
                         "type": "text/plain"
                       },
                       "type": "any",
-                      "value": "qui laboris in sit",
+                      "value": "in esse cillum sunt",
                       "key": "sellerLeadId"
                     }
                   ]
@@ -1582,7 +1582,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "364f9a86-a0bb-4912-b9cf-10587134c001",
+                "id": "1605da0e-fd31-4c48-ac41-3382864b6e42",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/seller-register/pvt/seller-leads/:sellerLeadId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1595,7 +1595,7 @@
           }
         },
         {
-          "id": "f73d7baf-5be4-4848-b663-eecb8ec84aac",
+          "id": "8ce0efbd-d977-40c9-8bec-3febee73ec5d",
           "name": "Delete Seller Lead",
           "request": {
             "name": "Delete Seller Lead",
@@ -1642,7 +1642,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "qui laboris in sit",
+                  "value": "in esse cillum sunt",
                   "key": "sellerLeadId"
                 }
               ]
@@ -1654,7 +1654,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "18481ebe-bdb5-4306-85f8-cefe6284abfe",
+              "id": "b8f3ff72-0be6-4ee7-9489-ea50989e573d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1696,7 +1696,7 @@
                         "type": "text/plain"
                       },
                       "type": "any",
-                      "value": "qui laboris in sit",
+                      "value": "in esse cillum sunt",
                       "key": "sellerLeadId"
                     }
                   ]
@@ -1748,7 +1748,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3f6911d0-1996-4e4b-b63d-dd3af5ed78c0",
+                "id": "9c7adb88-f166-42ec-b5aa-55cbe7b1fc43",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/seller-register/pvt/seller-leads/:sellerLeadId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1761,7 +1761,7 @@
           }
         },
         {
-          "id": "a0e40685-6995-4d6a-a033-1b8de279c872",
+          "id": "b267b739-a4e9-4608-9472-498ea56dc693",
           "name": "Create Seller From Lead",
           "request": {
             "name": "Create Seller From Lead",
@@ -1819,7 +1819,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "qui laboris in sit",
+                  "value": "in esse cillum sunt",
                   "key": "sellerLeadId"
                 }
               ]
@@ -1831,7 +1831,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2d7d5948-2809-49d6-bc1b-6edb051f78c3",
+              "id": "7ccbc19d-cc1b-4825-bd55-ede4ee3d4598",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1879,7 +1879,7 @@
                         "type": "text/plain"
                       },
                       "type": "any",
-                      "value": "qui laboris in sit",
+                      "value": "in esse cillum sunt",
                       "key": "sellerLeadId"
                     }
                   ]
@@ -1931,7 +1931,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a0919072-470f-438e-aa8c-af0ff5a3369e",
+                "id": "c4385ffa-b2d0-4196-b67a-0d18788415b2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/seller-register/pvt/seller-leads/:sellerLeadId/seller - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1944,7 +1944,7 @@
           }
         },
         {
-          "id": "2d310b7a-7d81-4f85-ba49-80780765fa3d",
+          "id": "34fc5e3c-f8ce-4d30-a61e-c69e13e97070",
           "name": "Resend Seller Lead Invite",
           "request": {
             "name": "Resend Seller Lead Invite",
@@ -1992,7 +1992,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "qui laboris in sit",
+                  "value": "in esse cillum sunt",
                   "key": "sellerLeadId"
                 }
               ]
@@ -2019,7 +2019,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "56cc66f4-a098-4f48-a5a7-3dcb55580f0d",
+              "id": "942d0e73-f57e-45e7-9aa3-c70eb79fd4a9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2062,7 +2062,7 @@
                         "type": "text/plain"
                       },
                       "type": "any",
-                      "value": "qui laboris in sit",
+                      "value": "in esse cillum sunt",
                       "key": "sellerLeadId"
                     }
                   ]
@@ -2122,7 +2122,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1dda7bde-f2b3-4d3e-b06b-c2b2b5f39099",
+                "id": "ea0c6bac-54ac-4e64-a713-8d3167cf419c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/seller-register/pvt/seller-leads/:sellerLeadId/status - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2138,7 +2138,7 @@
       "event": []
     },
     {
-      "id": "1ca55a7e-dbd4-4fc0-9d5c-4dfd4b8cdd87",
+      "id": "2a270325-6cc5-4f68-91f9-4345e9e0739b",
       "name": "Seller Commissions",
       "description": {
         "content": "Get sellers' data",
@@ -2146,7 +2146,7 @@
       },
       "item": [
         {
-          "id": "834ceccc-78a5-4239-b435-163548bc36bb",
+          "id": "3118ec58-74f1-45eb-994c-2e03769ecbd9",
           "name": "Upsert Seller Commissions in Bulk",
           "request": {
             "name": "Upsert Seller Commissions in Bulk",
@@ -2222,7 +2222,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d32be887-a5cb-4e58-b48b-8f377f77c03b",
+              "id": "d531664a-924f-462a-9502-576d149bdfce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2326,7 +2326,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45c91458-0335-49b8-8a2e-cd9e76d2a6cd",
+                "id": "4f1ebdb6-ec67-4220-8864-7390a6212a89",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/seller-register/pvt/sellers/:sellerId/commissions/categories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2339,7 +2339,7 @@
           }
         },
         {
-          "id": "e57b9375-6fc3-48e1-a3e8-a9e87ea67b43",
+          "id": "6fe447e6-a487-4864-b4d7-445aa85f3d53",
           "name": "List Seller Commissions by seller ID",
           "request": {
             "name": "List Seller Commissions by seller ID",
@@ -2399,7 +2399,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4f07d340-8135-4374-aae5-1981031b0911",
+              "id": "2df5b335-a4b1-4590-b5ed-e9250cfab316",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2494,7 +2494,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "18c58ace-b97c-4634-b413-c11e07583765",
+                "id": "b4e0bfd6-4737-4266-9920-e8dad7a06582",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/seller-register/pvt/sellers/:sellerId/commissions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2507,7 +2507,7 @@
           }
         },
         {
-          "id": "0e4c72db-e3f6-4e67-a70c-2ab22a98f60f",
+          "id": "579d3276-e5b6-4196-99d6-e43275234699",
           "name": "Upsert Seller Commissions by Category ID",
           "request": {
             "name": "Upsert Seller Commissions by Category ID",
@@ -2521,8 +2521,7 @@
                 "pvt",
                 "sellers",
                 ":sellerId",
-                "commissions",
-                ":categoryId"
+                "commissions"
               ],
               "host": [
                 "{{baseUrl}}"
@@ -2593,7 +2592,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c4334f74-0e68-4768-810a-92b62cab4cfc",
+              "id": "a63b6161-a645-480d-abee-39728eb49da5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2602,8 +2601,7 @@
                     "pvt",
                     "sellers",
                     ":sellerId",
-                    "commissions",
-                    ":categoryId"
+                    "commissions"
                   ],
                   "host": [
                     "{{baseUrl}}"
@@ -2707,10 +2705,10 @@
             {
               "listen": "test",
               "script": {
-                "id": "00d7cb00-b4c6-4699-83a8-5348846b0399",
+                "id": "d7408010-31dd-49b3-ba2f-da8a8a044aed",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[PUT]::/seller-register/pvt/sellers/:sellerId/commissions/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
+                  "// Validate status 2xx \npm.test(\"[PUT]::/seller-register/pvt/sellers/:sellerId/commissions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
                 ]
               }
             }
@@ -2720,7 +2718,7 @@
           }
         },
         {
-          "id": "a2fdf428-5103-4b69-805e-3608cbb7e19d",
+          "id": "fea02121-086e-4a76-9ff5-8cc5dfb688bf",
           "name": "Remove Seller Commissions by Category ID",
           "request": {
             "name": "Remove Seller Commissions by Category ID",
@@ -2791,7 +2789,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2124485f-84e7-4011-9ff4-d44c9d1ba28f",
+              "id": "3506bdc8-1497-435e-a34e-3ee67b863bc1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2897,7 +2895,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2782df0b-0dfa-4991-a714-d19ba20725f8",
+                "id": "72b1237f-6749-4f7a-8a67-8f40f6809a75",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/seller-register/pvt/sellers/:sellerId/commissions/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2910,7 +2908,7 @@
           }
         },
         {
-          "id": "511371c4-cc60-48e4-a706-2a2b29650c4a",
+          "id": "0de36f8d-4a15-47b5-bf35-d2b6d807bd67",
           "name": "Get Seller Commissions by Category ID",
           "request": {
             "name": "Get Seller Commissions by Category ID",
@@ -2981,7 +2979,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "34409a82-0131-41f5-bd32-fd16c4d122ac",
+              "id": "9cb4d483-3af1-4cb2-8230-ef87e7191adc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3087,7 +3085,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "43f53865-f001-444c-a5da-dd040d608196",
+                "id": "2a9ee412-309c-491e-aad6-161b96f711fa",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/seller-register/pvt/sellers/:sellerId/commissions/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -3103,7 +3101,7 @@
       "event": []
     },
     {
-      "id": "c04393ef-861b-4b88-9aee-2ef8bd9b4784",
+      "id": "40b1cf15-d339-430b-8aeb-884281138ce4",
       "name": "Notification",
       "description": {
         "content": "",
@@ -3111,7 +3109,7 @@
       },
       "item": [
         {
-          "id": "a1dbe9d1-9db2-4663-96c9-44e89e317151",
+          "id": "9585d0db-d5a7-415e-8f30-1bb32c5b4925",
           "name": "Notify marketplace of price update",
           "request": {
             "name": "Notify marketplace of price update",
@@ -3181,7 +3179,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f3cead38-6454-4cc9-b027-d8bf620384b3",
+              "id": "8682901b-2a68-4ecb-b841-1e8b5104a4e2",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -3286,7 +3284,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f65714db-dc29-46ab-9fa9-b5504327f833",
+                "id": "de20abb2-7d53-44c8-966c-713495c2aa8e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/notificator/:sellerId/changenotification/:skuId/price - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -3299,7 +3297,7 @@
           }
         },
         {
-          "id": "69957ad5-db66-4747-a161-c9af451cd435",
+          "id": "ac06b071-4814-413c-af83-398d478e2e39",
           "name": "Notify marketplace of inventory update",
           "request": {
             "name": "Notify marketplace of inventory update",
@@ -3369,7 +3367,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2d98ad07-a095-4070-a002-b428e082cce5",
+              "id": "b5760b97-75cd-4070-8e9b-a990f118b030",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -3474,7 +3472,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1bdcbecf-5a80-47f6-8a09-f74dbc55e7d2",
+                "id": "ad35e7b8-e7d0-46d1-963f-ff8853a5100e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/notificator/:sellerId/changenotification/:skuId/inventory - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -3490,7 +3488,7 @@
       "event": []
     },
     {
-      "id": "904ed5dc-e98e-4e76-b7cd-06083d17f549",
+      "id": "2a6a87da-b5de-49bb-a6e8-78c9abb3b501",
       "name": "Matched Offers",
       "description": {
         "content": "",
@@ -3498,7 +3496,7 @@
       },
       "item": [
         {
-          "id": "33b9a187-17a2-4e61-8f57-0b57a8df4ff5",
+          "id": "8f903742-2933-47ea-9f58-113e829ddaf8",
           "name": "Get Matched Offers List",
           "request": {
             "name": "Get Matched Offers List",
@@ -3589,7 +3587,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7905019f-f5e0-4f09-94da-b9fa8347f0cf",
+              "id": "4dc928c5-4fe1-476a-8d1c-5e105d1c93d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3693,7 +3691,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3de05e34-dae4-4670-ac86-1f376b861c61",
+                "id": "d9363f04-9d96-4dba-b797-dd474caf2130",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/offer-manager/pvt/offers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3709,7 +3707,7 @@
           }
         },
         {
-          "id": "2a9185d3-7fe1-477d-ad39-e83abfaf8efb",
+          "id": "8efe11ef-2a1b-4752-94af-bc3cfdfe8bc1",
           "name": "Get Matched Offer's Data by SKU ID",
           "request": {
             "name": "Get Matched Offer's Data by SKU ID",
@@ -3780,7 +3778,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3ff1053a-d2ee-441d-a982-cfc87fa68499",
+              "id": "98ed1c8f-2dee-4058-8791-32884e537396",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3886,7 +3884,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "63732e6e-c60a-41fc-acd9-43e9e2721b26",
+                "id": "729440bd-6f43-4013-a0be-b24119b81f37",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/offer-manager/pvt/product/:productId/sku/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -3899,7 +3897,7 @@
           }
         },
         {
-          "id": "5f5ee10e-27ef-4e03-92dd-c3b418140d53",
+          "id": "e3744c3a-dbd9-4a3f-883d-d92b5ee2058a",
           "name": "Get Matched Offer's Data by Product ID",
           "request": {
             "name": "Get Matched Offer's Data by Product ID",
@@ -3958,7 +3956,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dadd69e2-2bc4-4471-940a-058e2660f27d",
+              "id": "905cfa66-5155-4f26-b2a5-705ede21db38",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4052,7 +4050,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "05a07863-7719-46a6-9fa6-e5fbbd9b1492",
+                "id": "4a6e3daa-eea0-47f9-81af-45924aea381b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/offer-manager/pvt/product/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4068,7 +4066,7 @@
       "event": []
     },
     {
-      "id": "7f7f8564-438d-48d7-a6fd-bb4fbe3fedfa",
+      "id": "25a14ac5-c4e2-4ceb-8711-4d1a0c7e9f6e",
       "name": "Sales Channel Mapping",
       "description": {
         "content": "Mapping between a marketplace's sales channel and a seller's affiliate.",
@@ -4076,7 +4074,7 @@
       },
       "item": [
         {
-          "id": "3c1a3469-6ac6-43fc-af9c-104cd88304c2",
+          "id": "9ce25e4a-f48f-48f8-894d-067f6e7cdd54",
           "name": "Upsert Sales Channel Mapping",
           "request": {
             "name": "Upsert Sales Channel Mapping",
@@ -4166,7 +4164,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f679afb7-e339-4f1d-8471-759d427db039",
+              "id": "9004cb03-17f1-4174-addc-ed0da9a7a145",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4279,7 +4277,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a5bd3b95-0767-4562-9001-04fa386fdb40",
+                "id": "74d38411-9b5a-456b-aae5-6372db71cd0a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/seller-register/pvt/sellers/:sellerId/sales-channel/mapping - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4295,7 +4293,7 @@
           }
         },
         {
-          "id": "dccbf595-91df-4e47-b5ff-ed4cf11a1c81",
+          "id": "bc908208-cca0-4566-9a70-0ee526977c3a",
           "name": "Get Sales Channel Mapping Data",
           "request": {
             "name": "Get Sales Channel Mapping Data",
@@ -4372,7 +4370,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d8b12a51-28e3-47c0-9b8e-118e05a064f1",
+              "id": "baa956e8-7d4e-4184-b265-a4dd1f465715",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4477,7 +4475,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f4254e15-bd83-4421-a34a-de974352284f",
+                "id": "65b5bee1-e515-4e83-b7c2-7f7605d57f23",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/seller-register/pvt/sellers/:sellerId/sales-channel/mapping - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4543,7 +4541,7 @@
     }
   ],
   "info": {
-    "_postman_id": "244e1997-5c49-4137-905c-94004407125b",
+    "_postman_id": "a6963abf-6720-475d-ab33-ab7c14b67c63",
     "name": "Marketplace API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -1381,9 +1381,7 @@
                     }
                 },
                 "deprecated": false
-            }
-        },
-        "/seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}": {
+            },
             "put": {
                 "tags": [
                     "Seller Commissions"
@@ -1481,7 +1479,9 @@
                     }
                 },
                 "deprecated": false
-            },
+            }
+        },
+        "/seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}": {
             "delete": {
                 "tags": [
                     "Seller Commissions"


### PR DESCRIPTION
Changing the path of  Upsert Seller Commissions by Category ID.

Previous: https://{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}
Current: https://{accountName}.{environment}.com.br/api/seller-register/pvt/sellers/{sellerId}/commissions

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [x] No, but I am going to.
