### PR TITLE
Update link id field behavior in Catalog api categories' endpoints

### DIFF
--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -7334,7 +7334,7 @@
                                     "GlobalCategoryId": 3367,
                                     "StockKeepingUnitSelectionMode": "LIST",
                                     "Score": null,
-                                    "LinkId": "Alimentacao",
+                                    "LinkId": "Home-appliances",
                                     "HasChildren": true
                                 },
                                 "schema": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -2824,7 +2824,7 @@
                                     },
                                     "MeasurementUnit": {
                                         "type": "string",
-                                        "description": "Measurement unit. This field should only be used when it is necessary to convert the unit of measure for sale. In common cases, use `un` (unit).\r\nThe acceptables values are:\r\n-`kg`: Kilogram\r\n-`g`: Gram\r\n-`l`: Liter\r\n-`ml`: Milliliter\r\n-`m`: Meter\r\n-`cm`: Centimeter\r\n-`un`: Unit",
+                                        "description": "Measurement unit. This field should only be used when it is necessary to convert the unit of measure for sale. In common cases, use `un` (unit).\n\rThe acceptables values are:\n\r- `kg`: Kilogram\n\r- `g`: Gram\n\r- `l`: Liter\n\r- `ml`: Milliliter\n\r- `m`: Meter\n\r- `cm`: Centimeter\n\r- `un`: Unit",
                                         "example": "un"
                                     },
                                     "UnitMultiplier": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -14947,7 +14947,7 @@
                     },
                     "LinkId": {
                         "type": "string",
-                        "description": "This field value is automatically generated when you create or update a category, and it corresponds to the category `name`. Once the category `linkId` is generated, it cannot be modified directly, but you can change it by updating the category with a new `name`. "
+                        "description": "Category text link ID. This field value is automatically generated when you create or update a category, and it corresponds to the category `name`. Once the category `linkId` is generated, it cannot be modified directly, but you can change it by updating the category with a new `name`."
                     },
                     "HasChildren": {
                         "type": "boolean",

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -14947,7 +14947,7 @@
                     },
                     "LinkId": {
                         "type": "string",
-                        "description": "Text link.",
+                        "description": "This field value is automatically generated when you create or update a category, and it corresponds to the category `name`. Once the category `linkId` is generated, it cannot be modified directly, but you can change it by updating the category with a new `name`. ",
                         "nullable": true
                     },
                     "HasChildren": {
@@ -14971,7 +14971,7 @@
                     "GlobalCategoryId": 3367,
                     "StockKeepingUnitSelectionMode": "LIST",
                     "Score": null,
-                    "LinkId": "Alimentacao",
+                    "LinkId": "Home-appliances",
                     "HasChildren": true
                 }
             },

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -7492,7 +7492,7 @@
                                     "GlobalCategoryId": 3367,
                                     "StockKeepingUnitSelectionMode": "LIST",
                                     "Score": null,
-                                    "LinkId": "Alimentacao",
+                                    "LinkId": "Home-appliances",
                                     "HasChildren": true
                                 },
                                 "schema": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -7549,7 +7549,7 @@
                                     "GlobalCategoryId": 3367,
                                     "StockKeepingUnitSelectionMode": "LIST",
                                     "Score": null,
-                                    "LinkId": "Alimentacao",
+                                    "LinkId": "Home-appliances",
                                     "HasChildren": true
                                 },
                                 "schema": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -14947,8 +14947,7 @@
                     },
                     "LinkId": {
                         "type": "string",
-                        "description": "This field value is automatically generated when you create or update a category, and it corresponds to the category `name`. Once the category `linkId` is generated, it cannot be modified directly, but you can change it by updating the category with a new `name`. ",
-                        "nullable": true
+                        "description": "This field value is automatically generated when you create or update a category, and it corresponds to the category `name`. Once the category `linkId` is generated, it cannot be modified directly, but you can change it by updating the category with a new `name`. "
                     },
                     "HasChildren": {
                         "type": "boolean",


### PR DESCRIPTION
The `linkId` value is generated automatically based on the category name when the category is created or updated.

Task
- Indicate that it's generated automatically based on the category name and cannot be modified directly.
- The response examples must be corrected.
- The field is not nullable.


#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.
