### PR TITLE
Improve spectral rule items type

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -99,7 +99,7 @@ rules:
       function: defined
 
   response-body-items-type:
-    description: Each response body array "items" property must contain a type, unless it is an example. 
+    description: Each array "items property" in the response body schema must contain a type. 
     severity: warning
     given: "$.paths.*.*.responses.*.content.*.schema..items"
     then:

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -92,7 +92,7 @@ rules:
 
   request-body-items-type:
     description: Each request body array "items" property must contain a type.
-    severity: warning
+    severity: warn
     given: "$.paths.*.*.requestBody.content.*.schema..items"
     then:
       field: "type"
@@ -100,7 +100,7 @@ rules:
 
   response-body-items-type:
     description: Each array "items property" in the response body schema must contain a type. 
-    severity: warning
+    severity: warn
     given: "$.paths.*.*.responses.*.content.*.schema..items"
     then:
       field: "type"

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -90,10 +90,10 @@ rules:
       field: "items"
       function: defined
 
-  items-type:
-    description: Each request or response body array "items" property must contain a type. This rule may also be triggered due to your request schema containing a complete example. If this is the case, make sure that your request examples exist only at scalar field levels (integer, string or boolean). 
-    severity: error
-    given: "$.[^example].items"
+  request-body-items-type:
+    description: Each request body array "items" property must contain a type. 
+    severity: warning
+    given: "$.paths.*.*.requestBody..items"
     then:
       field: "type"
       function: defined

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -91,9 +91,17 @@ rules:
       function: defined
 
   request-body-items-type:
-    description: Each request body array "items" property must contain a type. 
+    description: Each request body array "items" property must contain a type.
     severity: warning
-    given: "$.paths.*.*.requestBody..items"
+    given: "$.paths.*.*.requestBody.content.*.schema..items"
+    then:
+      field: "type"
+      function: defined
+
+  response-body-items-type:
+    description: Each response body array "items" property must contain a type, unless it is an example. 
+    severity: warning
+    given: "$.paths.*.*.responses.*.content.*.schema..items"
     then:
       field: "type"
       function: defined


### PR DESCRIPTION
Solving `items-type` issue, by splitting it into 2 rules (request and response) and giving a more precise path.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
