### PR TITLE
ci: fix Convert to Postman by pinning portman and co-installing tslib

### DIFF
--- a/.github/workflows/portman.yml
+++ b/.github/workflows/portman.yml
@@ -33,7 +33,7 @@ jobs:
           IFS=","
           for file in $FILES; do
             echo "Processing $file"
-            npx @apideck/portman -l "$file" -o "./PostmanCollections/$file"
+            npx -y -p tslib -p @apideck/portman@1.34.0 portman -l "$file" -o "./PostmanCollections/$file"
           done
 
       - name: Configure Git


### PR DESCRIPTION
## Summary

The `Convert to Postman` workflow has been failing on every PR since ~Apr 23 with:

```
Error: Cannot find module 'tslib'
  at Object.<anonymous> (.../node_modules/@apideck/portman/dist/index.js:3:15)
code: 'MODULE_NOT_FOUND'
```

(see [failing run on #1637](https://github.com/vtex/openapi-schemas/actions/runs/24912385865/job/72956812689))

### Root cause

The job runs `npx @apideck/portman` with no lockfile, so npm resolves portman's full dependency tree fresh on every run. Comparing a passing run (Apr 8) to the failing runs (Apr 23 onward) shows the transitive dep tree changed:

| Deprecation warning | Apr 8 (passed) | Apr 23+ (failed) |
|---|---|---|
| `uuid@3.4.0` | yes | yes |
| `har-validator@5.1.5` | — | yes |
| `inflight@1.0.6` | — | yes |
| `glob@7.2.3` | — | yes |
| `@faker-js/faker@5.5.3` | — | yes |

Same Node (18.20.8), same `@apideck/portman@1.34.0`, but a different sub-dep graph. In the new graph `tslib` is no longer hoisted to a location where `@apideck/portman/dist/index.js` can `require('tslib')`, so Node throws before any OpenAPI JSON is touched.

### Fix

```diff
- npx @apideck/portman -l "$file" -o "./PostmanCollections/$file"
+ npx -y -p tslib -p @apideck/portman@1.34.0 portman -l "$file" -o "./PostmanCollections/$file"
```

- `-p tslib` co-installs `tslib` into the same npx tree portman resolves from, fixing the `require('tslib')` failure regardless of how npm hoists portman's other deps.
- `-p @apideck/portman@1.34.0` pins to the version `npx` was already implicitly installing, so future portman releases can't silently change behavior again.
- `-y` suppresses the npx install prompt that can occasionally hang in CI.

Smallest possible diff (one line) and directly targets the actual failure mode. A more robust long-term fix would be a committed `package.json` + lockfile, but that's overkill for a single tool invocation.

## Test plan

- [ ] Merge and confirm `Convert to Postman` succeeds on the next PR opened against `master`.
- [ ] Verify the generated `PostmanCollections/*.json` is committed back to the PR branch as before.