### PR TITLE
Improve spectral rules

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -77,17 +77,9 @@ rules:
   properties-description:
     description: Each request or response body property must contain a description.
     severity: error
-    given: "$..properties..*"
+    given: "$..*[?(@ && @property != 'schema' && (@.type=='object' || @.type=='array' || @.type=='integer' || @.type=='boolean' || @.type=='string' || @.type=='number'))]"
     then:
       field: "description"
-      function: defined
-
-  properties-type:
-    description: Each request or response body property must contain a type.
-    severity: error
-    given: "$..properties..*"
-    then:
-      field: "type"
       function: defined
 
   array-items:
@@ -96,14 +88,6 @@ rules:
     given: "$..[?(@ && @.type == 'array')]"
     then:
       field: "items"
-      function: defined
-
-  items-description:
-    description: Each request or response body array "items" property must contain a description. This rule may also be triggered due to your request schema containing a complete example. If this is the case, make sure that your request examples exist only at scalar field levels (integer, string or boolean).
-    severity: error
-    given: "$.[^example].items"
-    then:
-      field: "description"
       function: defined
 
   items-type:


### PR DESCRIPTION
- Remove `properties-type` rule.
- Improve `properties-description` rule, which now makes items-description rule obsolete.
- Remove `items-description` rule.