### PR TITLE
Improve spectral alerts' text.

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -58,7 +58,7 @@ rules:
         match: "^[A-Z][a-z ]*$"
 
   no-empty-descriptions:
-    description: No empty descriptions allowed.
+    description: No empty descriptions allowed. Make sure that this description is a valid string that does not start with a line break (\n or \r).
     severity: error
     given: "$..*[?(@property === 'description')]"
     then:
@@ -99,7 +99,7 @@ rules:
       function: truthy
 
   items-description:
-    description: Each request or response body array "items" property must contain a description.
+    description: Each request or response body array "items" property must contain a description. This rule may also be triggered due to your request schema containing a complete example. If this is the case, make sure that your request examples exist only at scalar field levels (integer, string or boolean). 
     severity: error
     given: "$.[^example].items"
     then:
@@ -107,7 +107,7 @@ rules:
       function: truthy
 
   items-type:
-    description: Each request or response body array "items" property must contain a type.
+    description: Each request or response body array "items" property must contain a type. This rule may also be triggered due to your request schema containing a complete example. If this is the case, make sure that your request examples exist only at scalar field levels (integer, string or boolean). 
     severity: error
     given: "$.[^example].items"
     then:


### PR DESCRIPTION
I have found two spectral rules that may be triggered due to cases we had not predicted. This led to some confusing errors with the bot lint.

So I am improving the alerts' text so that tech writers know how to handle each alert.