### PR TITLE
Headless CMS: update the Builder ID field to Project ID

### DIFF
--- a/PostmanCollections/VTEX - Headless CMS API.json
+++ b/PostmanCollections/VTEX - Headless CMS API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "faf33c1d-087e-4904-86ec-a7748f57f5e1"
+    "postman_id": "5d5e66e8-8db6-46a6-a1ec-1fbb47b63bef"
   },
   "item": [
     {
-      "id": "37d56783-8ad1-43dd-a8dd-a1ef642b20e9",
+      "id": "82b6f7bb-f5de-45ef-adb7-1baf1d53a4a5",
       "name": "Pages",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "35aa8eb2-0b3d-4add-af6e-58361cb26168",
+          "id": "94440e66-1012-4c6d-9438-d3177b0cadb0",
           "name": "Get all Content Types",
           "request": {
             "name": "Get all Content Types",
@@ -25,7 +25,7 @@
                 "_v",
                 "cms",
                 "api",
-                ":builderId",
+                ":projectId",
                 ""
               ],
               "host": [
@@ -36,12 +36,12 @@
                 {
                   "disabled": false,
                   "description": {
-                    "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                    "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                     "type": "text/plain"
                   },
                   "type": "any",
                   "value": "faststore",
-                  "key": "builderId"
+                  "key": "projectId"
                 },
                 {
                   "description": {
@@ -67,7 +67,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2e73d704-83f9-4fda-b287-81df04aada90",
+              "id": "1399623f-f5cd-46be-8a46-2d76200d4af7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -75,7 +75,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ""
                   ],
                   "host": [
@@ -86,12 +86,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "description": {
@@ -128,7 +128,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4fd51bec-cc5d-43c1-a086-44f07b5cad66",
+              "id": "0273e725-d572-46ac-bc41-c36563ec4206",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -136,7 +136,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ""
                   ],
                   "host": [
@@ -147,12 +147,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "description": {
@@ -183,7 +183,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d7828b64-c199-44c5-a42f-a50dcacc63d2",
+              "id": "c409d363-9422-4f9c-acf2-90b4c0607cdc",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -191,7 +191,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ""
                   ],
                   "host": [
@@ -202,12 +202,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "description": {
@@ -239,13 +239,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "a872248e-8cfe-4a0a-8e48-2a5b71238e81",
+                "id": "95c0bb79-42f0-47f0-83bf-f706fa236434",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[GET]::/_v/cms/api/:builderId/ - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
-                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/_v/cms/api/:builderId/ - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[GET]::/_v/cms/api/:builderId/ - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"title\":\"\",\"description\":\"\",\"type\":\"object\",\"properties\":{\"contentTypes\":{\"description\":\"Array with data of each Content Type.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data of a specific Content Type.\",\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"Content Type identifier specified in the FastStore project.\",\"type\":\"string\"},\"name\":{\"description\":\"Content Type name specified in the FastStore project.\",\"type\":\"string\"},\"configurationSchemaSets\":{\"description\":\"Array with data of the `configurationSchemaSets` tabs specified in the FastStore project.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data about a specific Content Type tab.\",\"type\":\"object\",\"properties\":{\"name\":{\"description\":\"Name of the Content Type tab.\",\"type\":\"string\"},\"configurations\":{\"description\":\"Custom configurations of the Content Type tab. Varies depending on the Content Type schema defined in the FastStore project.\",\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"Object with custom configurations of the Content Type tab.\"}}}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/_v/cms/api/:builderId/ - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate status 2xx \npm.test(\"[GET]::/_v/cms/api/:projectId/ - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/_v/cms/api/:projectId/ - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/_v/cms/api/:projectId/ - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"title\":\"\",\"description\":\"\",\"type\":\"object\",\"properties\":{\"contentTypes\":{\"description\":\"Array with data of each Content Type.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data of a specific Content Type.\",\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"Content Type identifier specified in the FastStore project.\",\"type\":\"string\"},\"name\":{\"description\":\"Content Type name specified in the FastStore project.\",\"type\":\"string\"},\"configurationSchemaSets\":{\"description\":\"Array with data of the `configurationSchemaSets` tabs specified in the FastStore project.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data about a specific Content Type tab.\",\"type\":\"object\",\"properties\":{\"name\":{\"description\":\"Name of the Content Type tab.\",\"type\":\"string\"},\"configurations\":{\"description\":\"Custom configurations of the Content Type tab. Varies depending on the Content Type schema defined in the FastStore project.\",\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"Object with custom configurations of the Content Type tab.\"}}}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/_v/cms/api/:projectId/ - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -255,7 +255,7 @@
           }
         },
         {
-          "id": "8ed3ca45-7767-4e26-a6bc-888633c7838a",
+          "id": "cfce03c4-5fae-48cf-8fda-54feb31f2217",
           "name": "Get all CMS pages by Content Type",
           "request": {
             "name": "Get all CMS pages by Content Type",
@@ -268,7 +268,7 @@
                 "_v",
                 "cms",
                 "api",
-                ":builderId",
+                ":projectId",
                 ":content-type"
               ],
               "host": [
@@ -307,12 +307,12 @@
                 {
                   "disabled": false,
                   "description": {
-                    "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                    "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                     "type": "text/plain"
                   },
                   "type": "any",
                   "value": "faststore",
-                  "key": "builderId"
+                  "key": "projectId"
                 },
                 {
                   "disabled": false,
@@ -348,7 +348,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3b8f3986-13bd-40ac-84a0-cdcf94c6a1d9",
+              "id": "a685fd54-9d74-4e0d-8201-422c26a6ed00",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -356,7 +356,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ":content-type"
                   ],
                   "host": [
@@ -380,12 +380,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "disabled": false,
@@ -432,7 +432,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "55ec71cc-18da-4156-a236-7b59b9d99fef",
+              "id": "9427d049-ae0f-4210-b16a-2e35c7bc5ae3",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -440,7 +440,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ":content-type"
                   ],
                   "host": [
@@ -464,12 +464,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "disabled": false,
@@ -510,7 +510,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dc4de8f1-1615-475a-a933-c147dea745c2",
+              "id": "c7452ee6-c2a9-48aa-9549-e4bc655d132d",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -518,7 +518,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ":content-type"
                   ],
                   "host": [
@@ -542,12 +542,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "disabled": false,
@@ -589,13 +589,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "5100378c-137b-445b-bb8b-8a2835ceb241",
+                "id": "4caa8d4d-b014-4d5d-8bad-fef9a0b38adb",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
-                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"description\":\"\",\"type\":\"object\",\"properties\":{\"hasNextPage\":{\"description\":\"Indicates if there are more items to fetch.\",\"type\":\"boolean\"},\"totalItems\":{\"description\":\"Total number of results.\",\"type\":\"integer\"},\"data\":{\"description\":\"Array with data from all pages of the given Content Type.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data from a specific page.\",\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"Document ID presented in the URL path of a CMS preview.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the page created via the CMS interface.\",\"type\":\"string\"},\"type\":{\"description\":\"Name of the Content Type defined in the FastStore project.\",\"type\":\"string\"},\"status\":{\"description\":\"Current status of the page.\",\"type\":\"string\"},\"versionId\":{\"description\":\"Version ID.\",\"type\":\"string\"},\"versionStatus\":{\"description\":\"Version status.\",\"type\":\"string\"},\"sections\":{\"description\":\"Sections that compose the page.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data about a specific section.\",\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"Section ID.\",\"type\":\"string\"},\"name\":{\"description\":\"Section name.\",\"type\":\"string\"},\"data\":{\"description\":\"Custom field values of the Section. Varies depending on the Section schema defined in the FastStore project.\",\"type\":\"object\"}}}},\"parameters\":{\"description\":\"Object with the configuration values of a `configurationSchemaSets` tab. Varies depending on the Content Type schema defined in the FastStore project.\",\"type\":\"object\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate status 2xx \npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"description\":\"\",\"type\":\"object\",\"properties\":{\"hasNextPage\":{\"description\":\"Indicates if there are more items to fetch.\",\"type\":\"boolean\"},\"totalItems\":{\"description\":\"Total number of results.\",\"type\":\"integer\"},\"data\":{\"description\":\"Array with data from all pages of the given Content Type.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data from a specific page.\",\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"Document ID presented in the URL path of a CMS preview.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the page created via the CMS interface.\",\"type\":\"string\"},\"type\":{\"description\":\"Name of the Content Type defined in the FastStore project.\",\"type\":\"string\"},\"status\":{\"description\":\"Current status of the page.\",\"type\":\"string\"},\"versionId\":{\"description\":\"Version ID.\",\"type\":\"string\"},\"versionStatus\":{\"description\":\"Version status.\",\"type\":\"string\"},\"sections\":{\"description\":\"Sections that compose the page.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data about a specific section.\",\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"Section ID.\",\"type\":\"string\"},\"name\":{\"description\":\"Section name.\",\"type\":\"string\"},\"data\":{\"description\":\"Custom field values of the Section. Varies depending on the Section schema defined in the FastStore project.\",\"type\":\"object\"}}}},\"parameters\":{\"description\":\"Object with the configuration values of a `configurationSchemaSets` tab. Varies depending on the Content Type schema defined in the FastStore project.\",\"type\":\"object\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -605,7 +605,7 @@
           }
         },
         {
-          "id": "0e28f8ac-7a57-4e58-84ca-a2ed084d852b",
+          "id": "fa4f6af6-b699-4e51-ab9b-ed1f8643910b",
           "name": "Get CMS page",
           "request": {
             "name": "Get CMS page",
@@ -618,7 +618,7 @@
                 "_v",
                 "cms",
                 "api",
-                ":builderId",
+                ":projectId",
                 ":content-type",
                 ":document-id",
                 ""
@@ -650,12 +650,12 @@
                 {
                   "disabled": false,
                   "description": {
-                    "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                    "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                     "type": "text/plain"
                   },
                   "type": "any",
                   "value": "faststore",
-                  "key": "builderId"
+                  "key": "projectId"
                 },
                 {
                   "disabled": false,
@@ -701,7 +701,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "65ab4cba-fdd4-4999-9047-0ee0f16f1131",
+              "id": "f94f0735-5ade-4d21-8f4a-3d21a5eea652",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -709,7 +709,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ":content-type",
                     ":document-id",
                     ""
@@ -731,12 +731,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "disabled": false,
@@ -786,14 +786,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"id\": \"tempor eu Duis exercitation\",\n  \"name\": \"laboris do adipisicing dolor aliqua\",\n  \"type\": \"anim adipisicing Excepteur labore\",\n  \"status\": \"consequat\",\n  \"versionId\": \"enim irure dolor\",\n  \"versionStatus\": \"qui dolor mollit ex\",\n  \"sections\": [\n    {\n      \"id\": \"esse voluptate proident ad\",\n      \"name\": \"Ut quis\",\n      \"data\": {}\n    },\n    {\n      \"id\": \"dolore\",\n      \"name\": \"incididunt elit ullamco Lorem\",\n      \"data\": {}\n    }\n  ]\n}",
+              "body": "{\n  \"id\": \"mollit Excepteur deserunt\",\n  \"name\": \"do Excepteur voluptate\",\n  \"type\": \"reprehenderit ipsum\",\n  \"status\": \"culpa voluptate\",\n  \"versionId\": \"deserunt culpa proident commodo\",\n  \"versionStatus\": \"veniam exercitation occaecat\",\n  \"sections\": [\n    {\n      \"id\": \"voluptate incididunt dolore aliquip\",\n      \"name\": \"voluptate in tempor sit\",\n      \"data\": {}\n    },\n    {\n      \"id\": \"nostrud laboris\",\n      \"name\": \"ipsum ut dolor exercitation\",\n      \"data\": {}\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0f918d01-99ef-4ef4-9200-6a9364994e55",
+              "id": "66bdc8ee-c32d-4705-be35-0b78cbe46f89",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -801,7 +801,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ":content-type",
                     ":document-id",
                     ""
@@ -823,12 +823,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "disabled": false,
@@ -879,7 +879,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "07abc39d-903c-40a7-81a9-2e423fe6cd33",
+              "id": "818ef997-135f-4fb9-8b6f-0786875eb572",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -887,7 +887,7 @@
                     "_v",
                     "cms",
                     "api",
-                    ":builderId",
+                    ":projectId",
                     ":content-type",
                     ":document-id",
                     ""
@@ -909,12 +909,12 @@
                     {
                       "disabled": false,
                       "description": {
-                        "content": "(Required) Builder ID specified in the settings of the CMS app.",
+                        "content": "(Required) Project ID specified in the settings of the CMS (alpha) app.",
                         "type": "text/plain"
                       },
                       "type": "any",
                       "value": "faststore",
-                      "key": "builderId"
+                      "key": "projectId"
                     },
                     {
                       "disabled": false,
@@ -966,13 +966,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "09de7b45-5e5e-4606-a577-a7aee238d584",
+                "id": "62a2a8ff-f5dd-4fec-a3e0-a8aa89cf2f58",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type/:document-id/ - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
-                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type/:document-id/ - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type/:document-id/ - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"example\":{\"id\":\"ad2fd81d-a53c-4281-8d01-a4fc2f274db3\",\"name\":\"Home\",\"type\":\"home\",\"status\":\"published\",\"versionId\":\"e3867e2c-7082-4fe6-83ed-c473242b6970\",\"versionStatus\":\"publishing\",\"sections\":[{\"id\":\"1651804180614\",\"name\":\"Alert\",\"data\":{\"dismissible\":true,\"icon\":\"Bell\",\"text\":\"alert text\",\"linkText\":\"alert link\",\"actionLink\":\"link.url.com\"}},{\"id\":\"1647286556072\",\"name\":\"Hero\",\"data\":{\"imageSrc\":\"https://storeframework.vtexassets.com/assets/vtex.file-manager-graphql/images/299f7d32-bb6a-40fd-82a0-4af5573ba572___17239443c00c1e894cff10ca05018058.jpg\",\"title\":\"New Products Available\",\"subtitle\":\"At FastStore you can shop the best tech of 2022. Enjoy and get 10% off on your first purchase.\",\"linkText\":\"See all\",\"link\":\"/office\",\"imageAlt\":\"hero image\"}},{\"id\":\"1649293076336\",\"name\":\"ProductShelf\",\"data\":{\"first\":5,\"after\":\"0\",\"sort\":\"score_desc\",\"selectedFacets\":[{\"key\":\"productClusterIds\",\"value\":\"140\"}],\"title\":\"Most Wanted!\"}},{\"id\":\"1649293548351\",\"name\":\"ProductTiles\",\"data\":{\"first\":3,\"after\":\"0\",\"sort\":\"score_desc\",\"selectedFacets\":[{\"key\":\"productClusterIds\",\"value\":\"141\"}],\"title\":\"Just Arrived\"}},{\"id\":\"1647286735093\",\"name\":\"BannerText\",\"data\":{\"title\":\"Receive our news and promotions in advance.\",\"caption\":\"Enjoy and get 10% off on your first purchase!!\",\"actionPath\":\"/office\",\"actionLabel\":\"See all\"}},{\"id\":\"1649293131632\",\"name\":\"ProductShelf\",\"data\":{\"first\":5,\"after\":\"0\",\"sort\":\"score_desc\",\"selectedFacets\":[{\"key\":\"productClusterIds\",\"value\":\"142\"}],\"title\":\"Deals & Promotions\"}}]},\"title\":\"\",\"description\":\"Object containing the data related to a specific page.\",\"type\":\"object\",\"required\":[\"id\",\"name\",\"type\",\"status\"],\"properties\":{\"id\":{\"description\":\"Document ID.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the page created in the CMS app.\",\"type\":\"string\"},\"type\":{\"description\":\"Name of the Content Type defined in the FastStore project.\",\"type\":\"string\"},\"status\":{\"description\":\"Current status of the page.\",\"type\":\"string\"},\"versionId\":{\"description\":\"Version ID.\",\"type\":\"string\"},\"versionStatus\":{\"description\":\"Version status\",\"type\":\"string\"},\"sections\":{\"description\":\"Sections that compose the page.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data about a specific section.\",\"type\":\"object\",\"required\":[\"id\",\"name\",\"data\"],\"properties\":{\"id\":{\"description\":\"Section ID.\",\"type\":\"string\"},\"name\":{\"description\":\"Section name.\",\"type\":\"string\"},\"data\":{\"description\":\"Content of the Section. Varies depending on the Section schema defined in the FastStore project.\",\"type\":\"object\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/_v/cms/api/:builderId/:content-type/:document-id/ - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate status 2xx \npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type/:document-id/ - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type/:document-id/ - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type/:document-id/ - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"example\":{\"id\":\"ad2fd81d-a53c-4281-8d01-a4fc2f274db3\",\"name\":\"Home\",\"type\":\"home\",\"status\":\"published\",\"versionId\":\"e3867e2c-7082-4fe6-83ed-c473242b6970\",\"versionStatus\":\"publishing\",\"sections\":[{\"id\":\"1651804180614\",\"name\":\"Alert\",\"data\":{\"dismissible\":true,\"icon\":\"Bell\",\"text\":\"alert text\",\"linkText\":\"alert link\",\"actionLink\":\"link.url.com\"}},{\"id\":\"1647286556072\",\"name\":\"Hero\",\"data\":{\"imageSrc\":\"https://storeframework.vtexassets.com/assets/vtex.file-manager-graphql/images/299f7d32-bb6a-40fd-82a0-4af5573ba572___17239443c00c1e894cff10ca05018058.jpg\",\"title\":\"New Products Available\",\"subtitle\":\"At FastStore you can shop the best tech of 2022. Enjoy and get 10% off on your first purchase.\",\"linkText\":\"See all\",\"link\":\"/office\",\"imageAlt\":\"hero image\"}},{\"id\":\"1649293076336\",\"name\":\"ProductShelf\",\"data\":{\"first\":5,\"after\":\"0\",\"sort\":\"score_desc\",\"selectedFacets\":[{\"key\":\"productClusterIds\",\"value\":\"140\"}],\"title\":\"Most Wanted!\"}},{\"id\":\"1649293548351\",\"name\":\"ProductTiles\",\"data\":{\"first\":3,\"after\":\"0\",\"sort\":\"score_desc\",\"selectedFacets\":[{\"key\":\"productClusterIds\",\"value\":\"141\"}],\"title\":\"Just Arrived\"}},{\"id\":\"1647286735093\",\"name\":\"BannerText\",\"data\":{\"title\":\"Receive our news and promotions in advance.\",\"caption\":\"Enjoy and get 10% off on your first purchase!!\",\"actionPath\":\"/office\",\"actionLabel\":\"See all\"}},{\"id\":\"1649293131632\",\"name\":\"ProductShelf\",\"data\":{\"first\":5,\"after\":\"0\",\"sort\":\"score_desc\",\"selectedFacets\":[{\"key\":\"productClusterIds\",\"value\":\"142\"}],\"title\":\"Deals & Promotions\"}}]},\"title\":\"\",\"description\":\"Object containing the data related to a specific page.\",\"type\":\"object\",\"required\":[\"id\",\"name\",\"type\",\"status\"],\"properties\":{\"id\":{\"description\":\"Document ID.\",\"type\":\"string\"},\"name\":{\"description\":\"Name of the page created in the CMS app.\",\"type\":\"string\"},\"type\":{\"description\":\"Name of the Content Type defined in the FastStore project.\",\"type\":\"string\"},\"status\":{\"description\":\"Current status of the page.\",\"type\":\"string\"},\"versionId\":{\"description\":\"Version ID.\",\"type\":\"string\"},\"versionStatus\":{\"description\":\"Version status\",\"type\":\"string\"},\"sections\":{\"description\":\"Sections that compose the page.\",\"type\":\"array\",\"items\":{\"description\":\"Object with data about a specific section.\",\"type\":\"object\",\"required\":[\"id\",\"name\",\"data\"],\"properties\":{\"id\":{\"description\":\"Section ID.\",\"type\":\"string\"},\"name\":{\"description\":\"Section name.\",\"type\":\"string\"},\"data\":{\"description\":\"Content of the Section. Varies depending on the Section schema defined in the FastStore project.\",\"type\":\"object\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/_v/cms/api/:projectId/:content-type/:document-id/ - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -1003,7 +1003,7 @@
     }
   ],
   "info": {
-    "_postman_id": "faf33c1d-087e-4904-86ec-a7748f57f5e1",
+    "_postman_id": "5d5e66e8-8db6-46a6-a1ec-1fbb47b63bef",
     "name": "VTEX Headless CMS",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/VTEX - Headless CMS API.json
+++ b/VTEX - Headless CMS API.json
@@ -31,7 +31,7 @@
         }
     ],
     "paths": {
-        "/_v/cms/api/{builderId}/": {
+        "/_v/cms/api/{projectId}/": {
             "get": {
                 "summary": "Get all Content Types",
                 "tags": [
@@ -41,9 +41,9 @@
                 "operationId": "GetAllContentTypes",
                 "parameters": [
                     {
-                        "name": "builderId",
+                        "name": "projectId",
                         "in": "path",
-                        "description": "Builder ID specified in the settings of the CMS app.",
+                        "description": "Project ID specified in the settings of the CMS (alpha) app.",
                         "required": true,
                         "style": "simple",
                         "schema": {
@@ -350,7 +350,7 @@
                 "deprecated": false
             }
         },
-        "/_v/cms/api/{builderId}/{content-type}": {
+        "/_v/cms/api/{projectId}/{content-type}": {
             "get": {
                 "summary": "Get all CMS pages by Content Type",
                 "tags": [
@@ -360,9 +360,9 @@
                 "operationId": "GetPagesbyContentType",
                 "parameters": [
                     {
-                        "name": "builderId",
+                        "name": "projectId",
                         "in": "path",
-                        "description": "Builder ID specified in the settings of the CMS app.",
+                        "description": "Project ID specified in the settings of the CMS (alpha) app.",
                         "required": true,
                         "style": "simple",
                         "schema": {
@@ -584,7 +584,7 @@
                 "deprecated": false
             }
         },
-        "/_v/cms/api/{builderId}/{content-type}/{document-id}/": {
+        "/_v/cms/api/{projectId}/{content-type}/{document-id}/": {
             "get": {
                 "summary": "Get CMS page",
                 "tags": [
@@ -594,9 +594,9 @@
                 "operationId": "GetCMSpage",
                 "parameters": [
                     {
-                        "name": "builderId",
+                        "name": "projectId",
                         "in": "path",
-                        "description": "Builder ID specified in the settings of the CMS app.",
+                        "description": "Project ID specified in the settings of the CMS (alpha) app.",
                         "required": true,
                         "style": "simple",
                         "schema": {


### PR DESCRIPTION
#### Types of changes
- [ ] New content (endpoints, descriptions, or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [x] No, but I am going to.

This PR fixes
- The Builder ID name: In the CMS  (alpha) app this field is now called Project ID.
- Add `alpha` to the CMS app name: since the app is called CMS (alpha) in the VTEX Admin.