### PR TITLE
fix: use singular example format in Custom Fields API search response

### DIFF
--- a/PostmanCollections/VTEX - Custom Fields API.json
+++ b/PostmanCollections/VTEX - Custom Fields API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "9ecd6f9a-952a-42f7-b646-28051c2e1ab7"
+    "postman_id": "3f2be1c8-096b-4d1e-8b12-42cb4d58a630"
   },
   "item": [
     {
-      "id": "afdf9041-08cc-44fb-a897-baef564208ed",
+      "id": "709b8494-5884-4273-8ef4-a27ed6f5b5ea",
       "name": "Custom field settings",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "90950d1e-a208-4d84-90f1-af3932e434b5",
+          "id": "eb17ade0-c27f-49d8-90ec-34cae627975a",
           "name": "Get custom field settings",
           "request": {
             "name": "Get custom field settings",
@@ -93,7 +93,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d234a295-5af2-41e9-a821-46e11f0904a7",
+              "id": "bc462cc3-eb02-4aa7-ab22-2c434f3cc1d3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -188,7 +188,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1c36f845-fdff-47b3-84d2-67a66dbcb5fa",
+                "id": "e6515998-d6df-4d7b-b6d8-f8cec581a8bc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldSettings/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -204,7 +204,7 @@
           }
         },
         {
-          "id": "e050df44-d718-4667-9b1b-15b0534edab6",
+          "id": "42df9cf8-38cd-45a9-b95b-f3186a914ff2",
           "name": "Create custom field settings",
           "request": {
             "name": "Create custom field settings",
@@ -280,7 +280,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "36155a99-ffcf-4811-bbb7-f017d768cc38",
+              "id": "940f81a9-81ea-4bd4-8269-4fa7f60f3d2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -370,7 +370,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0821020d-c97a-4d2f-99a4-3d156d1f320f",
+                "id": "c0ea42ca-c802-43a6-b65d-e74493dc20b3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/customFieldSettings/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -386,7 +386,7 @@
           }
         },
         {
-          "id": "2b777063-b21e-4a7b-8a46-2a8775679732",
+          "id": "ca41775e-7da8-4a63-b185-1541cd8029bd",
           "name": "Update custom field settings",
           "request": {
             "name": "Update custom field settings",
@@ -474,7 +474,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d7fc15fc-970f-4707-8863-57661a65b6a5",
+              "id": "55ee528d-442d-42e1-ba1a-089880792a1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -565,7 +565,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "faaeb825-91bb-499e-bf2d-841e3c1708c6",
+                "id": "d54eaa96-05a8-472c-bc34-44b4f8298177",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/customFieldSettings/documents/:documentId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -581,7 +581,7 @@
           }
         },
         {
-          "id": "4c875eb2-a1fd-4548-a3c2-c33d6ba2a99c",
+          "id": "654ec02d-8a41-4942-b104-cfb412c594e6",
           "name": "Delete custom field setting",
           "request": {
             "name": "Delete custom field setting",
@@ -643,7 +643,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4a85f4aa-6447-4512-bcf4-2593997ad212",
+              "id": "a940c7f2-5a53-4a81-a07b-6fef2a1ca64e",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -702,7 +702,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f53efcec-1495-463b-95bf-5381a2c9fe9a",
+                "id": "1b17af6e-e2de-4dcf-b014-0488ef117e24",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/customFieldSettings/documents/:documentId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -719,7 +719,7 @@
       "event": []
     },
     {
-      "id": "1f9bf82b-d4bf-47f6-b956-580b540a845d",
+      "id": "1c4a59ef-08fa-48aa-96a9-24364a810cf0",
       "name": "Custom field values",
       "description": {
         "content": "",
@@ -727,7 +727,7 @@
       },
       "item": [
         {
-          "id": "4c484853-057e-4fca-85cd-0706f41ac749",
+          "id": "33c1fd01-1ff1-44c9-89dd-46735f204d1c",
           "name": "Create custom field value",
           "request": {
             "name": "Create custom field value",
@@ -803,7 +803,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "06eb32eb-4715-4e30-b63c-e58ccfddd051",
+              "id": "38e7557c-b20b-4197-aa91-914b66a9f916",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -893,7 +893,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c6807200-9afd-491a-a2bc-b170cfabe501",
+                "id": "9aaa9170-502f-4eb4-8294-2b251f08da20",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/customFieldValues/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -909,7 +909,7 @@
           }
         },
         {
-          "id": "4f75dba5-277e-4b0b-a868-a638723c70e6",
+          "id": "41848543-8c9f-4bb4-9f25-eed964f57518",
           "name": "Get custom field value",
           "request": {
             "name": "Get custom field value",
@@ -984,7 +984,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5366fbcb-73d7-4b28-8bf5-767102355e5f",
+              "id": "3d307db3-8a29-4b9e-bd96-3af58f60bb4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1062,7 +1062,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2d6c40d7-e298-48bc-8a92-352d50b777e4",
+                "id": "8efd5f1f-67a7-4136-b1f4-47bfe1199ac1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldValues/documents/:customFieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1078,7 +1078,7 @@
           }
         },
         {
-          "id": "0ca105d1-40a1-4a14-8123-e45275c71802",
+          "id": "3390530c-65d8-41e8-88e7-5c75c7cd693e",
           "name": "Update custom field value",
           "request": {
             "name": "Update custom field value",
@@ -1162,7 +1162,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "72b58f86-0606-49bc-bd22-5e498e5caa76",
+              "id": "675752e6-3c3a-4716-89e2-42b9c77574a3",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "de99b320-1ba5-4222-b28f-1411c211c454",
+                "id": "358e8a71-b18c-4712-96a5-f65729c980f4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/customFieldValues/documents/:customFieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1257,7 +1257,7 @@
           }
         },
         {
-          "id": "9b3949f0-6d56-4635-9ed4-5c4aaf1167a1",
+          "id": "faac1264-3e13-4bcd-b8b5-f0061a22f8c1",
           "name": "Delete custom field value",
           "request": {
             "name": "Delete custom field value",
@@ -1328,7 +1328,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "375bf54c-033e-40ac-b975-55e596d19918",
+              "id": "b630a557-1e64-4847-9877-31c4a3cdd12f",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -1396,7 +1396,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "abfc66ff-33c1-4569-a954-db5c56e16c86",
+                "id": "e575ea82-3a88-483a-91b2-b0a4e2924d29",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/customFieldValues/documents/:customFieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1410,7 +1410,7 @@
           }
         },
         {
-          "id": "01109ba0-e178-423e-a7bd-147bf519c5e2",
+          "id": "6b966d47-7cc9-46cd-b458-ac93ee3eb068",
           "name": "Search custom field values",
           "request": {
             "name": "Search custom field values",
@@ -1491,8 +1491,8 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f4d97987-0ded-4d13-9555-086f1303f5a8",
-              "name": "Search all values for a custom field",
+              "id": "69f059f2-3761-4d1d-b2b8-405251eb2f8b",
+              "name": "OK",
               "originalRequest": {
                 "url": {
                   "path": [
@@ -1580,107 +1580,13 @@
               ],
               "body": "[\n  {\n    \"id\": \"e5130781-32ed-11f0-b37f-942217c27f9b\",\n    \"contractId\": \"1124b2d8-32eb-11f0-b37f-e2557e6b18d5\",\n    \"customFieldId\": \"a7f2b3d4-5c6e-7f89-0123-456789abcdef\",\n    \"auxId\": null,\n    \"value\": \"CC1\",\n    \"description\": \"Cost Center 1\"\n  },\n  {\n    \"id\": \"f6240892-43fe-22f1-c48a-053328d28f0c\",\n    \"contractId\": \"1124b2d8-32eb-11f0-b37f-e2557e6b18d5\",\n    \"customFieldId\": \"a7f2b3d4-5c6e-7f89-0123-456789abcdef\",\n    \"auxId\": null,\n    \"value\": \"CC2\",\n    \"description\": \"Cost Center 2\"\n  },\n  {\n    \"id\": \"a7351903-54ff-33f2-d59b-164439e39g1d\",\n    \"contractId\": \"1124b2d8-32eb-11f0-b37f-e2557e6b18d5\",\n    \"customFieldId\": \"a7f2b3d4-5c6e-7f89-0123-456789abcdef\",\n    \"auxId\": null,\n    \"value\": \"CC3\",\n    \"description\": \"Cost Center 3\"\n  }\n]",
               "cookie": []
-            },
-            {
-              "_": {
-                "postman_previewlanguage": "json"
-              },
-              "id": "16d8c302-80bb-4ea0-90ee-e1e813dada47",
-              "name": "Get a specific value",
-              "originalRequest": {
-                "url": {
-                  "path": [
-                    "api",
-                    "dataentities",
-                    "customFieldValues",
-                    "search"
-                  ],
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "query": [
-                    {
-                      "disabled": false,
-                      "description": {
-                        "content": "(Required) Schema version to use for the request. This query string defines which schema version to apply when retrieving data. Learn more about [Master Data schemas](https://developers.vtex.com/docs/guides/master-data-schema-lifecycle).",
-                        "type": "text/plain"
-                      },
-                      "key": "_schema",
-                      "value": "v2"
-                    },
-                    {
-                      "disabled": false,
-                      "description": {
-                        "content": "(Required) Comma-separated list of field names to be returned in the response. Use `_all` to return all fields, or specify individual fields like `id,contractId,value`. Learn more about [searching documents in Master Data v2](https://developers.vtex.com/docs/guides/search-documents-in-master-data).",
-                        "type": "text/plain"
-                      },
-                      "key": "_fields",
-                      "value": "_all"
-                    },
-                    {
-                      "disabled": false,
-                      "description": {
-                        "content": "(Required) Filter expression to search documents using Master Data v2 query syntax. You can combine multiple conditions using `AND`. Examples:\n- Get all values for a contract: `contractId={{contractId}}`\n- Filter by contract and custom field: `contractId={{contractId}} AND customFieldId=\"{{customFieldId}}\"`\n- Filter by specific value: `contractId={{contractId}} AND customFieldId=\"{{customFieldId}}\" AND value=\"{{value}}\"`\n\nLearn more about [searching documents in Master Data v2](https://developers.vtex.com/docs/guides/search-documents-in-master-data).",
-                        "type": "text/plain"
-                      },
-                      "key": "_where",
-                      "value": "contractId={{contractId}} AND customFieldId=\"{{customFieldId}}\""
-                    },
-                    {
-                      "disabled": true,
-                      "description": {
-                        "content": "Defines the field and order for sorting results. Use the pattern `{fieldName} {ASC|DESC}`. For example, `value ASC` sorts results by the `value` field in ascending order. Learn more about [searching documents in Master Data v2](https://developers.vtex.com/docs/guides/search-documents-in-master-data).",
-                        "type": "text/plain"
-                      },
-                      "key": "_sort",
-                      "value": "value ASC"
-                    }
-                  ],
-                  "variable": []
-                },
-                "header": [
-                  {
-                    "disabled": false,
-                    "description": {
-                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
-                      "type": "text/plain"
-                    },
-                    "key": "Accept",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  },
-                  {
-                    "description": {
-                      "content": "Added as a part of security scheme: apikey",
-                      "type": "text/plain"
-                    },
-                    "key": "VtexIdclientAutCookie",
-                    "value": "<API Key>"
-                  }
-                ],
-                "method": "GET",
-                "body": {}
-              },
-              "status": "OK",
-              "code": 200,
-              "header": [
-                {
-                  "key": "Content-Type",
-                  "value": "application/json"
-                }
-              ],
-              "body": "[\n  {\n    \"id\": \"e5130781-32ed-11f0-b37f-942217c27f9b\",\n    \"contractId\": \"1124b2d8-32eb-11f0-b37f-e2557e6b18d5\",\n    \"customFieldId\": \"a7f2b3d4-5c6e-7f89-0123-456789abcdef\",\n    \"auxId\": null,\n    \"value\": \"CC3\",\n    \"description\": \"Cost Center 3\"\n  }\n]",
-              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "897bdff0-0a2b-436a-aaf9-6c66216fb102",
+                "id": "093b77e4-ff33-4d0a-a0a1-460806a63c22",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldValues/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1738,7 +1644,7 @@
     }
   ],
   "info": {
-    "_postman_id": "9ecd6f9a-952a-42f7-b646-28051c2e1ab7",
+    "_postman_id": "3f2be1c8-096b-4d1e-8b12-42cb4d58a630",
     "name": "Custom Fields API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/VTEX - Custom Fields API.json
+++ b/VTEX - Custom Fields API.json
@@ -960,52 +960,32 @@
                                         }
                                     }
                                 },
-                                "examples": {
-                                    "allValues": {
-                                        "summary": "Search all values for a custom field",
-                                        "description": "Returns all values for a specific custom field, sorted by value. Use `_where=contractId={{contractId}} AND customFieldId=\"{{customFieldId}}\"` with `_sort=value ASC`.",
-                                        "value": [
-                                            {
-                                                "id": "e5130781-32ed-11f0-b37f-942217c27f9b",
-                                                "contractId": "1124b2d8-32eb-11f0-b37f-e2557e6b18d5",
-                                                "customFieldId": "a7f2b3d4-5c6e-7f89-0123-456789abcdef",
-                                                "auxId": null,
-                                                "value": "CC1",
-                                                "description": "Cost Center 1"
-                                            },
-                                            {
-                                                "id": "f6240892-43fe-22f1-c48a-053328d28f0c",
-                                                "contractId": "1124b2d8-32eb-11f0-b37f-e2557e6b18d5",
-                                                "customFieldId": "a7f2b3d4-5c6e-7f89-0123-456789abcdef",
-                                                "auxId": null,
-                                                "value": "CC2",
-                                                "description": "Cost Center 2"
-                                            },
-                                            {
-                                                "id": "a7351903-54ff-33f2-d59b-164439e39g1d",
-                                                "contractId": "1124b2d8-32eb-11f0-b37f-e2557e6b18d5",
-                                                "customFieldId": "a7f2b3d4-5c6e-7f89-0123-456789abcdef",
-                                                "auxId": null,
-                                                "value": "CC3",
-                                                "description": "Cost Center 3"
-                                            }
-                                        ]
+                                "example": [
+                                    {
+                                        "id": "e5130781-32ed-11f0-b37f-942217c27f9b",
+                                        "contractId": "1124b2d8-32eb-11f0-b37f-e2557e6b18d5",
+                                        "customFieldId": "a7f2b3d4-5c6e-7f89-0123-456789abcdef",
+                                        "auxId": null,
+                                        "value": "CC1",
+                                        "description": "Cost Center 1"
                                     },
-                                    "specificValue": {
-                                        "summary": "Get a specific value",
-                                        "description": "Returns a specific custom field value. Use `_where=contractId={{contractId}} AND customFieldId=\"{{customFieldId}}\" AND value=\"{{value}}\"`.",
-                                        "value": [
-                                            {
-                                                "id": "e5130781-32ed-11f0-b37f-942217c27f9b",
-                                                "contractId": "1124b2d8-32eb-11f0-b37f-e2557e6b18d5",
-                                                "customFieldId": "a7f2b3d4-5c6e-7f89-0123-456789abcdef",
-                                                "auxId": null,
-                                                "value": "CC3",
-                                                "description": "Cost Center 3"
-                                            }
-                                        ]
+                                    {
+                                        "id": "f6240892-43fe-22f1-c48a-053328d28f0c",
+                                        "contractId": "1124b2d8-32eb-11f0-b37f-e2557e6b18d5",
+                                        "customFieldId": "a7f2b3d4-5c6e-7f89-0123-456789abcdef",
+                                        "auxId": null,
+                                        "value": "CC2",
+                                        "description": "Cost Center 2"
+                                    },
+                                    {
+                                        "id": "a7351903-54ff-33f2-d59b-164439e39g1d",
+                                        "contractId": "1124b2d8-32eb-11f0-b37f-e2557e6b18d5",
+                                        "customFieldId": "a7f2b3d4-5c6e-7f89-0123-456789abcdef",
+                                        "auxId": null,
+                                        "value": "CC3",
+                                        "description": "Cost Center 3"
                                     }
-                                }
+                                ]
                             }
                         }
                     }


### PR DESCRIPTION
Fixes the Search custom field values endpoint response example format to comply with the `must-include-response-examples` Spectral rule.

## Changes

- Converted the response from `examples` (plural, named examples) to `example` (singular) on the Search custom field values endpoint
- Used the multi-value example as the representative response

## Why

The Spectral rule `must-include-response-examples` checks for the singular `example` field. Using the plural `examples` format caused a linting error that was flagged during portal builds.
