### PR TITLE
fix: align B2B Buyer Portal OpenAPI specs with master data architecture

### DIFF
--- a/PostmanCollections/VTEX - B2B Addresses API.json
+++ b/PostmanCollections/VTEX - B2B Addresses API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "74af3a79-1841-48eb-82db-37cd2822396d"
+    "postman_id": "3d96097b-73e9-41e1-b81b-5af69aa0cef5"
   },
   "item": [
     {
-      "id": "c97cb45b-f7a7-49e0-a227-dad8ac567d44",
+      "id": "5dc1aff1-989d-48b1-abfd-26f081faa6f4",
       "name": "Addresses",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "5e777e38-5ea8-4513-bb51-4002089b13e2",
+          "id": "6ee333bc-7e8a-4749-b53f-49028efa53a1",
           "name": "Create B2B address",
           "request": {
             "name": "Create B2B address",
@@ -78,7 +78,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "12853642-bea2-4306-bf9c-7769fee6f18f",
+              "id": "e1757727-f782-4b5c-8201-4a293b443dc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -158,7 +158,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9389bc9d-6364-4df5-976c-f2508a524854",
+                "id": "64c90690-8a26-4ca2-b6be-e17dc295627f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/AD/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -174,7 +174,7 @@
           }
         },
         {
-          "id": "920e3ca5-c32e-4ea0-b056-3838cad4eeae",
+          "id": "c4975fa4-8e81-4b3b-afa3-6046825681a0",
           "name": "Search B2B addresses",
           "request": {
             "name": "Search B2B addresses",
@@ -255,7 +255,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "185b9746-814b-4262-87a8-cdd46091f1ea",
+              "id": "3986ee7d-0bd6-4abc-8248-37da7a593e8a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -348,7 +348,7 @@
                     "type": "text/plain"
                   },
                   "key": "REST-Content-Range",
-                  "value": "in ut ipsum est"
+                  "value": "aute magna"
                 }
               ],
               "body": "[\n  {\n    \"id\": \"4286e252-050b-11f0-b37f-d6617047d485\",\n    \"addressType\": \"commercial\",\n    \"addressLabel\": \"NC Office\",\n    \"receiverName\": \".\",\n    \"street\": \"Toringon Street\",\n    \"number\": \"11\",\n    \"city\": \"Orlando\",\n    \"state\": \"FL\",\n    \"country\": \"USA\",\n    \"postalCode\": \"02999\",\n    \"geoCoordinates\": [\n      28.48,\n      -81.2\n    ],\n    \"userId\": \"2da4e9ab-050b-11f0-b37f-f4b136dbcce1\"\n  },\n  {\n    \"id\": \"7de8a913-16a4-11ef-bc95-0ac138d2d42e\",\n    \"addressType\": \"invoice\",\n    \"addressLabel\": \"Billing HQ\",\n    \"receiverName\": \".\",\n    \"street\": \"Corporate Ave\",\n    \"number\": \"200\",\n    \"city\": \"Miami\",\n    \"state\": \"FL\",\n    \"country\": \"USA\",\n    \"postalCode\": \"33101\",\n    \"geoCoordinates\": [],\n    \"userId\": \"2da4e9ab-050b-11f0-b37f-f4b136dbcce1\"\n  }\n]",
