### PR TITLE
EDU-14708 - Change param default

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -10566,7 +10566,7 @@
                             "compensateShippingChanges": {
                               "type": "boolean",
                               "description": "Defines if the orders modified will have zero shipping cost (`true`) or not (`false`). Merchants can enable this configuration to modify only items and prices, without impacting the orders' original freight costs.",
-                              "default": true,
+                              "default": false,
                               "example": true
                             }
                           }
@@ -22077,7 +22077,7 @@
                       "compensateShippingChanges": {  
                         "type": "boolean",
                         "description": "Defines if orders changed will have zero shipping cost (`true`) or not (`false`). Merchants usually enable this configuration to change only items and prices, without impacting the orders original freight costs.",
-                        "default": true
+                        "default": false
                       }
                     }
                   }


### PR DESCRIPTION
Change `compensateShippingChanges` default to `false`, as requested in [EDU-14708](https://vtex-dev.atlassian.net/browse/EDU-14708).

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.


[EDU-14708]: https://vtex-dev.atlassian.net/browse/EDU-14708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