### PR TITLE
Improve spectral rule: sentence case

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -49,13 +49,13 @@ rules:
         match: "example"
 
   summaries-should-be-in-sentence-case:
-    description: All endpoint summaries should use sentence case (capitalize only the first letter).
+    description: All endpoint summaries should use sentence case (capitalize only the first letter). Exceptions include some product names.
     severity: warn
     given: "$..*[?( @property === 'summary')]"
     then:
       function: pattern
       functionOptions:
-        match: "^[A-Z][a-z ]*$"
+        match: "/^[A-Z\\d][a-z\\d ]*$/gm"
 
   no-empty-descriptions:
     description: No empty descriptions allowed. Make sure that this description is a valid string that does not start with a line break (\n or \r). If this description is inside an example, please fill it with a valid value.


### PR DESCRIPTION
Now the spectral rule about sentence case won't trigger for summaries that contain numbers.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