@@ -358,7 +358,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d2301c3c-41f2-445f-8dc4-a2d843dcd946",
+              "id": "1c37928a-c9cb-4220-8dbf-30533f9a8ce2",
               "name": "Service Unavailable",
               "originalRequest": {
                 "url": {
@@ -443,7 +443,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "995330d1-5be8-4c65-9ab2-2362fa512b1e",
+                "id": "8e4b853f-6f54-4524-856a-a83e4a8c7092",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/AD/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -459,7 +459,7 @@
           }
         },
         {
-          "id": "ff031223-8990-4032-9d09-ec8c78fa3ebb",
+          "id": "bb5b5153-8e24-4345-bade-616c8edfb5f4",
           "name": "Get B2B address by ID",
           "request": {
             "name": "Get B2B address by ID",
@@ -525,7 +525,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "58e238f6-61f9-40d0-9ac8-e35339f2fdd7",
+              "id": "efc6472b-f6f9-4036-8a0f-32e59676e6e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -594,7 +594,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "02d71812-b154-461d-b8e3-e885b9bd7367",
+                "id": "011e56da-a221-41c1-8186-76d2d64d00bc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/AD/documents/:addressId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -610,7 +610,7 @@
           }
         },
         {
-          "id": "d221de1b-1723-4460-b716-e5ef2a24101f",
+          "id": "fb028109-bf62-4261-be94-3cf658607590",
           "name": "Update B2B address",
           "request": {
             "name": "Update B2B address",
@@ -688,7 +688,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ba8dacc9-1022-47e3-96b9-12d898c8854b",
+              "id": "7bfc5056-aa6c-4b89-b31b-e2e5513b43ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -769,7 +769,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0944e7e8-2b07-486d-a9ac-bdf50407311a",
+                "id": "835a7b5d-9ac2-43b0-b5e7-57981e849fe9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/AD/documents/:addressId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -785,7 +785,7 @@
           }
         },
         {
-          "id": "c3c76bd4-2d4d-4012-9425-adde1f0c3303",
+          "id": "886fe265-461d-40fe-b701-321538534754",
           "name": "Delete B2B address",
           "request": {
             "name": "Delete B2B address",
@@ -837,7 +837,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6a2e2951-b165-4fb6-a912-034a58712eb9",
+              "id": "3d2bb6a0-3a28-40ba-95a5-b4829b5430eb",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -886,7 +886,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bf9af402-c47f-42ac-b00c-ca922c3f2c16",
+                "id": "9d1cdd84-2800-4a8f-8ca4-7ef8e7f8b129",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/AD/documents/:addressId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -903,7 +903,7 @@
       "event": []
     },
     {
-      "id": "cbf4037d-36b8-4c04-959e-b55812e6b23c",
+      "id": "5b5cd16a-9c67-4450-ab64-9f4a7c9fa19c",
       "name": "Recipients",
       "description": {
         "content": "",
@@ -911,7 +911,7 @@
       },
       "item": [
         {
-          "id": "cf826cf4-3b12-4f9e-acea-601c51c17524",
+          "id": "883517ab-165b-45ea-a68a-b247aa40832e",
           "name": "Create recipient",
           "request": {
             "name": "Create recipient",
@@ -977,7 +977,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3e3e8b17-6fbe-439e-b4a0-9118059ed076",
+              "id": "7cb2541a-1ad3-4fab-8849-43b9a8675ba0",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -1057,7 +1057,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "82213324-96ce-48e0-a659-631a462a79aa",
+                "id": "324b836c-6da2-4dd8-b071-12b40ecf80d9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/contact_information/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1073,7 +1073,7 @@
           }
         },
         {
-          "id": "5594a337-1189-414b-ad06-2bdaa9af5e46",
+          "id": "e49f658a-fb4a-45c7-a1bf-25a80d3f8986",
           "name": "Search recipients",
           "request": {
             "name": "Search recipients",
@@ -1145,7 +1145,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "be3185ec-8408-4aaa-8879-e86069003503",
+              "id": "5ce010fc-4b6f-40c1-8c70-139a5b2bee4b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1231,7 +1231,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e8a495d2-09d9-4503-9c81-b2efa4cb8eac",
+                "id": "30afb7a9-232a-41f5-9419-c2b7806d8c46",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/contact_information/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1247,7 +1247,7 @@
           }
         },
         {
-          "id": "6ed65a01-9cf2-4fbb-bb9c-7b56e7f0072c",
+          "id": "109c57c3-82a9-4bd3-bf66-9711dd199ed1",
           "name": "Get recipient by ID",
           "request": {
             "name": "Get recipient by ID",
@@ -1322,7 +1322,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "78b55b71-eb0d-4805-a370-c7d177a53621",
+              "id": "35a61ef8-9b92-4f67-8325-93a2f0b42426",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1400,13 +1400,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "b8e8bb53-9f55-4c3c-96d9-822c35391038",
+                "id": "8c00c270-eb38-4d61-a008-3fc2be9da046",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/contact_information/documents/:recipientId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/dataentities/contact_information/documents/:recipientId - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/api/dataentities/contact_information/documents/:recipientId - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"description\":\"Recipient document object. A recipient can be associated with one or more B2B addresses through the `addressIds` field.\",\"required\":[\"firstName\",\"lastName\"],\"properties\":{\"email\":{\"type\":\"string\",\"description\":\"Recipient email.\"},\"firstName\":{\"type\":\"string\",\"description\":\"Recipient first name.\"},\"lastName\":{\"type\":\"string\",\"description\":\"Recipient last name.\"},\"profileId\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"References a buyer by its UUID.\"},\"phone\":{\"type\":\"string\",\"description\":\"Main phone number.\"},\"phoneExtension\":{\"type\":\"string\",\"description\":\"Internal phone extension, if applicable.\"},\"document\":{\"type\":\"string\",\"description\":\"Identification document.\"},\"documentType\":{\"type\":\"string\",\"description\":\"Type of document.\"},\"addressIds\":{\"type\":\"array\",\"description\":\"References to the B2B addresses associated with the recipient. Each value is the UUID of an address stored in the `AD` data entity.\",\"items\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"B2B address UUID.\"}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/dataentities/contact_information/documents/:recipientId - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"description\":\"Recipient document object. A recipient can be associated with one or more B2B addresses through the `addressIds` field.\",\"required\":[\"firstName\",\"lastName\"],\"properties\":{\"email\":{\"type\":\"string\",\"description\":\"Recipient email.\"},\"firstName\":{\"type\":\"string\",\"description\":\"Recipient first name.\"},\"lastName\":{\"type\":\"string\",\"description\":\"Recipient last name.\"},\"profileId\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"ID of the contract (`CL` data entity) that owns the recipient. This is the `id` returned by the contract creation request.\"},\"phone\":{\"type\":\"string\",\"description\":\"Main phone number.\"},\"phoneExtension\":{\"type\":\"string\",\"description\":\"Internal phone extension, if applicable.\"},\"document\":{\"type\":\"string\",\"description\":\"Identification document.\"},\"documentType\":{\"type\":\"string\",\"description\":\"Type of document.\"},\"addressIds\":{\"type\":\"array\",\"description\":\"References to the B2B addresses associated with the recipient. Each value is the UUID of an address stored in the `AD` data entity.\",\"items\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"B2B address UUID.\"}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/dataentities/contact_information/documents/:recipientId - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -1416,7 +1416,7 @@
           }
         },
         {
-          "id": "db75f391-2e95-4722-ab03-11f905ecbf3b",
+          "id": "c8b773f6-fac6-4850-9c9c-82af09ad6ff6",
           "name": "Update recipient",
           "request": {
             "name": "Update recipient",
@@ -1490,7 +1490,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4f1d7598-58f2-4fd5-a4ac-aa3e5a478979",
+              "id": "3c99663a-49d4-4b18-8b40-81f92a6e122c",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -1561,7 +1561,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "99c5b45b-4199-41d5-9737-3377cc37a56b",
+                "id": "422d7136-3dcd-4f02-a6dc-966ce7829938",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/contact_information/documents/:recipientId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1575,7 +1575,7 @@
           }
         },
         {
-          "id": "534bf21c-9c34-4848-a56e-1fc32b5d0235",
+          "id": "59108a6d-7b2b-427b-950e-e3a33385fd65",
           "name": "Delete recipient",
           "request": {
             "name": "Delete recipient",
@@ -1627,7 +1627,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f0b0ea52-5c7a-445d-bf5f-f067b31b0abd",
+              "id": "119ebb31-4a93-4451-8809-ec4a92bf581e",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -1676,7 +1676,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5b045113-6a91-44a6-b721-3afe4a04a5a9",
+                "id": "f0433a4c-322e-48c2-a245-5ee287045775",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/contact_information/documents/:recipientId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1693,7 +1693,7 @@
       "event": []
     },
     {
-      "id": "7b38209f-407b-40a2-86a4-96210ca397d6",
+      "id": "b351b92d-b8d4-4db9-8098-e437a062dbf0",
       "name": "Locations",
       "description": {
         "content": "",
@@ -1701,7 +1701,7 @@
       },
       "item": [
         {
-          "id": "3461587c-e9a4-488a-bfc9-d32d63cb9121",
+          "id": "c3d820ce-ff22-4b19-942e-2fa84988a112",
           "name": "Create location",
           "request": {
             "name": "Create location",
@@ -1767,7 +1767,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8ad5266e-706c-41a3-8d7d-b9749236d4a4",
+              "id": "89d5d3c0-2a83-4190-888d-5ce7136ee81f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1847,7 +1847,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "00a7561b-1be2-49e1-ac9f-a67375969329",
+                "id": "7cc2e264-ff6a-4935-b240-428b3d0e8644",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/customFieldValues/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1863,7 +1863,7 @@
           }
         },
         {
-          "id": "a3d30838-4bce-4c41-8403-62918ddd7e4a",
+          "id": "7264a25b-3bf6-4833-9327-7ca410ad1586",
           "name": "Get location",
           "request": {
             "name": "Get location",
@@ -1929,7 +1929,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3a16322d-4bc3-4e55-bead-27c9c08aba8a",
+              "id": "a0b8ee4c-b74f-49e0-a58d-7ca1345020c1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1998,7 +1998,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "afca720b-b0e8-4fd7-b16f-4449a48f226b",
+                "id": "cdf481da-8f39-4691-b46b-483c3d308818",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldValues/documents/:locationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2014,7 +2014,7 @@
           }
         },
         {
-          "id": "227ebc45-0689-4ad9-93ff-b2dd6647a853",
+          "id": "ccc79bf3-bab2-4e8c-bf36-acc1a11674af",
           "name": "Update location",
           "request": {
             "name": "Update location",
@@ -2088,7 +2088,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7b0d7728-fc27-4776-aa2b-7ef115ac49ab",
+              "id": "1b41ae01-4bd9-4521-8d7d-fd862f578bb3",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -2159,7 +2159,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0da9010b-f06c-464b-9679-03f4cadaffe5",
+                "id": "62587734-2003-49fc-94ae-6dd9765341f9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/customFieldValues/documents/:locationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2173,7 +2173,7 @@
           }
         },
         {
-          "id": "585f2cf7-ec28-4ad2-8e51-dbe8478da2d0",
+          "id": "132c04e5-1dc3-489c-9c74-fa1eb6da8c4c",
           "name": "Delete location",
           "request": {
             "name": "Delete location",
@@ -2235,7 +2235,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ca07cc25-8d85-470d-ae60-789446a1859b",
+              "id": "4290f3ef-5ae9-49e7-97d4-9a62dfb084c3",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -2294,7 +2294,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "22f3636a-353d-46b1-ba79-c286fc48030f",
+                "id": "e7adc08b-8995-4d51-8dea-e4163dcb9ff8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/customFieldValues/documents/:locationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2308,7 +2308,7 @@
           }
         },
         {
-          "id": "299cef5f-a9b4-4315-a271-e52b065f3a87",
+          "id": "9db614a0-852f-45c9-960a-dc5f9708fa28",
           "name": "Search locations",
           "request": {
             "name": "Search locations",
@@ -2389,7 +2389,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "696abbe4-c16a-4a1a-a755-4bea68535b4e",
+              "id": "59d191a4-6e44-40d1-bd8b-0e65e56515de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2484,7 +2484,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9cc5c91c-100d-45ab-af6f-39d3948617d7",
+                "id": "6c29d6ea-c4e7-4618-87b7-697daa7b98d1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldValues/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2542,7 +2542,7 @@
     }
   ],
   "info": {
-    "_postman_id": "74af3a79-1841-48eb-82db-37cd2822396d",
+    "_postman_id": "3d96097b-73e9-41e1-b81b-5af69aa0cef5",
     "name": "B2B Addresses API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Custom Fields API.json
+++ b/PostmanCollections/VTEX - Custom Fields API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "9ecd6f9a-952a-42f7-b646-28051c2e1ab7"
+    "postman_id": "067c9aad-0afe-4414-a689-c3d87642bd1f"
   },
   "item": [
     {
-      "id": "afdf9041-08cc-44fb-a897-baef564208ed",
+      "id": "ac8553fd-dc0b-4577-ac47-8585bdfa55d4",
       "name": "Custom field settings",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "90950d1e-a208-4d84-90f1-af3932e434b5",
+          "id": "060a592d-0303-4c40-82de-5a666f927483",
           "name": "Get custom field settings",
           "request": {
             "name": "Get custom field settings",
@@ -38,7 +38,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 },
                 {
                   "disabled": false,
@@ -93,7 +93,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d234a295-5af2-41e9-a821-46e11f0904a7",
+              "id": "ad4b6ae9-0871-4153-87c3-b46c91610ed8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -114,7 +114,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     },
                     {
                       "disabled": false,
@@ -180,7 +180,7 @@
                   "value": "application/json"
                 }
               ],
-              "body": "[\n  {\n    \"id\": \"34575ee8-80c1-458d-b75a-7492b36513e3\",\n    \"dataEntityId\": \"customFieldSettings\",\n    \"accountId\": \"6e41729c-a5ca-4f37-a46f-62315ef3a56a\",\n    \"accountName\": \"connections\",\n    \"followers\": [],\n    \"schemas\": [\n      \"v2\"\n    ],\n    \"contractId\": \"2da4e9ab-050b-11f0-b37f-f4b136dbcce1\",\n    \"name\": \"PO Number\",\n    \"enabled\": true,\n    \"required\": false,\n    \"level\": \"item\",\n    \"type\": \"option\",\n    \"additionalData\": \"teste\",\n    \"createdBy\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n    \"createdBy_USER\": {\n      \"Id\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n      \"Login\": \"user@vtex.com\",\n      \"Name\": null\n    },\n    \"createdIn\": \"2025-09-24T12:32:08.6879184Z\",\n    \"lastInteractionBy\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n    \"lastInteractionBy_USER\": {\n      \"Id\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n      \"Login\": \"user@vtex.com\",\n      \"Name\": null\n    },\n    \"lastInteractionIn\": \"2025-09-24T12:32:08.6879204Z\",\n    \"tags\": [],\n    \"dataInstanceId\": \"34575ee8-80c1-458d-b75a-7492b36513e3\"\n  }\n]",
+              "body": "[\n  {\n    \"id\": \"34575ee8-80c1-458d-b75a-7492b36513e3\",\n    \"dataEntityId\": \"customFieldSettings\",\n    \"accountId\": \"6e41729c-a5ca-4f37-a46f-62315ef3a56a\",\n    \"accountName\": \"connections\",\n    \"followers\": [],\n    \"schemas\": [\n      \"v1\"\n    ],\n    \"contractId\": \"2da4e9ab-050b-11f0-b37f-f4b136dbcce1\",\n    \"name\": \"PO Number\",\n    \"enabled\": true,\n    \"required\": false,\n    \"level\": \"item\",\n    \"type\": \"option\",\n    \"additionalData\": \"teste\",\n    \"createdBy\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n    \"createdBy_USER\": {\n      \"Id\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n      \"Login\": \"user@vtex.com\",\n      \"Name\": null\n    },\n    \"createdIn\": \"2025-09-24T12:32:08.6879184Z\",\n    \"lastInteractionBy\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n    \"lastInteractionBy_USER\": {\n      \"Id\": \"6ce199d2-8a85-4e83-831c-389dcb64c0c1\",\n      \"Login\": \"user@vtex.com\",\n      \"Name\": null\n    },\n    \"lastInteractionIn\": \"2025-09-24T12:32:08.6879204Z\",\n    \"tags\": [],\n    \"dataInstanceId\": \"34575ee8-80c1-458d-b75a-7492b36513e3\"\n  }\n]",
               "cookie": []
             }
           ],
@@ -188,7 +188,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1c36f845-fdff-47b3-84d2-67a66dbcb5fa",
+                "id": "a193c120-ae02-4e12-ad67-46cfb470d82f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldSettings/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -204,7 +204,7 @@
           }
         },
         {
-          "id": "e050df44-d718-4667-9b1b-15b0534edab6",
+          "id": "5e1c3be9-d66d-456e-85f4-2038f2536d4f",
           "name": "Create custom field settings",
           "request": {
             "name": "Create custom field settings",
@@ -230,7 +230,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 }
               ],
               "variable": []
@@ -280,7 +280,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "36155a99-ffcf-4811-bbb7-f017d768cc38",
+              "id": "ebbe267d-ce7f-4911-b56f-fcdfd05c3621",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -301,7 +301,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     }
                   ],
                   "variable": []
@@ -362,7 +362,7 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"Id\": \"customFieldSettings-89f1da93-6917-4cbf-894e-1f1399682826c\",\n  \"Href\": \"https://accountName.myvtex.com.br/api/dataentities/customFieldSettings/documents/89f1da93-6917-4cbf-894e-1f1399682826c?_schema=v2\",\n  \"DocumentId\": \"89f1da93-6917-4cbf-894e-1f1399682826c\"\n}",
+              "body": "{\n  \"Id\": \"customFieldSettings-89f1da93-6917-4cbf-894e-1f1399682826c\",\n  \"Href\": \"https://accountName.myvtex.com.br/api/dataentities/customFieldSettings/documents/89f1da93-6917-4cbf-894e-1f1399682826c?_schema=v1\",\n  \"DocumentId\": \"89f1da93-6917-4cbf-894e-1f1399682826c\"\n}",
               "cookie": []
             }
           ],
