### PR TITLE
EDU-7406 - Fix Seller's commision path

### DIFF
--- a/VTEX - Marketplace APIs.json
+++ b/VTEX - Marketplace APIs.json
@@ -1211,7 +1211,77 @@
                 "deprecated": false
             }
         },
-        "/seller-register/pvt/sellers/{sellerId}/commissions/categories": {
+        "/seller-register/pvt/sellers/{sellerId}/commissions": {
+            "get": {
+                "tags": [
+                    "Seller Commissions"
+                ],
+                "summary": "List Seller Commissions by seller ID",
+                "description": "This endpoint retrieves all comissions configured for a specific seller.",
+                "operationId": "ListSellerCommissions",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "description": "Name of the VTEX account that belongs to the marketplace. All data extracted, and changes added will be posted into this account.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL.",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "sellerId",
+                        "in": "path",
+                        "description": "A string that identifies the seller in the marketplace. This ID must be created by the marketplace.",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "seller123"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Describes the type of the content being sent.",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {}
+                    }
+                },
+                "deprecated": false
+            },
             "put": {
                 "tags": [
                     "Seller Commissions"
@@ -1301,176 +1371,6 @@
                                     "freightCommissionPercentage": 2.43
                                 }
                             ]
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {}
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/seller-register/pvt/sellers/{sellerId}/commissions": {
-            "get": {
-                "tags": [
-                    "Seller Commissions"
-                ],
-                "summary": "List Seller Commissions by seller ID",
-                "description": "This endpoint retrieves all comissions configured for a specific seller.",
-                "operationId": "ListSellerCommissions",
-                "parameters": [
-                    {
-                        "name": "accountName",
-                        "in": "path",
-                        "description": "Name of the VTEX account that belongs to the marketplace. All data extracted, and changes added will be posted into this account.",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "default": "apiexamples"
-                        }
-                    },
-                    {
-                        "name": "environment",
-                        "in": "path",
-                        "required": true,
-                        "description": "Environment to use. Used as part of the URL.",
-                        "schema": {
-                            "type": "string",
-                            "default": "vtexcommercestable"
-                        }
-                    },
-                    {
-                        "name": "sellerId",
-                        "in": "path",
-                        "description": "A string that identifies the seller in the marketplace. This ID must be created by the marketplace.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "seller123"
-                        }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Describes the type of the content being sent.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {}
-                    }
-                },
-                "deprecated": false
-            },
-            "put": {
-                "tags": [
-                    "Seller Commissions"
-                ],
-                "summary": "Upsert Seller Commissions by Category ID",
-                "operationId": "UpsertSellerCommissions",
-                "description": "This endpoint is used by marketplace operators to define comissions for a single category, by ID.",
-                "parameters": [
-                    {
-                        "name": "accountName",
-                        "in": "path",
-                        "description": "Name of the VTEX account that belongs to the marketplace. All data extracted, and changes added will be posted into this account.",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "default": "apiexamples"
-                        }
-                    },
-                    {
-                        "name": "environment",
-                        "in": "path",
-                        "required": true,
-                        "description": "Environment to use. Used as part of the URL.",
-                        "schema": {
-                            "type": "string",
-                            "default": "vtexcommercestable"
-                        }
-                    },
-                    {
-                        "name": "sellerId",
-                        "in": "path",
-                        "description": "A string that identifies the seller in the marketplace. This ID must be created by the marketplace.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "seller123"
-                        }
-                    },
-                    {
-                        "name": "categoryId",
-                        "in": "path",
-                        "description": "ID of the category in which the comission will be applied.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "6"
-                        }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Describes the type of the content being sent.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpsertSellerCommissionsRequest"
-                            },
-                            "example": {
-                                "categoryId": "6",
-                                "categoryFullPath": null,
-                                "productCommissionPercentage": 9.85,
-                                "freightCommissionPercentage": 2.43
-                            }
                         }
                     },
                     "required": true
@@ -1639,6 +1539,104 @@
                         }
                     }
                 ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {}
+                    }
+                },
+                "deprecated": false
+            },
+            "put": {
+                "tags": [
+                    "Seller Commissions"
+                ],
+                "summary": "Upsert Seller Commissions by Category ID",
+                "operationId": "UpsertSellerCommissions",
+                "description": "This endpoint is used by marketplace operators to define comissions for a single category, by ID.",
+                "parameters": [
+                    {
+                        "name": "accountName",
+                        "in": "path",
+                        "description": "Name of the VTEX account that belongs to the marketplace. All data extracted, and changes added will be posted into this account.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "default": "apiexamples"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "required": true,
+                        "description": "Environment to use. Used as part of the URL.",
+                        "schema": {
+                            "type": "string",
+                            "default": "vtexcommercestable"
+                        }
+                    },
+                    {
+                        "name": "sellerId",
+                        "in": "path",
+                        "description": "A string that identifies the seller in the marketplace. This ID must be created by the marketplace.",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "seller123"
+                        }
+                    },
+                    {
+                        "name": "categoryId",
+                        "in": "path",
+                        "description": "ID of the category in which the comission will be applied.",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "6"
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Describes the type of the content being sent.",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "string",
+                            "default": "application/json"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpsertSellerCommissionsRequest"
+                            },
+                            "example": {
+                                "categoryId": "6",
+                                "categoryFullPath": null,
+                                "productCommissionPercentage": 9.85,
+                                "freightCommissionPercentage": 2.43
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "responses": {
                     "200": {
                         "description": "OK",


### PR DESCRIPTION
- The Upsert Seller Commissions by Category ID endpoint now belongs to the path /seller-register/pvt/sellers/{sellerId}/commissions/{categoryId}
- The Upsert Seller Commissions in Bulk endpoint now belongs to the path /seller-register/pvt/sellers/{sellerId}/commissions
- The path /seller-register/pvt/sellers/{sellerId}/commissions/categories no longer exists.

#### Types of changes
- [ ] New content (endpoints, descriptions, or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [x] No, but I am going to.
