### PR TITLE
EDU-14058 - Fix `paymentAccountId` description

### DIFF
--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -3628,8 +3628,8 @@
                         "properties": {
                             "paymentAccountId": {
                                 "type": "string",
-                                "description": "Information about the customer profile, such as their credit card number. To obtain that information, use the endpoint [Get client profile by email](https://developers.vtex.com/docs/api-reference/checkout-api#get-/api/checkout/pub/profiles).",
-                                "example": "340357032569595",
+                                "description": "Information about the customer profile. To obtain that information, use the endpoint [Get client profile by email](https://developers.vtex.com/docs/api-reference/checkout-api#get-/api/checkout/pub/profiles) to find the `accountId`.",
+                                "example": "6559E125DB084A46994E045547DE504B",
                                 "nullable": true
                             },
                             "paymentSystem": {

--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -3622,7 +3622,8 @@
                         "type": "object",
                         "description": "Object with [payment method](https://help.vtex.com/en/tutorial/difference-between-payment-methods-and-payment-conditions--3azJenhGFyUy2gsocms42Q) information.",
                         "required": [
-                            "paymentSystem"
+                            "paymentSystem",
+                            "paymentAccountId"
                         ],
                         "properties": {
                             "paymentAccountId": {


### PR DESCRIPTION
Fix `paymentAccountId` field description and example and add it to `required` section. Refers to [EDU-14058](https://vtex-dev.atlassian.net/browse/EDU-14058).

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [x] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.