@@ -370,7 +370,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0821020d-c97a-4d2f-99a4-3d156d1f320f",
+                "id": "2e727647-e52d-4d3e-b180-43bf4036c051",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/customFieldSettings/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -386,7 +386,7 @@
           }
         },
         {
-          "id": "2b777063-b21e-4a7b-8a46-2a8775679732",
+          "id": "67a8d2e9-99cf-4d5e-80e3-5b08ad9450a5",
           "name": "Update custom field settings",
           "request": {
             "name": "Update custom field settings",
@@ -413,7 +413,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 }
               ],
               "variable": [
@@ -474,7 +474,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d7fc15fc-970f-4707-8863-57661a65b6a5",
+              "id": "640a454f-a22e-4d99-b04b-b3db68db1866",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -496,7 +496,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     }
                   ],
                   "variable": []
@@ -565,7 +565,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "faaeb825-91bb-499e-bf2d-841e3c1708c6",
+                "id": "80b612c8-917e-4933-b886-945f26ed0e95",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/customFieldSettings/documents/:documentId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -581,7 +581,7 @@
           }
         },
         {
-          "id": "4c875eb2-a1fd-4548-a3c2-c33d6ba2a99c",
+          "id": "a3875717-efbc-4703-8e85-a7b98e4650a2",
           "name": "Delete custom field setting",
           "request": {
             "name": "Delete custom field setting",
@@ -608,7 +608,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 }
               ],
               "variable": [
@@ -643,7 +643,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4a85f4aa-6447-4512-bcf4-2593997ad212",
+              "id": "b4461294-4aaa-472e-a837-31324ef16809",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -665,7 +665,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     }
                   ],
                   "variable": []
