### PR TITLE
EDU-12823 - spectral rule properties-description

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,5 +1,7 @@
 extends: ["spectral:oas"]
 
+functions:
+  - definedNotExample
 rules:
   path-params: off
   operation-operationId: off
@@ -80,7 +82,7 @@ rules:
     given: "$..*[?(@ && @property != 'schema' && (@.type=='object' || @.type=='array' || @.type=='integer' || @.type=='boolean' || @.type=='string' || @.type=='number'))]"
     then:
       field: "description"
-      function: defined
+      function: definedNotExample
 
   array-items:
     description: Each array field must contain an "items" property.

--- a/functions/definedNotExample.js
+++ b/functions/definedNotExample.js
@@ -1,0 +1,9 @@
+// Custom spectral linting function which throws exception only if target is undefined AND is not within an example (any level)
+// Learn more about custom spectral functions:
+// https://docs.stoplight.io/docs/spectral/a781e290eb9f9-custom-functions
+
+export default function definedNotExample (input, options, context) {
+    if (!context.path.includes('example') && input == undefined) {
+        return [{message: 'error'}]
+    }
+}


### PR DESCRIPTION
Improving the `properties-description` Spectral rule with a custom function that detects if the target description is within any level of an example. This fixes the latest reported false positives caused by this rule.

#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)
