### PR TITLE
EDU-13895 - Add fields to response body

### DIFF
--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -4304,16 +4304,16 @@
                                                             "properties": {
                                                                 "name": {
                                                                     "type": "string",
-                                                                    "description": "Gift attachment name.",
+                                                                    "description": "Attachment name.",
                                                                     "nullable": true
                                                                 },
                                                                 "content": {
                                                                     "type": "object",
-                                                                    "description": "Custom field for the gift attachment content.",
+                                                                    "description": "Custom field for the attachment content.",
                                                                     "nullable": true,
                                                                     "additionalProperties": {
                                                                         "type": "string",
-                                                                        "description": "Custom field information.",
+                                                                        "description": "Key-value pairs containing attachment custom information.",
                                                                         "nullable": true
                                                                     }
                                                                 }

--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -4300,21 +4300,21 @@
                                                         "items": {
                                                             "type": "object",
                                                             "description": "Information about a given attachment.",
-                                                            "nullable": true,
+                                                            "nullable": false,
                                                             "properties": {
                                                                 "name": {
                                                                     "type": "string",
                                                                     "description": "Attachment name.",
-                                                                    "nullable": true
+                                                                    "nullable": false
                                                                 },
                                                                 "content": {
                                                                     "type": "object",
                                                                     "description": "Custom field for the attachment content.",
-                                                                    "nullable": true,
+                                                                    "nullable": false,
                                                                     "additionalProperties": {
                                                                         "type": "string",
                                                                         "description": "Key-value pairs containing attachment custom information.",
-                                                                        "nullable": true
+                                                                        "nullable": false
                                                                     }
                                                                 }
                                                             }

--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -3771,6 +3771,7 @@
                                             "name": {
                                                 "type": "string",
                                                 "description": "Attachment name.",
+                                                "example": "null",
                                                 "nullable": false
                                             },
                                             "content": {

--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -3759,6 +3759,31 @@
                                     "description": "[Manual price](https://help.vtex.com/en/tutorial/change-the-price-of-an-item-in-the-shopping-cart--7Cd37aCAmtL1qmoZJJvjNf).",
                                     "example": 400.0,
                                     "nullable": true
+                                },
+                                "attachments": {
+                                    "type": "array",
+                                    "description": "Information about subscription [attachments](https://help.vtex.com/en/tutorial/what-is-an-attachment--aGICk0RVbqKg6GYmQcWUm).",
+                                    "nullable": true,
+                                    "items": {
+                                        "type": "object",
+                                        "description": "Information about a given attachment.",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Attachment name.",
+                                                "nullable": true
+                                            },
+                                            "content": {
+                                                "type": "object",
+                                                "description": "Custom field for attachment content.",
+                                                "nullable": true,
+                                                "additionalProperties": {
+                                                    "type": "string",
+                                                    "description": "Custom field information."
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -3771,15 +3771,16 @@
                                             "name": {
                                                 "type": "string",
                                                 "description": "Attachment name.",
-                                                "nullable": true
+                                                "nullable": false
                                             },
                                             "content": {
                                                 "type": "object",
                                                 "description": "Custom field for attachment content.",
-                                                "nullable": true,
+                                                "nullable": false,
                                                 "additionalProperties": {
                                                     "type": "string",
-                                                    "description": "Custom field information."
+                                                    "description": "Custom field information.",
+                                                    "nullable": false
                                                 }
                                             }
                                         }

--- a/VTEX - Subscriptions API v3.json
+++ b/VTEX - Subscriptions API v3.json
@@ -4300,21 +4300,21 @@
                                                         "items": {
                                                             "type": "object",
                                                             "description": "Information about a given attachment.",
-                                                            "nullable": false,
+                                                            "nullable": true,
                                                             "properties": {
                                                                 "name": {
                                                                     "type": "string",
-                                                                    "description": "Attachment name.",
-                                                                    "nullable": false
+                                                                    "description": "Gift attachment name.",
+                                                                    "nullable": true
                                                                 },
                                                                 "content": {
                                                                     "type": "object",
-                                                                    "description": "Custom field for the attachment content.",
-                                                                    "nullable": false,
+                                                                    "description": "Custom field for the gift attachment content.",
+                                                                    "nullable": true,
                                                                     "additionalProperties": {
                                                                         "type": "string",
-                                                                        "description": "Key-value pairs containing attachment custom information.",
-                                                                        "nullable": false
+                                                                        "description": "Custom field information.",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             }


### PR DESCRIPTION
Add `attachments`, `name` and `content` fields to [Create subscription](https://developers.vtex.com/docs/api-reference/subscriptions-api-v3#post-/api/rns/pub/subscriptions) endpoint. Refers to [EDU-13895](https://vtex-dev.atlassian.net/browse/EDU-13895).

#### Types of changes
- [ ] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] No, but I am going to.
