### PR TITLE
fix: narrow tags-should-be-in-sentence-case Spectral rule to avoid false positives

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -147,7 +147,9 @@ rules:
   tags-should-be-in-sentence-case:
     description: All tags should use sentence case (capitalize only the first letter). Exceptions include product names and specific terms (e.g., VTEX, SKU, ID, API, Session Manager). To add exceptions, edit the regex pattern in the 'match' field.
     severity: error
-    given: "$..tags[*]"
+    given:
+      - "$.tags[*].name"
+      - "$.paths.*.*.tags[*]"
     then:
       function: pattern
       functionOptions:


### PR DESCRIPTION
Fixes false positives in the `tags-should-be-in-sentence-case` Spectral rule that were triggered by response body schema properties named `tags`.

## Changes

- Replaced the broad recursive JSONPath `$..tags[*]` with two specific paths:
  - `$.tags[*].name` — targets root-level OpenAPI tag definitions
  - `$.paths.*.*.tags[*]` — targets operation-level tag references
- This prevents the rule from matching schema properties named `tags` in response bodies

## Why

The recursive descent operator (`$..`) matched ANY property named `tags` anywhere in the document, including response body schema properties that describe an API's `tags` field. This caused false positive errors during portal builds (e.g., in the Custom Fields API schema).