@@ -702,7 +702,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f53efcec-1495-463b-95bf-5381a2c9fe9a",
+                "id": "ab2429d4-b3e5-41e9-9a63-a1d02a865f8b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/customFieldSettings/documents/:documentId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -719,7 +719,7 @@
       "event": []
     },
     {
-      "id": "1f9bf82b-d4bf-47f6-b956-580b540a845d",
+      "id": "e2d251e8-95c9-41b8-9a62-01da792c7c52",
       "name": "Custom field values",
       "description": {
         "content": "",
@@ -727,7 +727,7 @@
       },
       "item": [
         {
-          "id": "4c484853-057e-4fca-85cd-0706f41ac749",
+          "id": "23027814-faae-4fec-b946-6b270e531c70",
           "name": "Create custom field value",
           "request": {
             "name": "Create custom field value",
@@ -753,7 +753,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 }
               ],
               "variable": []
@@ -803,7 +803,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "06eb32eb-4715-4e30-b63c-e58ccfddd051",
+              "id": "d542e9a8-b7bf-4a0d-a730-4939bca601b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -824,7 +824,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     }
                   ],
                   "variable": []
@@ -893,7 +893,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c6807200-9afd-491a-a2bc-b170cfabe501",
+                "id": "96ad36b5-1c8e-4a03-aaa0-8df737c204c9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/customFieldValues/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -909,7 +909,7 @@
           }
         },
         {
-          "id": "4f75dba5-277e-4b0b-a868-a638723c70e6",
+          "id": "b104bae9-1a99-4887-b393-46b8e497999a",
           "name": "Get custom field value",
           "request": {
             "name": "Get custom field value",
@@ -945,7 +945,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 }
               ],
               "variable": [
@@ -984,7 +984,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5366fbcb-73d7-4b28-8bf5-767102355e5f",
+              "id": "d7c7ca6d-43cc-4689-a2e2-84ac6e34bbf4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1015,7 +1015,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     }
                   ],
                   "variable": []
