### PR TITLE
new: add name, category, and url optional fields to product view event

### DIFF
--- a/PostmanCollections/VTEX - Recommendations BFF API.json
+++ b/PostmanCollections/VTEX - Recommendations BFF API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "d925c38e-0ecd-4bfc-ad48-4276e1968139"
+    "postman_id": "67f0ea03-8f5a-44e4-a6b1-a636f5950f90"
   },
   "item": [
     {
-      "id": "acb7eabb-04d7-4092-b081-1b9f5f1393ec",
+      "id": "be9a6a40-bc2f-4a78-ade9-de765b0ba3c8",
       "name": "Events",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "1cb80883-c32e-4752-9f0b-c7caf605f5e3",
+          "id": "45401f52-b7b7-4df1-8696-2586efc7496f",
           "name": "Recommendation view",
           "request": {
             "name": "Recommendation view",
@@ -76,7 +76,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4b73e396-221f-4d88-ba09-daa69031b93d",
+              "id": "7c8b240b-60ff-4340-b66f-648b96d481a2",
               "name": "Accepted\n\nEvent queued for processing.",
               "originalRequest": {
                 "url": {
@@ -139,7 +139,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "32067294-4e39-4de8-b66e-af38ad6adf6d",
+              "id": "81b4da4d-9652-4761-9879-7c1eac8b402a",
               "name": "Bad Request\n\nInvalid payload or missing fields.",
               "originalRequest": {
                 "url": {
@@ -202,7 +202,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "78dfe8bd-332b-4a74-bd6d-963153505e42",
+              "id": "a40f93c8-31a8-4f15-a749-e7ea43ea0ddf",
               "name": "Unauthorized\n\nMissing or invalid credentials.",
               "originalRequest": {
                 "url": {
@@ -265,7 +265,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "499068bf-e123-4ed7-a32f-c16235eb65e2",
+              "id": "ada4b086-54ca-425b-9c4f-152a70e6bba9",
               "name": "Forbidden\n\nRequest origin not allowed.",
               "originalRequest": {
                 "url": {
@@ -328,7 +328,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fafac001-58ff-4cb0-870b-4e86bccd5232",
+              "id": "9fbd983a-6279-4050-a010-b0e4628cea70",
               "name": "Not Found\n\nReferenced resources were not found.",
               "originalRequest": {
                 "url": {
@@ -391,7 +391,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b1c99ce5-3cc1-46dd-af28-6287eae3214d",
+              "id": "c4572932-9c0e-48f5-9ddb-bf6b0fc608a8",
               "name": "Unprocessable Entity\n\nValidation failed.",
               "originalRequest": {
                 "url": {
@@ -454,7 +454,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4f85cfa6-2979-44d9-930a-bfc34d93411b",
+              "id": "f926b981-93c5-4c7f-9499-42df294e65b8",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -517,7 +517,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "67d96069-ce13-44da-9352-1c5963d76c1e",
+              "id": "229520e4-0b43-4403-8f1c-b0b9a50aeee5",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -581,7 +581,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cf68eb70-65ed-44d2-8b0a-04503ef00e5f",
+                "id": "e5e46fcc-9cf2-4240-9b42-84093d08e2fa",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/recommend-bff/v2/events/recommendation-view - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -594,7 +594,7 @@
           }
         },
         {
-          "id": "716e1394-7466-4dee-9102-669e6be53896",
+          "id": "fb1695ce-444b-47b1-a8ac-1e1648a53ea2",
           "name": "Recommendation click",
           "request": {
             "name": "Recommendation click",
@@ -658,7 +658,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9712b799-fec7-4b66-a518-c7b0400803b6",
+              "id": "70148c2c-6917-4073-8956-dfc4f39163ea",
               "name": "Accepted\n\nEvent queued for processing.",
               "originalRequest": {
                 "url": {
@@ -721,7 +721,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ca23d472-0e69-4cc4-8a28-656a24f1b6c1",
+              "id": "c67d782c-8818-4069-af9a-c1792f1ce34f",
               "name": "Bad Request\n\nInvalid payload or missing fields.",
               "originalRequest": {
                 "url": {
@@ -784,7 +784,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ba413556-281c-45d8-b5e0-b12a6e93f1bc",
+              "id": "d0f82f4c-e513-42b0-86d0-3c680fce2023",
               "name": "Unauthorized\n\nMissing or invalid credentials.",
               "originalRequest": {
                 "url": {
@@ -847,7 +847,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c1b9ce69-fa09-4535-b9b8-2d307565628a",
+              "id": "41a1d566-a02a-4c41-a99a-3da4a0c8acfe",
               "name": "Forbidden\n\nRequest origin not allowed.",
               "originalRequest": {
                 "url": {
@@ -910,7 +910,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "519eaa28-debb-48dc-834b-8489a1d6f85a",
+              "id": "d1d7eadd-2198-4a72-819f-fad0f1827937",
               "name": "Not Found\n\nReferenced resources were not found.",
               "originalRequest": {
                 "url": {
@@ -973,7 +973,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4f418217-a73a-4a6e-8bb4-0843fd836531",
+              "id": "90b53fea-6b10-428e-99a3-b9d47ebb4a5b",
               "name": "Unprocessable Entity\n\nValidation failed.",
               "originalRequest": {
                 "url": {
@@ -1036,7 +1036,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "131bda90-6542-4162-827d-e270ebdd4386",
+              "id": "7d8c4d29-ba3c-4637-a9cf-0bbc70d2acf1",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -1099,7 +1099,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a6313509-a2b1-485e-bb30-a9ed70c6a60c",
+              "id": "4738d676-01be-4e9d-bad1-5fc8a4980212",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -1163,7 +1163,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8bd46a60-5c4f-43a7-8b1f-854a86e556a5",
+                "id": "5517905f-5cb0-448a-a234-ab53b44bc303",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/recommend-bff/v2/events/recommendation-click - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1176,7 +1176,7 @@
           }
         },
         {
-          "id": "3ad52504-da94-46da-9bf6-a2de89dcce5f",
+          "id": "d8f66033-ef32-43d0-b15a-0f6742fae900",
           "name": "Product view",
           "request": {
             "name": "Product view",
@@ -1235,7 +1235,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+              "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -1249,7 +1249,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7caabc89-fc3d-4a5d-a21c-c7ca71ce9c1c",
+              "id": "cf7003d5-b0f8-40a4-aac8-6fccae15e6d1",
               "name": "Accepted\n\nEvent queued for processing.",
               "originalRequest": {
                 "url": {
@@ -1303,7 +1303,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1321,7 +1321,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "15898520-e95f-42f2-a01b-580fc510d27f",
+              "id": "cdb26e95-a25f-4b2c-b3d4-78db183d4384",
               "name": "Bad Request\n\nInvalid payload or missing fields.",
               "originalRequest": {
                 "url": {
@@ -1375,7 +1375,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1393,7 +1393,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0c46c1aa-fefd-4486-ba80-78f352e7d75b",
+              "id": "11464b1b-2a5a-4879-82cb-81270da18047",
               "name": "Unauthorized\n\nMissing or invalid credentials.",
               "originalRequest": {
                 "url": {
@@ -1447,7 +1447,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1465,7 +1465,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9d0f44cf-6a8a-4d50-9102-04465f3cfceb",
+              "id": "1a810a3a-83bc-4882-a39a-14839b16b271",
               "name": "Forbidden\n\nRequest origin not allowed.",
               "originalRequest": {
                 "url": {
@@ -1519,7 +1519,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1537,7 +1537,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7d48b505-864c-427d-8e8d-56d506842ada",
+              "id": "ccf7ab08-2bd0-463e-9352-aa76c84261db",
               "name": "Not Found\n\nReferenced resources were not found.",
               "originalRequest": {
                 "url": {
@@ -1591,7 +1591,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1609,7 +1609,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "39b0f808-33bc-486a-9d2d-d4d328c00cd7",
+              "id": "3f98cf17-f19d-42ce-8792-b6218f34b9d1",
               "name": "Unprocessable Entity\n\nValidation failed.",
               "originalRequest": {
                 "url": {
@@ -1663,7 +1663,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1681,7 +1681,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ce78f509-54c2-4ded-b4ae-72bfcb6c69af",
+              "id": "f3f9a4b4-9699-4d03-8344-bdcf547b67ce",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -1735,7 +1735,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1753,7 +1753,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a396b80f-ed36-4610-ad98-c2b70210ccdb",
+              "id": "21dd19b0-f355-4b50-8c46-0a8938011936",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -1807,7 +1807,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"userId\": \"198e0f50-acf8-42f7-998a-5cd125464749\",\n  \"product\": \"14\",\n  \"source\": \"WEB_DESKTOP\"\n}",
+                  "raw": "{\n  \"userId\": \"550e8400-e29b-41d4-a716-446655440000\",\n  \"product\": \"2000026\",\n  \"source\": \"WEB_DESKTOP\",\n  \"name\": \"Coca-Cola Lata 350ml\",\n  \"category\": \"Bebidas/Refrigerantes\",\n  \"url\": \"https://loja.com.br/coca-cola-lata-350ml/p\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -1826,7 +1826,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c10d54b1-f563-4100-854a-f4369aa73e57",
+                "id": "2e1ac35d-604c-46c8-bafc-2b72a3658632",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/recommend-bff/v2/events/product-view - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1842,7 +1842,7 @@
       "event": []
     },
     {
-      "id": "293fb2d1-4da3-4125-8378-dc44cd4a6f92",
+      "id": "94aab6e0-eff8-4611-b529-4f27fde53b9a",
       "name": "Recommendations",
       "description": {
         "content": "",
@@ -1850,7 +1850,7 @@
       },
       "item": [
         {
-          "id": "7c459a98-7513-41a9-9b91-bae3b9269dd8",
+          "id": "fbca094d-ed54-4c34-8848-425a3188afec",
           "name": "Fetch recommendations",
           "request": {
             "name": "Fetch recommendations",
@@ -1976,7 +1976,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d921afbc-103b-49b8-b8a6-cfbf1924a1e5",
+              "id": "22f14c6b-42d3-4971-87a2-7ecc9b8702de",
               "name": "OK\n\nSuccessfully fetched recommendations.",
               "originalRequest": {
                 "url": {
@@ -2107,7 +2107,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "af4fbeb6-5ea9-46a8-8701-bf03064eb0f2",
+              "id": "7064807c-f414-4033-b067-f67b38a206fc",
               "name": "Bad Request\n\nInvalid or conflicting parameters.",
               "originalRequest": {
                 "url": {
@@ -2228,7 +2228,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "830b7d2e-36d6-4431-84c6-3499bfe112bc",
+              "id": "7c292016-821d-4509-addd-f1f568bfa61d",
               "name": "Unauthorized\n\nMissing or invalid credentials.",
               "originalRequest": {
                 "url": {
@@ -2349,7 +2349,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e904ffb8-1987-4ba1-8e75-affd4622a84c",
+              "id": "ac2f3487-1fd7-402e-8e59-f4a8d16704e1",
               "name": "Forbidden\n\nRequest origin not allowed.",
               "originalRequest": {
                 "url": {
@@ -2470,7 +2470,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fdac8320-c7ff-4880-b159-513a65d03e1e",
+              "id": "fe4bd84e-79a4-4b8a-89f8-81d61b6024df",
               "name": "Not Found\n\nCampaign not found or unavailable.",
               "originalRequest": {
                 "url": {
@@ -2591,7 +2591,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b5c44337-ff8b-40a5-80d3-26e8a881b863",
+              "id": "103a871f-2e3f-409f-9dba-9fb584981652",
               "name": "Unprocessable Entity\n\nValidation failed due to an invalid recommendation type.",
               "originalRequest": {
                 "url": {
@@ -2712,7 +2712,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5e91ead3-dd97-4fde-822f-f3b0383224b6",
+              "id": "19d9bb6b-424a-431f-907c-f4b39d28b300",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -2833,7 +2833,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "62f925a5-043e-4b29-ab54-79d3b26aeb17",
+              "id": "0ba020aa-213b-47aa-8730-24b6e67f5639",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -2955,7 +2955,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "db8beff0-2292-4af9-b0c4-821fdc8a2d88",
+                "id": "2fd643e3-9d5a-4e1d-ad1d-82b072093fe9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/recommend-bff/v2/recommendations - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2974,7 +2974,7 @@
       "event": []
     },
     {
-      "id": "ff934267-0618-4e0f-ad83-ec838f6f4337",
+      "id": "5431243b-5880-452e-9288-20869b1fefda",
       "name": "Users",
       "description": {
         "content": "",
@@ -2982,7 +2982,7 @@
       },
       "item": [
         {
-          "id": "fc6f1580-1852-43f1-887c-8db481fde5c2",
+          "id": "4c0e3ad0-dec9-4491-9527-e4e1e858819e",
           "name": "Start session",
           "request": {
             "name": "Start session",
@@ -3068,7 +3068,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2625efc9-9dcc-435a-aa85-bef0efdbe90c",
+              "id": "5fbf99e5-15ff-4487-85c3-7a8e89aa1d3d",
               "name": "OK\n\nSession started successfully.",
               "originalRequest": {
                 "url": {
@@ -3159,7 +3159,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "af79cc60-e8b8-4b9e-a7fa-963f83e28c3f",
+              "id": "adf56d9b-37db-4a1f-b085-99d6ffe2526c",
               "name": "Bad Request\n\nInvalid payload or missing fields.",
               "originalRequest": {
                 "url": {
@@ -3240,7 +3240,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "34caf5c4-3301-4aa1-a7d3-c9d13ffff4b3",
+              "id": "34341bf4-b3ce-4be0-bb2c-888265b91556",
               "name": "Unauthorized\n\nMissing or invalid credentials.",
               "originalRequest": {
                 "url": {
@@ -3321,7 +3321,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "70b11400-b983-4457-91be-59cb7ac2848d",
+              "id": "06962cb1-481a-4d87-9702-88e406f9dff6",
               "name": "Forbidden\n\nRequest origin not allowed.",
               "originalRequest": {
                 "url": {
@@ -3402,7 +3402,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "37abc2f0-9027-4cc8-ba10-555278ec363b",
+              "id": "9a56b8ba-9277-41ff-869a-e41fb1800483",
               "name": "Not Found\n\nReferenced resources were not found.",
               "originalRequest": {
                 "url": {
@@ -3483,7 +3483,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8106c4e2-1153-4842-a1ca-ba28acd0fa37",
+              "id": "89997a5b-7e27-4235-9ea4-6293c08da452",
               "name": "Unprocessable Entity\n\nValidation failed.",
               "originalRequest": {
                 "url": {
@@ -3564,7 +3564,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "927cd310-08d6-4cd4-9da0-450f8b1fc5c0",
+              "id": "0654c75d-97f0-4c44-9c25-e103adac3e23",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -3645,7 +3645,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a1af9675-0767-4821-87f8-ee215b595b71",
+              "id": "e27fdec3-1d8a-43ba-a341-618049240590",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -3727,7 +3727,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d89bcc88-bad7-4c60-846c-4e2bc5c6f50e",
+                "id": "264e45d5-c7b2-48a2-8dc4-f4405e3ccd3a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/recommend-bff/v2/users/start-session - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3760,7 +3760,7 @@
     }
   ],
   "info": {
-    "_postman_id": "d925c38e-0ecd-4bfc-ad48-4276e1968139",
+    "_postman_id": "67f0ea03-8f5a-44e4-a6b1-a636f5950f90",
     "name": "Recommendations BFF API",
     "version": {
       "raw": "1.0.0",

--- a/VTEX - Recommendations BFF API.json
+++ b/VTEX - Recommendations BFF API.json
@@ -631,9 +631,9 @@
                                 "userId": "550e8400-e29b-41d4-a716-446655440000",
                                 "product": "2000026",
                                 "source": "WEB_DESKTOP",
-                                "name": "Coca-Cola Lata 350ml",
-                                "category": "Bebidas/Refrigerantes",
-                                "url": "https://loja.com.br/coca-cola-lata-350ml/p"
+                                "name": "Coca-Cola Can 350ml",
+                                "category": "Beverages/Soft Drinks",
+                                "url": "https://mystore.com/coca-cola-can-350ml/p"
                             }
                         }
                     }
@@ -919,17 +919,17 @@
                     "name": {
                         "type": "string",
                         "description": "Display name of the product. Optional. When provided, enriches the product view event with additional product information. We recommend sending it whenever available.",
-                        "example": "Coca-Cola Lata 350ml"
+                        "example": "Coca-Cola Can 350ml"
                     },
                     "category": {
                         "type": "string",
                         "description": "Category of the product. Optional. When provided, enriches the product view event with additional product information. We recommend sending it whenever available.",
-                        "example": "Bebidas/Refrigerantes"
+                        "example": "Beverages/Soft Drinks"
                     },
                     "url": {
                         "type": "string",
                         "description": "URL of the product page. Optional. When provided, enriches the product view event with additional product information. We recommend sending it whenever available.",
-                        "example": "https://loja.com.br/coca-cola-lata-350ml/p"
+                        "example": "https://mystore.com/coca-cola-can-350ml/p"
                     }
                 },
                 "required": [

--- a/VTEX - Recommendations BFF API.json
+++ b/VTEX - Recommendations BFF API.json
@@ -628,9 +628,12 @@
                                 "$ref": "#/components/schemas/ProductViewEventV2Request"
                             },
                             "example": {
-                                "userId": "198e0f50-acf8-42f7-998a-5cd125464749",
-                                "product": "14",
-                                "source": "WEB_DESKTOP"
+                                "userId": "550e8400-e29b-41d4-a716-446655440000",
+                                "product": "2000026",
+                                "source": "WEB_DESKTOP",
+                                "name": "Coca-Cola Lata 350ml",
+                                "category": "Bebidas/Refrigerantes",
+                                "url": "https://loja.com.br/coca-cola-lata-350ml/p"
                             }
                         }
                     }
@@ -912,6 +915,21 @@
                             "MOBILE_APP"
                         ],
                         "example": "WEB_DESKTOP"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name of the product. Optional. When provided, enriches the product view event with additional product information. We recommend sending it whenever available.",
+                        "example": "Coca-Cola Lata 350ml"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "Category of the product. Optional. When provided, enriches the product view event with additional product information. We recommend sending it whenever available.",
+                        "example": "Bebidas/Refrigerantes"
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "URL of the product page. Optional. When provided, enriches the product view event with additional product information. We recommend sending it whenever available.",
+                        "example": "https://loja.com.br/coca-cola-lata-350ml/p"
                     }
                 },
                 "required": [


### PR DESCRIPTION
[EDU-18507](https://vtex-dev.atlassian.net/browse/EDU-18507)

Adds three new optional fields (name, category, url) to the ProductViewEventV2Request schema in the Recommendations BFF API. These fields enrich the product view event with additional product information and are fully backwards-compatible.

#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)
- [ ] Improvement (make an endpoint's title or description even better)
- [ ] Spelling and grammar accuracy (self-explanatory)

### Changelog
Do not forget to update your changes to our Developer Portal's changelog. Did you create a release note?
- [ ] Yes, I already created a release note about this change.
- [ ] Not yet, but I'm going to.
- [ ] No, it's just a fix.


[EDU-18507]: https://vtex-dev.atlassian.net/browse/EDU-18507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