### PR TITLE
EDU-14310 - Fix typos

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -20731,7 +20731,7 @@
                   "dimension": {
                     "type": "string",
                     "nullable": true,
-                    "description": "Replacing tem's dimensions in the measure unit configured in the catalog.",
+                    "description": "Replacing item's dimensions in the measure unit configured in the catalog.",
                     "example": null
                   },
                   "brandName": {

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -20227,7 +20227,7 @@
                             "properties": {
                               "id": {
                                 "type": "string",
-                                "description": "SKU ID of the item been replaced."
+                                "description": "SKU ID of the item being replaced."
                               },
                               "quantity": {
                                 "type": "integer",
@@ -20241,31 +20241,31 @@
                               "measurementUnit": {
                                 "type": "string",
                                 "nullable": true,
-                                "description": "Measurement unit of the item been replaced. For example, `kg` for kilograms or `un` for unitary items."
+                                "description": "Measurement unit of the item being replaced. For example, `kg` for kilograms or `un` for unitary items."
                               },
                               "unitMultiplier": {
                                 "type": "integer",
-                                "description": "Unit multiplier for item been update."
+                                "description": "Unit multiplier for item being updated."
                               },
                               "sellingPrice": {
                                 "type": "string",
-                                "description": "Selling price of the item been replaced.",
+                                "description": "Selling price of the item being replaced.",
                                 "nullable": true
                               },
                               "name": {
                                 "type": "string",
                                 "nullable": true,
-                                "description": "Name of the item been replaced."
+                                "description": "Name of the item being replaced."
                               },
                               "detailUrl": {
                                 "type": "string",
                                 "nullable": true,
-                                "description": "URL slug of the item been replaced."
+                                "description": "URL slug of the item being replaced."
                               },
                               "imageUrl": {
                                 "type": "string",
                                 "nullable": true,
-                                "description": "Image URL slug of the item been replaced."
+                                "description": "Image URL slug of the item being replaced."
                               }
                             }
                           }

--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -20708,7 +20708,7 @@
                   "priceDefinition": {
                     "type": "string",
                     "nullable": true,
-                    "description": "replacing item's price information.",
+                    "description": "Replacing item's price information.",
                     "example": null
                   }
                 }


### PR DESCRIPTION
Fixed several typos on the parameters section. Refers to [EDU-14310](https://vtex-dev.atlassian.net/browse/EDU-14310).

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [x] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.


[EDU-14310]: https://vtex-dev.atlassian.net/browse/EDU-14310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