@@ -1062,7 +1062,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2d6c40d7-e298-48bc-8a92-352d50b777e4",
+                "id": "3ad27181-434b-4421-a538-c3a1ac461bcc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldValues/documents/:customFieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1078,7 +1078,7 @@
           }
         },
         {
-          "id": "0ca105d1-40a1-4a14-8123-e45275c71802",
+          "id": "852830b4-dee4-4279-89fb-c3788b0dfdc5",
           "name": "Update custom field value",
           "request": {
             "name": "Update custom field value",
@@ -1105,7 +1105,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 }
               ],
               "variable": [
@@ -1162,7 +1162,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "72b58f86-0606-49bc-bd22-5e498e5caa76",
+              "id": "fc897330-21b1-4c7b-9f02-d332e1e6b70b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -1184,7 +1184,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     }
                   ],
                   "variable": []
@@ -1243,7 +1243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "de99b320-1ba5-4222-b28f-1411c211c454",
+                "id": "d25b3327-a361-4399-83b9-5d244c87ebf4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/customFieldValues/documents/:customFieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1257,7 +1257,7 @@
           }
         },
         {
-          "id": "9b3949f0-6d56-4635-9ed4-5c4aaf1167a1",
+          "id": "75d7dc8d-5007-4d27-b1d7-ccfea9759262",
           "name": "Delete custom field value",
           "request": {
             "name": "Delete custom field value",
@@ -1293,7 +1293,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 }
               ],
               "variable": [
@@ -1328,7 +1328,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "375bf54c-033e-40ac-b975-55e596d19918",
+              "id": "3c26ebb5-7a4e-47fa-a7a1-ed7c6c138e2b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -1359,7 +1359,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     }
                   ],
                   "variable": []
