### PR TITLE
test: add VtexIdclientAutCookie

### DIFF
--- a/PostmanCollections/VTEX - Catalog API Seller Portal.json
+++ b/PostmanCollections/VTEX - Catalog API Seller Portal.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "d34f7ca2-967c-42ac-aca1-d56ca248487b"
+    "postman_id": "0bb830f3-aa60-42ad-89de-0c91c1918195"
   },
   "item": [
     {
-      "id": "c7e93cf6-4a96-4c4c-97d7-3c81a21501ec",
+      "id": "f659cf88-7c4a-4222-b860-2dafdbdff3cc",
       "name": "Product",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "3c69c722-a128-4a9e-bc97-acf8b9922e64",
+          "id": "ea02880d-b951-4741-9e6c-a71b8bea3737",
           "name": "Get Product by ID",
           "request": {
             "name": "Get Product by ID",
@@ -75,7 +75,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b0bdf05f-2cce-4cbf-80ff-56670c522edc",
+              "id": "69a5871e-13df-4306-804e-51a961bef2c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -171,7 +171,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0032b6da-38a5-470b-a543-13214174c00c",
+                "id": "95fa979d-0c05-4f6b-81e6-cb641b42cc75",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/products/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -187,7 +187,7 @@
           }
         },
         {
-          "id": "f5e3bbb9-57b2-498b-bc77-ada1aafc2bb4",
+          "id": "7959e7c2-3482-4af1-a972-086ddb404fe7",
           "name": "Update Product",
           "request": {
             "name": "Update Product",
@@ -259,7 +259,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "244d98c4-741f-463d-838c-9adeb962a539",
+              "id": "ad43bda7-e8bf-4e13-9921-b4c05280d060",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -359,7 +359,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "33b22dfd-f2f2-465c-b9aa-1fe8a219c8e9",
+                "id": "837a389b-f5bf-4ae1-97f8-8ff981598cd9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog-seller-portal/products/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -373,7 +373,7 @@
           }
         },
         {
-          "id": "5132e94f-9d55-417d-bb2d-63bc1a5a6870",
+          "id": "6f8db02c-0358-41c4-9e05-f76dbb11765d",
           "name": "Get Product Description by Product ID",
           "request": {
             "name": "Get Product Description by Product ID",
@@ -437,7 +437,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c7014f93-c3a1-47d5-ab33-d55b92c95552",
+              "id": "18cf81d1-d083-4d60-a15b-66b8b8fa3415",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -534,7 +534,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "097fa0c4-8888-473d-a59e-106de0daab82",
+                "id": "b31b4679-3704-4b97-b37f-29cc8d23249c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/products/:productId/description - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -550,7 +550,7 @@
           }
         },
         {
-          "id": "5d964eee-ed42-4379-ae66-204600566915",
+          "id": "d908f1b1-28ca-4875-862e-cf2e9a0eb74b",
           "name": "Update Product Description by Product ID",
           "request": {
             "name": "Update Product Description by Product ID",
@@ -623,7 +623,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "efc3506b-5c73-48f6-9cea-5d7aa934f19e",
+              "id": "21c6d3df-5958-421d-87f8-25ee0311a594",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -724,7 +724,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "318dea6d-c59d-4ca8-aa64-f5f0410818a4",
+                "id": "9bc0c93a-ddc8-4ec3-9386-ab3ac8ecf491",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog-seller-portal/products/:productId/description - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -738,7 +738,7 @@
           }
         },
         {
-          "id": "a932e162-7f54-456a-bcd2-98a353873627",
+          "id": "bbc72518-96b1-4cd4-a045-6737fa95bfb5",
           "name": "Get Product by external ID,  SKU ID, SKU external ID or slug",
           "request": {
             "name": "Get Product by external ID,  SKU ID, SKU external ID or slug",
@@ -801,7 +801,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "db75db3c-4c68-4cec-84f5-ab1c24b8b8d0",
+              "id": "a192b63d-dada-43d5-a75e-a97388eb6f21",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -897,7 +897,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "14f13a80-9b2d-486b-ba74-9fa47d0333c6",
+                "id": "2f37f161-148c-4450-808d-98ed361b0866",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/products/:param - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -913,7 +913,7 @@
           }
         },
         {
-          "id": "269646ea-cfbd-4fce-8981-2c712592623a",
+          "id": "7343681a-0104-4468-bdd8-32c787240c71",
           "name": "Create Product",
           "request": {
             "name": "Create Product",
@@ -978,7 +978,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "927033ba-7c09-4e14-8312-995dce5e1a49",
+              "id": "39a71a0d-0111-40ff-b93f-95105887c417",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1070,7 +1070,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c2a91dc2-b566-4659-8614-633a07e6b171",
+              "id": "d2a8d29b-964b-477e-ac33-8b3593d6ba1e",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -1159,7 +1159,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a3fbdd47-7d44-416d-853f-5e9acf2d8eaf",
+                "id": "10f58abd-5346-4f56-92d1-c9d202c05b9d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog-seller-portal/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1178,7 +1178,7 @@
       "event": []
     },
     {
-      "id": "3183c1eb-8fcf-4fd7-90fc-012543416bd9",
+      "id": "7537752f-fe29-455b-8b24-fd8e340db273",
       "name": "SKU",
       "description": {
         "content": "",
@@ -1186,7 +1186,7 @@
       },
       "item": [
         {
-          "id": "32ace615-ce9e-400a-9118-f30c8d327b81",
+          "id": "8cb4497b-d782-4331-811a-57aedd40e652",
           "name": "Search for SKU",
           "request": {
             "name": "Search for SKU",
@@ -1276,7 +1276,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e250a2b7-7e33-4f76-9414-a468cc85138f",
+              "id": "ef521e45-3c50-4ac1-986a-220dec84b484",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1379,7 +1379,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d8c7f0ac-c2ad-46bc-8dd2-dfc8f489f834",
+                "id": "6b95762d-6db1-4f62-8352-e5f558706e4a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/skus/_search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1395,7 +1395,7 @@
           }
         },
         {
-          "id": "c41f9872-da9a-4d48-a631-ed8da5117697",
+          "id": "7378165a-114c-4f4e-afc2-4b0315108d3f",
           "name": "Get List of SKUs",
           "request": {
             "name": "Get List of SKUs",
@@ -1467,7 +1467,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dd96ba50-8ee0-431b-b1d5-40e5f6479ad1",
+              "id": "2c0154f2-0b0a-41aa-b0fa-81f41cf5b4af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1562,7 +1562,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e545fd46-8d75-4b90-8721-ce7cc7387f48",
+                "id": "7e0d53c0-b095-4cbc-a5b7-c3f29ee14f5c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/skus/ids - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1581,7 +1581,7 @@
       "event": []
     },
     {
-      "id": "9858ed55-6abe-4244-bb2c-a343110bdfd8",
+      "id": "7eccbe95-7f4f-4ac3-b918-d96403d54a3a",
       "name": "Brand",
       "description": {
         "content": "",
@@ -1589,7 +1589,7 @@
       },
       "item": [
         {
-          "id": "52957596-0343-4e61-a71d-723156f52212",
+          "id": "8eebba92-a894-4d2a-b210-646ae6c71b69",
           "name": "Get List of Brands",
           "request": {
             "name": "Get List of Brands",
@@ -1687,7 +1687,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "75595b8b-885e-4e98-a2f3-27faee1ba952",
+              "id": "9e0d3924-e93c-47b4-bc02-ab83205efde7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1793,7 +1793,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4fa9668a-ac3b-4542-b628-22d80a0db44e",
+                "id": "4183a50e-faa3-4ec0-81ef-ab17c5a13a4c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/brands - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1809,7 +1809,7 @@
           }
         },
         {
-          "id": "9840ffbb-19e9-4e40-bb17-ff14aa91b14e",
+          "id": "c0990aae-ab89-47c2-98dc-561e0ec3a68b",
           "name": "Create Brand",
           "request": {
             "name": "Create Brand",
@@ -1874,7 +1874,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "21f2b4b2-2dd7-46fe-9d76-5199ca19ffb2",
+              "id": "ae148f54-947d-4dcb-b705-7820238040fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1967,7 +1967,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "274d3df1-d60c-41ce-997f-b04603cfaea7",
+                "id": "443f43bd-59fb-40a0-baf1-7bbabbee0010",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog-seller-portal/brands - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1983,7 +1983,7 @@
           }
         },
         {
-          "id": "b5af2033-c7cf-4f5c-b327-33ec2a68a2a2",
+          "id": "40713b14-e50e-4852-aa98-b90bf3291570",
           "name": "Get Brand by ID",
           "request": {
             "name": "Get Brand by ID",
@@ -2046,7 +2046,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c4c3d5c8-cbd5-4283-a6a8-a7a2840938a2",
+              "id": "ec22ef6d-6b71-4517-a5f3-274be654d68c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2142,7 +2142,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "271113d0-304e-4ddd-b0fe-bb8c14218911",
+                "id": "54477e8c-6efa-42d1-9163-552ae6c02793",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/brands/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2158,7 +2158,7 @@
           }
         },
         {
-          "id": "23be4605-ed02-4ce8-bd6a-7b0182cef172",
+          "id": "76445691-cfd7-4a50-b327-89cf33b3d920",
           "name": "Update Brand",
           "request": {
             "name": "Update Brand",
@@ -2230,7 +2230,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "247b1738-a959-4944-94cf-2b2080deab34",
+              "id": "dbb27418-3b55-4b21-b7e6-65b55b30b730",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -2330,7 +2330,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7949d7bf-b0c8-41b8-8f27-92c4095b150b",
+                "id": "de69db5d-eef8-42b5-909e-7ae8af9a5da2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog-seller-portal/brands/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2347,7 +2347,7 @@
       "event": []
     },
     {
-      "id": "d54726bd-b644-4dd6-8e1b-c9719a064d42",
+      "id": "59838d3f-bb24-4ace-b9cf-536dfee13c9e",
       "name": "Category",
       "description": {
         "content": "",
@@ -2355,7 +2355,7 @@
       },
       "item": [
         {
-          "id": "f6e6aba3-ef8f-45e2-8cd1-6bde94e0a596",
+          "id": "7a5ccad9-f033-4372-bd54-b6c3b279d058",
           "name": "Get Category Tree",
           "request": {
             "name": "Get Category Tree",
@@ -2417,7 +2417,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e22408c5-2f22-480a-aa4c-70ae0d8d1f67",
+              "id": "aad186bf-76e0-4649-ac34-07981d35659b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2507,7 +2507,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7c7b75d0-aa61-48e7-b0cc-0034cc801669",
+                "id": "e6e686c1-08a2-4c2d-9ed2-d318e06f8fc8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/category-tree - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2523,7 +2523,7 @@
           }
         },
         {
-          "id": "16668604-361f-4ff3-9cff-60be06f7ce7f",
+          "id": "2100b29c-d747-4e24-877b-2a59428ecee1",
           "name": "Update Category Tree",
           "request": {
             "name": "Update Category Tree",
@@ -2584,7 +2584,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1709d9b6-aa69-42e9-bf71-1320bfaa8314",
+              "id": "567e15b3-8f97-4ea7-84c4-eb1834839a6d",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -2673,7 +2673,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c5308f55-7e84-408a-9cf2-cec8bf6938d6",
+                "id": "854f2ec9-7d49-44c3-b2c8-529fda77057d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog-seller-portal/category-tree - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2687,7 +2687,7 @@
           }
         },
         {
-          "id": "86a53975-4904-4917-b743-bb17f09be167",
+          "id": "d2dc79c6-fb92-4f1a-89da-8cf34f541cf1",
           "name": "Get Category by ID",
           "request": {
             "name": "Get Category by ID",
@@ -2751,7 +2751,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "43e9c6f3-77cb-4457-8a43-e6aab821c616",
+              "id": "32d101c6-27e5-49b7-8cc8-dfcbd654960f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2848,7 +2848,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "62013d2a-2da9-4726-b6a5-b23d3107fdc2",
+                "id": "e0ab9c61-60eb-42c1-ac4a-02c82e8b58b4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog-seller-portal/category-tree/categories/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2864,7 +2864,7 @@
           }
         },
         {
-          "id": "42dbec7d-5dd5-4f60-a7a3-63e6896eea17",
+          "id": "82c011f0-4584-44e3-abcd-4023a780651d",
           "name": "Create Category",
           "request": {
             "name": "Create Category",
@@ -2930,7 +2930,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9a2ef0fb-f456-4944-a979-574d0b2aabb2",
+              "id": "6d9c33d4-dbd1-4d9e-b6b7-9aa7ae806498",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3024,7 +3024,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1daa814d-70e1-4f29-abc1-c4e2398173e7",
+                "id": "b385267b-6d22-458b-b95e-4a95913a102c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog-seller-portal/category-tree/categories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3090,7 +3090,7 @@
     }
   ],
   "info": {
-    "_postman_id": "d34f7ca2-967c-42ac-aca1-d56ca248487b",
+    "_postman_id": "0bb830f3-aa60-42ad-89de-0c91c1918195",
     "name": "Catalog API - Seller Portal",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/VTEX - Catalog API Seller Portal.json
+++ b/VTEX - Catalog API Seller Portal.json
@@ -4422,6 +4422,9 @@
         {
             "appKey": [],
             "appToken": []
+        },
+        {
+            "VtexIdclientAutCookie": []
         }
     ],
     "components": {
@@ -4429,12 +4432,20 @@
             "appKey": {
                 "type": "apiKey",
                 "in": "header",
-                "name": "X-VTEX-API-AppKey"
+                "name": "X-VTEX-API-AppKey",
+                "description": "Unique identifier of the [application key](https://developers.vtex.com/docs/guides/authentication-overview#application-keys)."
             },
             "appToken": {
                 "type": "apiKey",
                 "in": "header",
-                "name": "X-VTEX-API-AppToken"
+                "name": "X-VTEX-API-AppToken",
+                "description": "Secret token of the [application key](https://developers.vtex.com/docs/guides/authentication-overview#application-keys)."
+            },
+            "VtexIdclientAutCookie": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "VtexIdclientAutCookie",
+                "description": "[User token](https://developers.vtex.com/docs/guides/authentication-overview#user-token), valid for 24 hours."
             }
         }
     },


### PR DESCRIPTION
Adding `VtexIdclientAutCookie` as an authentication option besides the `appKey`-`appToken` pair.

Based on [Swagger documentation](https://swagger.io/docs/specification/authentication/#:~:text=Using%20Multiple%20Authentication%20Types), it is possible to offer multiple authentication types separating them in different objects when referring to them in `security`. The goal of this PR is to test how these alternative options are rendered in Developer Portal.