### PR TITLE
Fix: Document searchField enum and companion query parameters in List Orders

### DIFF
--- a/VTEX - Orders API.json
+++ b/VTEX - Orders API.json
@@ -4429,13 +4429,93 @@
                     {
                         "name": "searchField",
                         "in": "query",
-                        "description": "You can search orders by using one of the following criterias: \r\n- SKU ID - `sku_Ids&sku_Ids` \r\n- Gift List ID - `listId&listId` \r\n- Transaction ID (TID) - `tid&tid` \r\n- PCI Connector's Transaction ID (TID) - `pci_tid&pci_tid` \r\n- Payment ID (PID) - `paymentId&paymentId` \r\n- Connector's NSU - `nsu&nsu`",
+                        "description": "Defines the search criteria for filtering orders. Must be used together with the corresponding query parameter that provides the search value. For example, to search by SKU ID: `?searchField=sku_Ids&sku_Ids=11223`.",
                         "required": false,
                         "style": "form",
                         "explode": true,
                         "schema": {
                             "type": "string",
-                            "example": "- SKU ID: `25` \r\n- Gift List ID: `11223` \r\n- Transaction ID (TID): `54546300238810034995829230012` \r\n- PCI Connector's Transaction ID (TID): `7032909234899834298423209` \r\n- Payment ID (PID): `2` \r\n- Connector's NSU: `2437281`"
+                            "enum": [
+                                "sku_Ids",
+                                "listId",
+                                "tid",
+                                "pci_tid",
+                                "paymentId",
+                                "nsu"
+                            ],
+                            "example": "sku_Ids"
+                        }
+                    },
+                    {
+                        "name": "sku_Ids",
+                        "in": "query",
+                        "description": "SKU ID to filter orders. Must be used with `searchField=sku_Ids`.",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "25"
+                        }
+                    },
+                    {
+                        "name": "listId",
+                        "in": "query",
+                        "description": "Gift List ID to filter orders. Must be used with `searchField=listId`.",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "11223"
+                        }
+                    },
+                    {
+                        "name": "tid",
+                        "in": "query",
+                        "description": "Transaction ID (TID) to filter orders. Must be used with `searchField=tid`.",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "54546300238810034995829230012"
+                        }
+                    },
+                    {
+                        "name": "pci_tid",
+                        "in": "query",
+                        "description": "PCI Connector's Transaction ID (TID) to filter orders. Must be used with `searchField=pci_tid`.",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "7032909234899834298423209"
+                        }
+                    },
+                    {
+                        "name": "paymentId",
+                        "in": "query",
+                        "description": "Payment ID (PID) to filter orders. Must be used with `searchField=paymentId`.",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "2"
+                        }
+                    },
+                    {
+                        "name": "nsu",
+                        "in": "query",
+                        "description": "Connector's NSU to filter orders. Must be used with `searchField=nsu`.",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "2437281"
                         }
                     },
                     {


### PR DESCRIPTION
## Summary
- Changed `searchField` from a free-form `string` to an `enum` with the 6 valid values: `sku_Ids`, `listId`, `tid`, `pci_tid`, `paymentId`, `nsu`.
- Added the 6 companion query parameters (`sku_Ids`, `listId`, `tid`, `pci_tid`, `paymentId`, `nsu`) that were missing from the schema.

## Why
The `searchField` parameter requires a companion query parameter to provide the actual search value. For example:

```
/api/oms/pvt/orders?searchField=sku_Ids&sku_Ids=11223
```

Previously, only `searchField` was documented (as a free string), so code generation tools and SDK clients had no way to know about the companion parameters like `sku_Ids`. This made it impossible to use this feature correctly via generated clients.

## Test plan
- [ ] Validate the OpenAPI schema is valid JSON
- [ ] Confirm the enum values match the API behavior
- [ ] Verify generated SDK clients now expose all search parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)