@@ -1396,7 +1396,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "abfc66ff-33c1-4569-a954-db5c56e16c86",
+                "id": "80017794-c7c7-42c1-86ac-22a3eeeb1da2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/customFieldValues/documents/:customFieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1410,7 +1410,7 @@
           }
         },
         {
-          "id": "01109ba0-e178-423e-a7bd-147bf519c5e2",
+          "id": "8f3b7883-0b45-41df-a281-dff79c2e9237",
           "name": "Search custom field values",
           "request": {
             "name": "Search custom field values",
@@ -1436,7 +1436,7 @@
                     "type": "text/plain"
                   },
                   "key": "_schema",
-                  "value": "v2"
+                  "value": "v1"
                 },
                 {
                   "disabled": false,
@@ -1491,7 +1491,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f4d97987-0ded-4d13-9555-086f1303f5a8",
+              "id": "ab5eb054-120f-40be-9c6a-d9abc5a0421c",
               "name": "Search all values for a custom field",
               "originalRequest": {
                 "url": {
@@ -1512,7 +1512,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     },
                     {
                       "disabled": false,
@@ -1585,7 +1585,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "16d8c302-80bb-4ea0-90ee-e1e813dada47",
+              "id": "8894b01c-ddcf-411b-bf5a-fe0219d62d48",
               "name": "Get a specific value",
               "originalRequest": {
                 "url": {
@@ -1606,7 +1606,7 @@
                         "type": "text/plain"
                       },
                       "key": "_schema",
-                      "value": "v2"
+                      "value": "v1"
                     },
                     {
                       "disabled": false,
@@ -1680,7 +1680,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "897bdff0-0a2b-436a-aaf9-6c66216fb102",
+                "id": "6bd615e9-4d46-4c3a-9839-9483d3acaa35",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/customFieldValues/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1738,7 +1738,7 @@
     }
   ],
   "info": {
-    "_postman_id": "9ecd6f9a-952a-42f7-b646-28051c2e1ab7",
+    "_postman_id": "067c9aad-0afe-4414-a689-c3d87642bd1f",
     "name": "Custom Fields API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Default Values API.json
+++ b/PostmanCollections/VTEX - Default Values API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "31555fea-81ee-41c9-bd3a-27c6536a8919"
+    "postman_id": "dcb41177-fbd3-4952-8f50-be39ede20768"
   },
   "item": [
     {
-      "id": "c0d65a31-acfa-4592-bdbf-289bed36e0b8",
+      "id": "8b58feb4-d297-46e5-983a-654d628dd990",
       "name": "Default values",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "127f38fc-d77d-40cb-a118-009f2e8948dd",
+          "id": "f17c6e51-9826-44de-96d7-3bd489bfe0cc",
           "name": "Create default values",
           "request": {
             "name": "Create default values",
@@ -78,7 +78,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2a8ad7d5-2b20-4f9c-9e43-5bc4f225f482",
+              "id": "67be9e72-1cff-456c-9f1b-5b82de909095",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -150,7 +150,7 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"Id\": \"c90354e8-08d6-11f0-b37f-daebda928cfa\",\n  \"Href\": \"http://store.myvtex.com/api/dataentities/customFieldSettings/documents/c90354e8-08d6-11f0-b37f-daebda928cfa\",\n  \"DocumentId\": \"c90354e8-08d6-11f0-b37f-daebda928cfa\"\n}",
+              "body": "{\n  \"Id\": \"c90354e8-08d6-11f0-b37f-daebda928cfa\",\n  \"Href\": \"http://store.myvtex.com/api/dataentities/defaultValues/documents/c90354e8-08d6-11f0-b37f-daebda928cfa\",\n  \"DocumentId\": \"c90354e8-08d6-11f0-b37f-daebda928cfa\"\n}",
               "cookie": []
             }
           ],
@@ -158,7 +158,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7a62924c-9ed4-4897-b35f-7b679b0c85ff",
+                "id": "184a88f5-f193-4860-9fce-0c567d35722c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/defaultValues/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -174,7 +174,7 @@
           }
         },
         {
-          "id": "a9fa1e60-60e8-458c-bf45-b4fafb805101",
+          "id": "a8ae948b-1240-4fa7-a195-58859ea19b43",
           "name": "Get default values",
           "request": {
             "name": "Get default values",
@@ -221,7 +221,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "incididunt consectetur",
+                  "value": "in occaecat",
                   "key": "unitId"
                 }
               ]
@@ -249,7 +249,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1630279b-a1a5-4d07-8cd7-209117811a37",
+              "id": "1a9a643f-c9a2-408c-bf1d-47c2df57e2df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -327,7 +327,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ce963183-8298-4abd-a0f9-05704ad80f9a",
+                "id": "8136ecfe-003f-4939-90ab-99b27f725aec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/defaultValues/documents/:unitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -343,7 +343,7 @@
           }
         },
         {
-          "id": "6c23af5a-a9b0-4ea3-b06f-5c2104505620",
+          "id": "29b2ad39-f824-4a17-8add-910852fee433",
           "name": "Update default values",
           "request": {
             "name": "Update default values",
@@ -371,7 +371,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "incididunt consectetur",
+                  "value": "in occaecat",
                   "key": "unitId"
                 }
               ]
