### PR TITLE
Update spectral linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,8 @@
 name: Run Spectral on Pull Requests
 
+
 on: pull_request
+
 
 jobs:
   build:
@@ -8,21 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out the repository
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+     
       # Add comment to PR
       - name: Comment a pull_request
-        uses: mb2dev/github-action-comment-pull-request@1.0.0
+        uses: mshick/add-pr-comment@v2
         with:
           message: "Thanks for your contribution. The .json file will be checked now with Spectral."
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
-      
+          repo-token: ${{ secrets.GITHUB_TOKEN }}        
+     
       # Get the name of changed files
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v11.7
+        uses: tj-actions/changed-files@v39.1.2
         with:
-          files: \.json$        
+          files: |
+            *.json
 
       # Run Spectral on changed files
       - uses: stoplightio/spectral-action@v0.8.10

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,39 +1,140 @@
 extends: ["spectral:oas"]
 
 rules:
+  path-params: off
+  operation-operationId: off
   oas3-examples-value-or-externalValue: off
   oas3-unused-component: off
-  operation-operationId: off
-  e-mail-in-description:
+  info-contact: off
+  write-email-not-e-mail:
     description: Should use email instead of e-mail in descriptions
-    severity: warn
+    severity: error
     given: "$..*[?(@property === 'description')]"	
     then:
       function: pattern
       functionOptions:
         notMatch: "\\be-mail\\b"
 
-  should-include-operation-summary:
+  must-include-operation-summary:
     description: Operation summary should be included
-    severity: warn
+    severity: error
     given: "$.paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]"
     then:
       - field: "summary"
         function: truthy        
 
-  should-include-response-examples:
+  must-include-response-examples:
     description: At least one example should be included for each API response
-    severity: warn
+    severity: error
     given: "$.paths..responses.*.content.*"
     then:
       - field: "example"
         function: truthy
 
-  avoid-empty-titles:
-    description: There can be no empty titles. Removing this title field from the property solves this issue.
+  must-include-response-schemas:
+    description: Each API response must contain a schema
     severity: error
-    given: "$..[?(@.title='')]~"
+    given: "$.paths..responses.*.content.*"
+    then:
+      - field: "schema"
+        function: truthy
+
+  no-empty-titles:
+    description: There can be no empty titles in schemas. Removing this title field from the property will solve this issue.
+    severity: error
+    given: "$..[?(@.title=='')]~"
     then:
       function: pattern
       functionOptions:
-        notMatch: "example"
+        match: "example"
+
+  must-end-field-descriptions-with-period:
+    description: All field descriptions must end with a period (".").
+    severity: error
+    given: "$..*['properties']..['description']"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^.*[.]$"
+
+  summaries-should-be-in-sentence-case:
+    description: All endpoint summaries should use sentence case (capitalize only the first letter).
+    severity: warn
+    given: "$..*[?( @property === 'summary')]"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[A-Z][a-z ]*$"
+
+  no-empty-descriptions:
+    description: No empty descriptions allowed.
+    severity: error
+    given: "$..*[?(@property === 'description')]"
+    then:
+      function: pattern
+      functionOptions:
+        match: "^(?!\\s*$).+"
+
+  parameters-description:
+    description: Each parameter must contain a description.
+    severity: error
+    given: "$.paths.*.*.parameters[*]"
+    then:
+      field: "description"
+      function: truthy
+
+  properties-description:
+    description: Each request or response body property must contain a description.
+    severity: error
+    given: "$..properties.*"
+    then:
+      field: "description"
+      function: truthy
+
+  properties-type:
+    description: Each request or response body property must contain a type.
+    severity: error
+    given: "$..properties.*"
+    then:
+      field: "type"
+      function: truthy
+
+  items-description:
+    description: Each request or response body array "items" property must contain a description.
+    severity: error
+    given: "$..items"
+    then:
+      field: "description"
+      function: truthy
+
+  items-type:
+    description: Each request or response body array "items" property must contain a type.
+    severity: error
+    given: "$..items"
+    then:
+      field: "type"
+      function: truthy
+
+  request-body-properties-example:
+    description: Each request body property must contain an example.
+    severity: error
+    given: "$..requestBody..*[?(@.type=='string' || @.type=='integer' || @.type=='boolean')]"
+    then:
+      field: "example"
+      function: truthy
+
+  request-body-objects-arrays-example:
+    description: In the request body, objects and arrays should not contain examples. Only scalar fields should contain examples in the request body.
+    severity: error
+    given: "$..requestBody..*[?(@.type=='object' || @.type=='array')]"
+    then:
+      field: "example"
+      function: falsy
+
+  response-body-objects-arrays-example:
+    description: Response body fields should not contain the "example" field. The response example corresponds to the whole schema.
+    severity: error
+    given: "$..responses..*[?(@.type=='object' || @.type=='array' || @.type=='integer' || @.type=='boolean' || @.type=='string')]"
+    then:
+      field: "example"
+      function: falsy


### PR DESCRIPTION
Updating Spectral action and adding new rules.

These changes were tested in other mock PRs, the latest one being [1006](https://github.com/vtex/openapi-schemas/pull/1006).

#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
