### PR TITLE
Fix spectral rule (summary)

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -55,7 +55,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^[A-Z](?:[a-z0-9 ]*(?:BLERG|DO|ID|SKU))*[a-z0-9 ]*$"
+        match: "^[A-Z](?:[a-z0-9 ]*(?:VTEX|DO|ID|SKU))*[a-z0-9 ]*$"
 
   no-empty-descriptions:
     description: No empty descriptions allowed. Make sure that this description is a valid string that does not start with a line break (\n or \r). If this description is inside an example, please fill it with a valid value.


### PR DESCRIPTION
The previous version had `BLERG` instead of `VTEX` in the regex.