@@ -417,7 +417,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "68eaa631-3768-4d01-81b1-efce863d21ff",
+              "id": "2c36d7f0-c2da-43d0-8ab6-0ab91286870b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -488,7 +488,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2c65b5ca-d7ef-45fd-a097-3920136fe4bf",
+                "id": "fcabd009-0671-49cf-80f8-5470bc4495d4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/defaultValues/documents/:unitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -502,7 +502,7 @@
           }
         },
         {
-          "id": "e3766c04-4906-4fdc-8842-f0a6bc712169",
+          "id": "07d8e4be-26d0-4512-8609-c9064ec513e3",
           "name": "Delete default values",
           "request": {
             "name": "Delete default values",
@@ -530,7 +530,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "incididunt consectetur",
+                  "value": "in occaecat",
                   "key": "unitId"
                 }
               ]
@@ -554,7 +554,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0deda65f-30fb-4b06-a343-8dfb5d369c7a",
+              "id": "068b66a0-8789-4443-a783-e429424284a3",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -602,7 +602,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f4add10b-dcf1-4930-bd44-e4912ad0367e",
+              "id": "943031ea-60b2-4e41-bad6-6d8a96319792",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -651,7 +651,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fb68f661-35c6-4f33-9131-46d2ce7c6aff",
+                "id": "0387c655-fc58-45b7-964a-8e68c85b5a8c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/defaultValues/documents/:unitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -706,7 +706,7 @@
     }
   ],
   "info": {
-    "_postman_id": "31555fea-81ee-41c9-bd3a-27c6536a8919",
+    "_postman_id": "dcb41177-fbd3-4952-8f50-be39ede20768",
     "name": "Default Values API",
     "version": {
       "raw": "1.0.0",

--- a/VTEX - B2B Addresses API.json
+++ b/VTEX - B2B Addresses API.json
@@ -1495,7 +1495,7 @@
                     "profileId": {
                         "type": "string",
                         "format": "uuid",
-                        "description": "References a buyer by its UUID."
+                        "description": "ID of the contract (`CL` data entity) that owns the recipient. This is the `id` returned by the contract creation request."
                     },
                     "phone": {
                         "type": "string",

--- a/VTEX - Custom Fields API.json
+++ b/VTEX - Custom Fields API.json
@@ -45,7 +45,7 @@
                         "explode": true,
                         "schema": {
                             "type": "string",
-                            "example": "v2"
+                            "example": "v1"
                         }
                     },
                     {
@@ -224,7 +224,7 @@
                                         "accountId": "6e41729c-a5ca-4f37-a46f-62315ef3a56a",
                                         "accountName": "connections",
                                         "followers": [],
-                                        "schemas": ["v2"],
+                                        "schemas": ["v1"],
                                         "contractId": "2da4e9ab-050b-11f0-b37f-f4b136dbcce1",
                                         "name": "PO Number",
                                         "enabled": true,
@@ -354,7 +354,7 @@
                                 },
                                 "example": {
                                     "Id": "customFieldSettings-89f1da93-6917-4cbf-894e-1f1399682826c",
-                                    "Href": "https://accountName.myvtex.com.br/api/dataentities/customFieldSettings/documents/89f1da93-6917-4cbf-894e-1f1399682826c?_schema=v2",
+                                    "Href": "https://accountName.myvtex.com.br/api/dataentities/customFieldSettings/documents/89f1da93-6917-4cbf-894e-1f1399682826c?_schema=v1",
                                     "DocumentId": "89f1da93-6917-4cbf-894e-1f1399682826c"
                                 }
                             }
@@ -479,7 +479,7 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "example": "v2"
+                            "example": "v1"
                         }
                     }
                 ],
