### PR TITLE
EDU-14388 - Add field on order modifications requests

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -19888,6 +19888,11 @@
                                 "description": "SKU ID of the item that will be modified.",
                                 "example": "1"
                               },
+                              "uniqueId": {
+                                "type": "string",
+                                "description": "Unique ID of the item being modified. This field is mandatory when modifying an order that contains items with the same `id`.",
+                                "example": "1D6A12BD177140B2BAF0C042D2FAEE54"
+                              },
                               "quantity": {
                                 "type": "integer",
                                 "description": "Quantity of the item being modified. Must be greater than 0.",
@@ -19925,6 +19930,11 @@
                                 "type": "string",
                                 "description": "SKU ID of the item that will replace the previous one. If you only wish to replace the product weight, you will repeat the SKU ID used in `from`.",
                                 "example": "1"
+                              },
+                              "uniqueId": {
+                                "type": "string",
+                                "description": "Unique ID of the item being modified. This field is mandatory when modifying an order that contains items with the same `id`.",
+                                "example": "1D6A12BD177140B2BAF0C042D2FAEE54"
                               },
                               "quantity": {
                                 "type": "integer",


### PR DESCRIPTION
Add `uniqueId` field on order modifications schemas.

#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.
