### PR TITLE
Document limit for RefId in Catalog API

### DIFF
--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -402,7 +402,7 @@
                                     },
                                     "RefId": {
                                         "type": "string",
-                                        "description": "Product Reference Code.",
+                                        "description": "Product Reference Code. The limit for the product `RefId` is 100 characters.",
                                         "example": "sr_1_90"
                                     },
                                     "IsVisible": {
@@ -1342,7 +1342,7 @@
                                             },
                                             "RefId": {
                                                 "type": "string",
-                                                "description": "Product Reference Code.",
+                                                "description": "Product Reference Code. The limit for the product `RefId` is 100 characters.",
                                                 "example": "sr_1_90"
                                             },
                                             "IsVisible": {
@@ -1439,7 +1439,7 @@
                                             },
                                             "RefId": {
                                                 "type": "string",
-                                                "description": "Product Reference Code.",
+                                                "description": "Product Reference Code. The limit for the product `RefId` is 100 characters.",
                                                 "example": "sr_1_90"
                                             },
                                             "IsVisible": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -859,7 +859,7 @@
                                         },
                                         "RefId": {
                                             "type": "string",
-                                            "description": "Product Reference ID.  The limit for the product `RefId` is 100 characters."
+                                            "description": "Product Reference ID. The limit for the product `RefId` is 100 characters."
                                         },
                                         "IsVisible": {
                                             "type": "boolean",

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -3605,7 +3605,7 @@
                                     },
                                     "RefId": {
                                         "type": "string",
-                                        "description": "Reference code used internally for organizational purposes. Must be unique. It is not required only if EAN code already exists. If not, this field must be provided.",
+                                        "description": "Reference code used internally for organizational purposes. Must be unique. It is not required only if EAN code already exists. If not, this field must be provided. The limit for the SKU `RefId` is 50 characters.",
                                         "example": "B096QW8Y8Z"
                                     },
                                     "PackagedHeight": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -2743,7 +2743,7 @@
                                     },
                                     "RefId": {
                                         "type": "string",
-                                        "description": "Reference code used internally for organizational purposes. Must be unique. Required only if `Ean` is not informed, but can be used alongside `Ean` as well.",
+                                        "description": "Reference code used internally for organizational purposes. Must be unique. Required only if `Ean` is not informed, but can be used alongside `Ean` as well. The limit for the SKU `RefId` is 50 characters.",
                                         "example": "B096QW8Y8Z"
                                     },
                                     "PackagedHeight": {
@@ -3358,8 +3358,7 @@
                     "500": {
                         "description": "Internal Server Error"
                     }
-                },
-                "deprecated": false
+                }
             }
         },
         "/api/catalog/pvt/stockkeepingunit/{skuId}": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -859,7 +859,7 @@
                                         },
                                         "RefId": {
                                             "type": "string",
-                                            "description": "Product Reference ID."
+                                            "description": "Product Reference ID.  The limit for the product `RefId` is 100 characters."
                                         },
                                         "IsVisible": {
                                             "type": "boolean",


### PR DESCRIPTION
The limit for the `RefId` field for a product is 100 characters, and 50 characters for the SKU. This information must be updated in request bodies.

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.