@@ -879,7 +879,7 @@
                         "explode": true,
                         "schema": {
                             "type": "string",
-                            "example": "v2"
+                            "example": "v1"
                         }
                     },
                     {
@@ -1070,7 +1070,7 @@
                 "style": "form",
                 "schema": {
                     "type": "string",
-                    "example": "v2"
+                    "example": "v1"
                 }
             },
             "_sort": {

--- a/VTEX - Default Values API.json
+++ b/VTEX - Default Values API.json
@@ -107,7 +107,7 @@
                 },
                 "example": {
                   "Id": "c90354e8-08d6-11f0-b37f-daebda928cfa",
-                  "Href": "http://store.myvtex.com/api/dataentities/customFieldSettings/documents/c90354e8-08d6-11f0-b37f-daebda928cfa",
+                  "Href": "http://store.myvtex.com/api/dataentities/defaultValues/documents/c90354e8-08d6-11f0-b37f-daebda928cfa",
                   "DocumentId": "c90354e8-08d6-11f0-b37f-daebda928cfa"
                 }
               }
@@ -395,7 +395,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Unique identifier of the default values document."
+            "description": "Unique identifier of the organizational unit. This value is used as the default values document ID."
           },
           "defaultValues": {
             "type": "array",


### PR DESCRIPTION
Aligns B2B Buyer Portal OpenAPI specs with the master data architecture guide after cross-checking entity relationships and linking fields.

## Changes

- **Custom Fields API**: Correct `_schema` query parameter examples from `v2` to `v1` (confirmed correct value).
- **Default Values API**: Fix create response `Href` example pointing to wrong entity; clarify that `id` is the organizational unit ID.
- **B2B Addresses API**: Clarify recipient `profileId` references the contract (`CL.id`), not a generic buyer UUID.
