### PR TITLE
fix: add Delivery Promise to tag sentence-case exceptions in Spectral

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -158,7 +158,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|Storefront Roles|Custom Storefront Roles|Custom Storefront Resources|B2B|[A-Z][a-z0-9]*(?:-[a-z][a-z0-9]*)*)(?:\\s+(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|Storefront Roles|Custom Storefront Roles|Custom Storefront Resources|B2B|[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*))*$"
+        match: "^(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|Storefront Roles|Custom Storefront Roles|Custom Storefront Resources|B2B|Delivery Promise|[A-Z][a-z0-9]*(?:-[a-z][a-z0-9]*)*)(?:\\s+(?:VTEX|SKU|SKUs|ID|API|CMS|EAN|URL|JSON|OAuth|SLA|Session Manager|Storefront Permissions|Storefront Roles|Custom Storefront Roles|Custom Storefront Resources|B2B|Delivery Promise|[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*))*$"
 
   request-example-parallel-to-schema:
     description: The request body must declare an example at the content-type level (as a sibling of `schema`), not nested inside schema properties. Use `example` (singular) for a single payload, or `examples` (plural, an object of named entries with `summary` and `value`) when the schema uses `anyOf`/`oneOf` and each branch needs its own illustrative payload.


### PR DESCRIPTION
## What changed

Added `Delivery Promise` to the allowlist in the `tags-should-be-in-sentence-case` regex in `.spectral.yml`.

## Why

`Delivery Promise` is a VTEX product name and requires title case (capital P). The existing rule only allowed single-word capitalized tags or multi-word exceptions explicitly listed (e.g., `Session Manager`, `Storefront Permissions`). Without this exception, any spec that uses `Delivery Promise` as a tag fails CI with a Spectral error — including `VTEX - Intelligent Search API.json`, which uses it on the `GET /pickup-point-availability/{facets}` endpoint and in the top-level tags array.

## Notes for reviewers

- The fix adds `Delivery Promise` to both alternation groups in the regex (first-word position and continuation-word position) so it works whether the tag is standalone or part of a longer tag name.
- This is a prerequisite for merging [PR #1731](https://github.com/vtex/openapi-schemas/pull/1731), which introduces the Intelligent Search API v1 reference and updates the legacy spec with this tag.