### PR TITLE
Improving spectral rule - sentence case

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -55,7 +55,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^[A-Z](?:[a-z0-9 ]*(?:VTEX|DO|ID|OAuth|Customer Credit|CMS|appKey|appToken|-|,|API|DKIM|SKU))*[a-z0-9 ]*$"
+        match: "^[A-Z](?:[a-z0-9 ]*(?:VTEX|TEX|DO|ID|OAuth|Customer Credit|CMS|appKey|appToken|-|,|API|DKIM|SKU))*[a-z0-9 ]*$"
 
   no-empty-descriptions:
     description: No empty descriptions allowed. Make sure that this description is a valid string that does not start with a line break (\n or \r). If this description is inside an example, please fill it with a valid value.


### PR DESCRIPTION
VTEX is already on the allow list of the rule. However, it counts as an error if it is the first thing in the summary. Since VTEX can often be used in the beginning of the summary and it is always correct to capitalize all of it, I am adding `TEX` to the allow list. This fixes the issue.