### PR TITLE
Improve spectral rule request examples

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -107,7 +107,7 @@ rules:
       function: defined
 
   request-body-properties-example:
-    description: Each request body property should have an example. In case the schema is also used as a response and there is already an example elsewhere, feel free to ignore this alert. If you have chosen to include a complete example to better represent arrays, feel free to ignore this alert.
+    description: Each request body property should have an example. In case the schema is also used as a response and there is already an example elsewhere, feel free to ignore this alert. If you have chosen to include a complete example of the schema to better represent arrays, feel free to ignore this alert.
     severity: warn
     given: "$..requestBody..*[?(@ && (@.type=='string' || @.type=='integer' || @.type=='boolean'))]"
     then:

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -107,8 +107,8 @@ rules:
       function: defined
 
   request-body-properties-example:
-    description: Each request body property must contain an example.
-    severity: error
+    description: Each request body property should have an example. In case the schema is also used as a response and there is already an example elsewhere, feel free to ignore this alert. If you have chosen to include a complete example to better represent arrays, feel free to ignore this alert.
+    severity: warn
     given: "$..requestBody..*[?(@ && (@.type=='string' || @.type=='integer' || @.type=='boolean'))]"
     then:
       field: "example"


### PR DESCRIPTION
Improving the rule `request-body-properties-example` to contemplate exceptions. However, the desirable future is that the rule looks for examples in the field declaration or in the complete schema example, if it exists and for the severity to be `error`.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

