### PR TITLE
Update Spectral rules to support B2B terminology and fix schema property matching

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -58,7 +58,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^[A-Z](?:[a-z0-9 ]*(?:VTEX|TEX|DO|ID|EAN|URL|JSON|)|(|OAuth|Customer Credit|CMS|appKey|appToken|autoApprove|-|,|API|DKIM|SKU|SLA|Change order|'))*[a-z0-9 ]*$"
+        match: "^[A-Z](?:[a-z0-9 ]*(?:VTEX|TEX|DO|ID|EAN|URL|JSON|B2B|)|(|OAuth|Customer Credit|CMS|appKey|appToken|autoApprove|-|,|API|DKIM|SKU|SLA|Change order|'))*[a-z0-9 ]*$"
 
   no-empty-descriptions:
     description: No empty descriptions allowed. Make sure that this description is a valid string that does not start with a line break (\n or \r). If this description is inside an example, please fill it with a valid value.
@@ -147,11 +147,11 @@ rules:
   tags-should-be-in-sentence-case:
     description: All tags should use sentence case (capitalize only the first letter). Exceptions include product names and specific terms (e.g., VTEX, SKU, ID, API, Session Manager). To add exceptions, edit the regex pattern in the 'match' field.
     severity: error
-    given: "$..tags[*]"
+    given: "$.paths.*.*.tags[*]"
     then:
       function: pattern
       functionOptions:
-        match: "^(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|[A-Z][a-z0-9]*(?:-[a-z][a-z0-9]*)*)(?:\\s+(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*))*$"
+        match: "^(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|B2B|[A-Z][a-z0-9]*(?:-[a-z][a-z0-9]*)*)(?:\\s+(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|B2B|[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*))*$"
 
   request-example-parallel-to-schema:
     description: The example for request body must be at the same level as the schema (as siblings), not nested inside schema properties. Place the example at the content-type level alongside the schema.


### PR DESCRIPTION
Update Spectral linting rules to support B2B terminology.
