### PR TITLE
Adding new description rules to spectral

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -91,3 +91,24 @@ rules:
       functionOptions:
         notMatch: "example"
 
+  parameters-description:
+    description: All parameters must be a description field.
+    given: "$.paths.*.*.parameters[*]"
+    then:
+      field: "description"
+      function: truthy
+
+  request-properties-description:
+    description: All request body properties must be a description field.
+    given: "$.paths.*.*.requestBody.properties.*"
+    then:
+      field: "description"
+      function: truthy
+      
+  response-properties-description:
+    description: All response body properties must be a description field.
+    given: "$.paths.*.*.responses.*.properties.*"
+    then:
+      field: "description"
+      function: truthy
+


### PR DESCRIPTION
#### Types of changes
- [X] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [X] No, but I am going to.

PR created to add new description rules to spectral:
- All parameters must be a description field
- All request body properties must be a description field
- All response body properties must be a description field

