### PR TITLE
EDU-18790: clarify Ads API event tracking endpoint descriptions

### DIFF
--- a/PostmanCollections/VTEX - Ads API.json
+++ b/PostmanCollections/VTEX - Ads API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "de19b574-7025-466b-a759-ed0062948d7f"
+    "postman_id": "0eb8b10b-41b2-48cc-9715-67164d40d51b"
   },
   "item": [
     {
-      "id": "04a336a5-6c50-4ab9-ad42-284a72ba7d28",
+      "id": "850a5691-cd31-4fa3-8341-a23d16770e91",
       "name": "Catalog synchronization",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "c0eab7a0-9e8a-44d3-abf2-bc6a93ca2ed3",
+          "id": "6df1f5a8-36df-4ed1-aced-d689456a0c3d",
           "name": "Synchronize product information",
           "request": {
             "name": "Synchronize product information",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a48a5c69-11c3-4817-befe-b068aac1a052",
+              "id": "71b2857b-1de0-408b-9475-205c3199d829",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -155,7 +155,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dabc5dc0-215d-442a-913e-148881934160",
+              "id": "0d78e751-ea9f-4879-9b23-4bbdbb0e8832",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -224,7 +224,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9abc00ee-7409-4860-b031-54f534bf72fe",
+                "id": "9622ad85-52b0-448d-bc4d-3508c9a8876a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -240,7 +240,7 @@
           }
         },
         {
-          "id": "c3455a85-2ecc-4b92-9a45-3959c4600c79",
+          "id": "bf65ccbd-dead-459b-9570-224c74aa6096",
           "name": "Synchronize inventory information",
           "request": {
             "name": "Synchronize inventory information",
@@ -305,7 +305,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dcffc8fc-cad7-4a4b-bb9e-ed1bfe92c0ed",
+              "id": "fd39b0c6-4a2c-4240-895f-6eadadcdbd81",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -383,7 +383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "65e343ce-1c7d-4a1a-b3c2-f46576bab117",
+              "id": "d7950a13-4b7f-401b-9fb9-252978621c5b",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -452,7 +452,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "087faec0-9c1f-40c9-8b5c-a27e29991253",
+                "id": "991176f1-7be2-4740-82a9-68a1c137c214",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/inventories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -471,7 +471,7 @@
       "event": []
     },
     {
-      "id": "4b241cf9-43c9-4029-a2dd-f053a13839c8",
+      "id": "15a62392-121f-4c55-bd61-b280cbc02cba",
       "name": "Audiences",
       "description": {
         "content": "",
@@ -479,7 +479,7 @@
       },
       "item": [
         {
-          "id": "076eff3e-c271-499a-bf79-a3756afaab43",
+          "id": "3e03debf-9471-47b0-8226-fae10b17a6da",
           "name": "Generate audience upload URL",
           "request": {
             "name": "Generate audience upload URL",
@@ -521,7 +521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a9a9054d-558f-4f0c-9315-53646bad8561",
+              "id": "0ad070df-b21c-477b-96d2-e183d0403e63",
               "name": "OK\n\nPresigned upload URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -576,7 +576,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2ad37bc3-cd50-4acf-8c35-be003bd2b3d7",
+              "id": "d5f05874-015b-4cbf-b492-b935824b59b5",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e78d27e3-4280-4168-9ab1-ee5476e8c132",
+                "id": "8eaa3dea-bf96-4d8d-b085-9bde4c7dbc26",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/audience/upload-url - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -641,7 +641,7 @@
       "event": []
     },
     {
-      "id": "87ef8115-1d41-423c-80ab-39dc25baec2d",
+      "id": "af60217f-e18e-40fb-a750-f27f4cdd3895",
       "name": "Ads events notification",
       "description": {
         "content": "",
@@ -649,12 +649,12 @@
       },
       "item": [
         {
-          "id": "1af365bd-c9a0-499e-819d-5c5e17525d35",
+          "id": "eabde541-2d97-4777-b5e0-0b2571679da6",
           "name": "Track ad impressions",
           "request": {
             "name": "Track ad impressions",
             "description": {
-              "content": "Track when an ad is rendered or visible to a user. The event URL must not be constructed manually — always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Track when an ad is rendered on a page. An impression does not determine whether the ad became visible to the user. Visibility is tracked by the separate `view` event. Do not construct the event URL manually. Always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n>ℹ️ Fire this event whenever a page loads that contains rendered ads.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -736,7 +736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "71517dde-8cc9-4083-9b46-2b9d09ff8efc",
+              "id": "4ca488ce-5099-419c-a779-2e7de932637a",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -825,7 +825,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "493027b7-efb8-4e21-8931-6e4433d64366",
+              "id": "4d928809-eea0-4d35-a441-aa2e99317bf9",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -914,7 +914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b2f8c893-48b1-4f7d-bf23-f0b2d524f058",
+              "id": "e14eb125-141d-46ff-a680-2a5f181729c3",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -994,7 +994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c42acd0a-341e-4a0b-922b-c4567c9b3184",
+                "id": "f3ea2f50-376a-4857-9fec-ffad09cbf08c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/impression/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1010,7 +1010,7 @@
           }
         },
         {
-          "id": "75a877da-837c-47b9-8b9b-ff8a2c2055c8",
+          "id": "65a83f67-e62c-4e6a-a820-45916c3abd8a",
           "name": "Track ad clicks",
           "request": {
             "name": "Track ad clicks",
@@ -1097,7 +1097,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9951f46a-fb93-4be4-82c9-35c6c48b87ea",
+              "id": "63faa53d-4821-46a8-bfba-e0128418c02a",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1186,7 +1186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ebd2fde6-b9ee-4f04-b98d-9936ec020bd3",
+              "id": "70279679-8434-41e4-b3c8-1069eea43276",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1275,7 +1275,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "72be6f57-033f-49a7-bce4-8388a9c5b780",
+              "id": "77830ac0-1e65-419e-868c-d4a7407897b1",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1355,7 +1355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "43c2f95c-4c8f-4b79-b63e-6c32df8bc0c0",
+                "id": "b29cb526-6f84-4e70-beb4-9ed013d64ece",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/click/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1371,12 +1371,12 @@
           }
         },
         {
-          "id": "75805752-81fd-4bce-9a5b-2403d4dfcb7e",
+          "id": "6f9a9546-c5dd-4de0-86ed-604543535a86",
           "name": "Track ad views",
           "request": {
             "name": "Track ad views",
             "description": {
-              "content": "Track views for banner ads. The event URL must not be constructed manually — always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Track when an ad becomes visible to the user. Do not construct the event URL manually. Always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n>ℹ️ Fire this event when the ad occupies at least 50% of the viewport for at least 1 second.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -1458,7 +1458,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "80e579e1-ae85-40a9-ba5d-18e104a7ac23",
+              "id": "754c5876-c5b7-4d2a-9e0f-b5cffdd8adc4",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1547,7 +1547,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "763f6608-fd86-4b15-a7c2-1963cf7019a9",
+              "id": "bc6fed89-bd0a-4c91-98d2-cbbaff119c27",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1636,7 +1636,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "773cbf45-63ba-4996-9358-5e8d84dca6fa",
+              "id": "b1cf6ceb-5072-44e7-bb75-ceaf8f2ceb5e",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1716,7 +1716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b11f1d56-e126-4d3c-95c6-5bff254aff2b",
+                "id": "eca5c911-15ed-4609-8b6a-e116669a3d33",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/view/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1732,12 +1732,12 @@
           }
         },
         {
-          "id": "efdb2d1d-7056-49cb-b8e9-7997a059ba9d",
+          "id": "81185f7c-a72e-40f1-bf4a-cb42c353c836",
           "name": "Track conversions",
           "request": {
             "name": "Track conversions",
             "description": {
-              "content": "Track when an ad leads to a purchase. This endpoint is used to notify one or more orders (sending them in a batch).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Track completed sales for conversion attribution. Send this event for every completed sale, regardless of whether an ad led to the purchase. Notifying all sales enables attribution within time windows after ad-impacted navigation and metrics such as assisted sales. Send one or more orders in a batch request.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -1797,7 +1797,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f77dad8a-2f31-48ad-a988-450ed3c1bc99",
+              "id": "7f087ee4-3d3d-41fa-a68d-90079ccc4342",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -1875,7 +1875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2bbbce5c-b0f7-4c16-b68e-a2a697252e1d",
+              "id": "deafb23d-8f26-49b0-94aa-ee9ad796ca33",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1944,7 +1944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fa736093-95cc-49ed-a19a-684afe554d2a",
+                "id": "a36aa507-18ca-414f-9a07-04e0e33585d1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/conversion - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1963,7 +1963,7 @@
       "event": []
     },
     {
-      "id": "489f14e9-9437-4731-bcd8-681e4855ef0a",
+      "id": "b3aa8c56-e139-4624-94d3-1b66cac2c9ff",
       "name": "Ads",
       "description": {
         "content": "",
@@ -1971,7 +1971,7 @@
       },
       "item": [
         {
-          "id": "51fcf7d7-93dd-4588-aa43-c6dbb4a49b64",
+          "id": "5121dcf8-9d26-4ae6-896f-22a31ea8a072",
           "name": "Get ads",
           "request": {
             "name": "Get ads",
@@ -2047,7 +2047,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8c17307a-ab1c-4c68-8237-5ef74bf47a5b",
+              "id": "01f7cbde-6749-46dc-a66f-873a60050037",
               "name": "OK\n\nQuery processed successfully.",
               "originalRequest": {
                 "url": {
@@ -2125,7 +2125,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c795fe18-2f12-4083-8f62-17b2f6466582",
+              "id": "7e61449c-e0bc-4b65-9c82-cf10c2ce4f4e",
               "name": "Bad Request\n\nInvalid request.",
               "originalRequest": {
                 "url": {
@@ -2193,7 +2193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "596301a1-660d-45ba-b6cd-cb90e5fd43ac",
+              "id": "157b11c4-9f6f-45d0-b7e5-1c9bf745ec03",
               "name": "Not Found\n\nResource not found.",
               "originalRequest": {
                 "url": {
@@ -2261,7 +2261,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ee9b17ac-282a-49cd-9174-65eaedd7f94f",
+              "id": "46ded926-7c7c-4bc0-8c02-4bc70c02d220",
               "name": "Unprocessable Entity\n\nField validation error.",
               "originalRequest": {
                 "url": {
@@ -2329,7 +2329,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "52bb4989-25eb-40db-9058-bd7dd0d7382b",
+              "id": "59e51929-00e1-4de2-9acc-e1ca813cc140",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -2398,7 +2398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7916f721-ed36-48ef-b061-e9c954e06206",
+                "id": "4ff4fd85-35db-4bf3-92c8-b336907c4221",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/rma/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2417,7 +2417,7 @@
       "event": []
     },
     {
-      "id": "d9bad6c9-6161-474b-b798-0d4d2500bc79",
+      "id": "cbb75152-a39f-414b-adf0-5b2bba5a4093",
       "name": "Reports",
       "description": {
         "content": "",
@@ -2425,7 +2425,7 @@
       },
       "item": [
         {
-          "id": "0b44625d-0c09-4ab5-b8b2-28c200226d02",
+          "id": "e3fc6b26-e2b0-4cff-abda-d99632474df2",
           "name": "Get advertisers report",
           "request": {
             "name": "Get advertisers report",
@@ -2541,7 +2541,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1641ea36-678c-4bf1-8cc6-2e4de8eabd79",
+              "id": "07de2471-6acb-4e89-8bb6-01576c255573",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -2670,7 +2670,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ba0f4936-38c2-4cd6-a7c5-d6db975b1613",
+              "id": "d5590b82-c9d9-4226-8ca9-dad824f2dd0b",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2790,7 +2790,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b30fb7be-2f7b-4e54-aa9a-0bed5cf540bd",
+                "id": "c14fd91d-7f46-41e7-96e9-91b240858b1e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/advertisers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2806,7 +2806,7 @@
           }
         },
         {
-          "id": "f230fe05-6d4f-4600-b2d6-a80f8d21bfb6",
+          "id": "1a247af2-1b67-461f-b31b-30f6423d1466",
           "name": "Get publishers report",
           "request": {
             "name": "Get publishers report",
@@ -2949,7 +2949,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "643cb0d6-31c5-42c8-9eef-a1f04577a49a",
+              "id": "e374a64c-b7f9-4fcf-aa0c-9e23cd2134df",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3105,7 +3105,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a1094654-e91d-4a6a-9b6e-f702940003d3",
+              "id": "c8a977dd-ba03-4a2d-bc5d-082aec89f5c4",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3252,7 +3252,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9163c1f0-edc0-40a5-b72c-a52e6fde1330",
+                "id": "a31935a7-f20f-40a3-9925-285ac950afeb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3268,7 +3268,7 @@
           }
         },
         {
-          "id": "46491d22-5f9f-44a5-bc5a-2f6b26324bc1",
+          "id": "bbb2ea85-a89e-41d5-92f1-3f653bb1c2ff",
           "name": "Get network publishers report",
           "request": {
             "name": "Get network publishers report",
@@ -3411,7 +3411,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "478b03df-9736-44b4-826c-1b6b56549249",
+              "id": "fe629d88-d2cb-4dde-9713-f5e379d446a3",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3567,7 +3567,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c21c7888-406d-4876-b0e8-90f1e017a8cd",
+              "id": "6c7ad326-4f04-47ac-8e3b-54db3fc84076",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3714,7 +3714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ee25b83c-1270-4563-bf27-767ead688fae",
+                "id": "d80441f4-814b-4732-8d14-1c7b4372cbbb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/network/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3730,7 +3730,7 @@
           }
         },
         {
-          "id": "ae40061b-1161-4f58-9664-73b242c0c41c",
+          "id": "2ba9b91a-74b3-43aa-8dd3-85a17017b848",
           "name": "List campaigns",
           "request": {
             "name": "List campaigns",
@@ -3899,7 +3899,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7c7c2614-fd12-4e77-9978-02d22c534ab9",
+              "id": "be8bccf3-71c0-42b2-9284-bf9b1dd10fce",
               "name": "OK\n\nCampaigns returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4074,14 +4074,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"total\": 1,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"campaign-id\",\n      \"advertiser_id\": \"advertiser-id\",\n      \"name\": \"Campaign Name\",\n      \"status\": \"partial_running\",\n      \"type\": \"on_site\",\n      \"settings\": {\n        \"daily_budget\": 10000,\n        \"cpc\": 250,\n        \"budget_type\": \"evenly\"\n      },\n      \"start_at\": \"2025-01-01T00:00:00.000Z\",\n      \"end_at\": \"2025-01-31T00:00:00.000Z\",\n      \"disabled_at\": null,\n      \"created_at\": \"2025-01-01T07:33:08.482Z\",\n      \"updated_at\": \"2025-01-26T16:16:08.482Z\",\n      \"deleted_at\": null,\n      \"description\": null,\n      \"publisher_id\": \"publisher-id\",\n      \"ad_type\": \"product\",\n      \"cid\": 16674,\n      \"seller_id\": null,\n      \"target\": \"target-name\",\n      \"network_id\": null,\n      \"audience_id\": null,\n      \"targeting_type\": null,\n      \"strategy_type\": \"standard\",\n      \"total_budget\": \"0.0000\",\n      \"active\": true,\n      \"advertiser_name\": \"advertiser name\",\n      \"advertiser_account_id\": \"advertiser-account-id\",\n      \"publisher_name\": \"publisher-name\",\n      \"publisher_account_id\": \"publisher-account-id\",\n      \"consumed_budget\": \"1750.0000\",\n      \"daily_budget\": \"10000.00\",\n      \"campaign_status\": 1,\n      \"advertiser_tags\": null,\n      \"pending\": [],\n      \"metrics\": {\n        \"clicks\": 39,\n        \"conversions\": 4,\n        \"impressions\": 7603,\n        \"views\": 51,\n        \"conversion_rate\": \"10.26\",\n        \"conversion_rate_click\": \"8.50\",\n        \"conversion_rate_view\": \"1.76\",\n        \"ctr\": \".51\",\n        \"roas\": \"2.64\",\n        \"roas_click\": \"1.80\",\n        \"roas_view\": \"0.84\",\n        \"roas_halo\": \"0.95\",\n        \"roas_overall\": \"3.59\",\n        \"adcost\": \"37.87\",\n        \"income\": \"25747.00\",\n        \"total_spent\": \"9750.00\",\n        \"ecpm\": \"3.3864\",\n        \"cpa\": \"2437.50\",\n        \"avg_cpc\": \"250.00\",\n        \"avg_cpm\": \"1282.39\",\n        \"halo_revenue\": \"9260.00\",\n        \"halo_orders\": 2,\n        \"halo_items\": 5\n      }\n    }\n  ]\n}",
+              "body": "{\n  \"total\": 1,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"campaign-id\",\n      \"advertiser_id\": \"advertiser-id\",\n      \"name\": \"Campaign Name\",\n      \"status\": \"partial_running\",\n      \"type\": \"on_site\",\n      \"settings\": {\n        \"daily_budget\": 10000,\n        \"cpc\": 250,\n        \"budget_type\": \"evenly\"\n      },\n      \"start_at\": \"2025-01-01T00:00:00.000Z\",\n      \"end_at\": \"2025-01-31T00:00:00.000Z\",\n      \"disabled_at\": null,\n      \"created_at\": \"2025-01-01T07:33:08.482Z\",\n      \"updated_at\": \"2025-01-26T16:16:08.482Z\",\n      \"deleted_at\": null,\n      \"description\": null,\n      \"publisher_id\": \"publisher-id\",\n      \"ad_type\": \"product\",\n      \"cid\": 16674,\n      \"seller_id\": null,\n      \"target\": \"target-name\",\n      \"network_id\": null,\n      \"audience_id\": null,\n      \"targeting_type\": null,\n      \"strategy_type\": \"standard\",\n      \"total_budget\": \"0.0000\",\n      \"active\": true,\n      \"advertiser_name\": \"advertiser name\",\n      \"advertiser_account_id\": \"advertiser-account-id\",\n      \"publisher_name\": \"publisher-name\",\n      \"publisher_account_id\": \"publisher-account-id\",\n      \"consumed_budget\": \"1750.0000\",\n      \"daily_budget\": \"10000.00\",\n      \"campaign_status\": 1,\n      \"advertiser_tags\": null,\n      \"pending\": [],\n      \"metrics\": {\n        \"clicks\": 39,\n        \"conversions\": 4,\n        \"impressions\": 7603,\n        \"views\": 51,\n        \"conversions_click\": \"3\",\n        \"conversions_view\": \"1\",\n        \"conversion_rate\": \"4.44\",\n        \"conversion_rate_click\": \"7.69\",\n        \"conversion_rate_view\": \"1.96\",\n        \"ctr\": \".51\",\n        \"roas\": \"2.64\",\n        \"roas_click\": \"1.80\",\n        \"roas_view\": \"0.84\",\n        \"roas_halo\": \"0.95\",\n        \"roas_overall\": \"3.59\",\n        \"adcost\": \"37.87\",\n        \"income\": \"25747.00\",\n        \"total_spent\": \"9750.00\",\n        \"ecpm\": \"3.3864\",\n        \"cpa\": \"2437.50\",\n        \"avg_cpc\": \"250.00\",\n        \"avg_cpm\": \"1282.39\",\n        \"halo_revenue\": \"9260.00\",\n        \"halo_orders\": \"2\",\n        \"halo_items\": \"5\"\n      }\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6c910135-d335-49eb-92a2-ef41f8a24aa6",
+              "id": "8442424a-482f-4a20-92da-5ab7716c069b",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4254,13 +4254,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "989ea5a6-d36d-4c17-b7a0-6787246ec163",
+                "id": "e3a7b2b4-86b4-4287-a21a-4ff620da53d5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/campaign/v2 - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/campaign/v2 - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of campaigns.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of campaign objects.\",\"items\":{\"type\":\"object\",\"description\":\"Campaign object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique campaign identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Campaign name.\"},\"status\":{\"type\":\"string\",\"description\":\"Campaign status.\"},\"type\":{\"type\":\"string\",\"description\":\"Campaign type.\"},\"settings\":{\"type\":\"object\",\"description\":\"Campaign settings object. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpc\":{\"type\":\"number\",\"description\":\"Cost per click value.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"start_at\":{\"type\":\"string\",\"description\":\"Campaign start date in ISO 8601 format.\"},\"end_at\":{\"type\":\"string\",\"description\":\"Campaign end date in ISO 8601 format.\"},\"disabled_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign disabled date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Campaign creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Campaign last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign deletion date in ISO 8601 format.\"},\"description\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign description.\"},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"cid\":{\"type\":\"integer\",\"description\":\"Campaign internal ID.\"},\"seller_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Seller identifier (when applicable).\"},\"target\":{\"type\":\"string\",\"description\":\"Campaign target (when applicable).\"},\"network_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Network identifier (when applicable).\"},\"audience_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Audience identifier (when applicable).\"},\"targeting_type\":{\"type\":[\"string\",\"null\"],\"description\":\"Targeting type.\"},\"strategy_type\":{\"type\":\"string\",\"description\":\"Campaign strategy type.\"},\"total_budget\":{\"type\":\"string\",\"description\":\"Total campaign budget.\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the campaign is active.\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"advertiser_account_id\":{\"type\":\"string\",\"description\":\"Advertiser account identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"publisher_account_id\":{\"type\":\"string\",\"description\":\"Publisher account identifier.\"},\"consumed_budget\":{\"type\":\"string\",\"description\":\"Amount of budget consumed.\"},\"daily_budget\":{\"type\":\"string\",\"description\":\"Daily budget amount.\"},\"campaign_status\":{\"type\":\"integer\",\"description\":\"Campaign status code.\"},\"advertiser_tags\":{\"type\":[\"array\",\"null\"],\"description\":\"Tags associated with the advertiser.\",\"items\":{\"type\":\"string\",\"description\":\"Advertiser tag.\"}},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"integer\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"integer\",\"description\":\"Total number of conversions.\"},\"impressions\":{\"type\":\"integer\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"integer\",\"description\":\"Total number of views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Conversion rate percentage.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"integer\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"integer\",\"description\":\"Quantity of halo items sold.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/campaign/v2 - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of campaigns.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of campaign objects.\",\"items\":{\"type\":\"object\",\"description\":\"Campaign object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique campaign identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Campaign name.\"},\"status\":{\"type\":\"string\",\"description\":\"Campaign status.\"},\"type\":{\"type\":\"string\",\"description\":\"Campaign type.\"},\"settings\":{\"type\":\"object\",\"description\":\"Campaign settings object. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpc\":{\"type\":\"number\",\"description\":\"Cost per click value.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"start_at\":{\"type\":\"string\",\"description\":\"Campaign start date in ISO 8601 format.\"},\"end_at\":{\"type\":\"string\",\"description\":\"Campaign end date in ISO 8601 format.\"},\"disabled_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign disabled date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Campaign creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Campaign last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign deletion date in ISO 8601 format.\"},\"description\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign description.\"},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"cid\":{\"type\":\"integer\",\"description\":\"Campaign internal ID.\"},\"seller_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Seller identifier (when applicable).\"},\"target\":{\"type\":\"string\",\"description\":\"Campaign target (when applicable).\"},\"network_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Network identifier (when applicable).\"},\"audience_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Audience identifier (when applicable).\"},\"targeting_type\":{\"type\":[\"string\",\"null\"],\"description\":\"Targeting type.\"},\"strategy_type\":{\"type\":\"string\",\"description\":\"Campaign strategy type.\"},\"total_budget\":{\"type\":\"string\",\"description\":\"Total campaign budget.\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the campaign is active.\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"advertiser_account_id\":{\"type\":\"string\",\"description\":\"Advertiser account identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"publisher_account_id\":{\"type\":\"string\",\"description\":\"Publisher account identifier.\"},\"consumed_budget\":{\"type\":\"string\",\"description\":\"Amount of budget consumed.\"},\"daily_budget\":{\"type\":\"string\",\"description\":\"Daily budget amount.\"},\"campaign_status\":{\"type\":\"integer\",\"description\":\"Campaign status code.\"},\"advertiser_tags\":{\"type\":[\"array\",\"null\"],\"description\":\"Tags associated with the advertiser.\",\"items\":{\"type\":\"string\",\"description\":\"Advertiser tag.\"}},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"integer\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"integer\",\"description\":\"Total number of conversions.\"},\"impressions\":{\"type\":\"integer\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"integer\",\"description\":\"Total number of views.\"},\"conversions_click\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to clicks.\"},\"conversions_view\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Consolidated conversion rate percentage, calculated as total conversions divided by the sum of clicks and views (`total_conversions / (total_clicks + total_views)`). This is the default conversion rate and considers both click- and view-attributed conversions.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only, calculated as `conversions_click / total_clicks`.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only, calculated as `conversions_view / total_views`.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"string\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"string\",\"description\":\"Quantity of halo items sold.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/campaign/v2 - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -4270,7 +4270,7 @@
           }
         },
         {
-          "id": "198ea5a9-a7d8-458f-be9f-957de95f0ce4",
+          "id": "5464550e-02b3-42a0-91d6-5600cb01f219",
           "name": "Get campaign details",
           "request": {
             "name": "Get campaign details",
@@ -4351,7 +4351,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0f99dc02-c13d-41fa-b27a-52b3cb0c87a5",
+              "id": "9fa44671-5c41-4f04-a723-f7591fea4072",
               "name": "OK\n\nCampaign returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4427,14 +4427,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"id\": \"campaign-001\",\n  \"advertiser_id\": \"advertiser-xyz\",\n  \"name\": \"Sample Campaign Name\",\n  \"description\": \"Sample Campaign Description\",\n  \"status\": \"running\",\n  \"type\": \"on_site\",\n  \"settings\": {\n    \"daily_budget\": 10000,\n    \"cpm\": 1000,\n    \"budget_type\": \"evenly\"\n  },\n  \"start_at\": \"2025-01-01T00:00:00.000Z\",\n  \"end_at\": \"2025-01-31T00:00:00.000Z\",\n  \"created_at\": \"2025-07-14T17:14:56.513Z\",\n  \"updated_at\": \"2025-07-14T17:14:56.513Z\",\n  \"deleted_at\": null,\n  \"ad_type\": \"banner\",\n  \"targeting_type\": \"category\",\n  \"strategy_type\": \"standard\",\n  \"total_budget\": \"0.0000\",\n  \"active\": true,\n  \"publisher_id\": \"publisher-id\",\n  \"seller_id\": null,\n  \"target\": \"target-name\",\n  \"network_id\": null,\n  \"audience_id\": null,\n  \"advertiser_name\": \"advertiser-name\",\n  \"advertiser_account_id\": \"advertiser-account-id\",\n  \"publisher_name\": \"publisher-name\",\n  \"publisher_account_id\": \"publisher-account-id\",\n  \"conversions_quantity\": \"82\",\n  \"consumed_budget\": \"36070.0000\",\n  \"pending\": [],\n  \"metrics\": {\n    \"clicks\": 39,\n    \"conversions\": 4,\n    \"impressions\": 7603,\n    \"views\": 51,\n    \"conversion_rate\": \"10.26\",\n    \"conversion_rate_click\": \"8.50\",\n    \"conversion_rate_view\": \"1.76\",\n    \"ctr\": \".51\",\n    \"roas\": \"2.64\",\n    \"roas_click\": \"1.80\",\n    \"roas_view\": \"0.84\",\n    \"roas_halo\": \"0.95\",\n    \"roas_overall\": \"3.59\",\n    \"adcost\": \"37.87\",\n    \"income\": \"25747.00\",\n    \"total_spent\": \"9750.00\",\n    \"ecpm\": \"3.3864\",\n    \"cpa\": \"2437.50\",\n    \"avg_cpc\": \"250.00\",\n    \"avg_cpm\": \"1282.39\",\n    \"halo_revenue\": \"9260.00\",\n    \"halo_orders\": 2,\n    \"halo_items\": 5\n  },\n  \"ads\": [\n    {\n      \"id\": \"ad-001\",\n      \"campaign_id\": \"ab90a43b-582e-4be9-b126-2067dd8f30a3\",\n      \"url\": \"https://example.com\",\n      \"settings\": {\n        \"ad_size\": \"example-size\",\n        \"media_url\": \"https://cdn.example.com/ad-image.jpeg\",\n        \"type\": \"banner\"\n      },\n      \"disabled_at\": null,\n      \"created_at\": \"2025-07-14T17:14:56.513Z\",\n      \"updated_at\": \"2025-07-14T17:14:56.513Z\",\n      \"deleted_at\": null,\n      \"status\": \"enabled\",\n      \"aid\": 255272,\n      \"asset_type\": \"image\",\n      \"active\": true,\n      \"campaign_name\": \"Sample Campaign Name\",\n      \"ad_type\": \"banner\",\n      \"campaign_status\": \"pending_review\",\n      \"is_running\": true,\n      \"campaign_settings\": {\n        \"daily_budget\": 10000,\n        \"cpm\": 1000,\n        \"budget_type\": \"evenly\"\n      },\n      \"metrics\": {\n        \"clicks\": 39,\n        \"conversions\": 4,\n        \"impressions\": 7603,\n        \"views\": 51,\n        \"conversion_rate\": \"10.26\",\n        \"ctr\": \".51\",\n        \"roas\": \"2.64\",\n        \"adcost\": \"37.87\",\n        \"income\": \"25747.00\",\n        \"total_spent\": \"9750.00\",\n        \"ecpm\": \"3.3864\",\n        \"cpa\": \"2437.50\",\n        \"avg_cpc\": \"250.00\",\n        \"avg_cpm\": \"1282.39\"\n      }\n    }\n  ],\n  \"products\": [\n    {\n      \"id\": \"product-001\",\n      \"name\": \"Example Product Name\",\n      \"sku\": \"123456\",\n      \"image_url\": \"https://example.com/product.jpg\"\n    }\n  ],\n  \"status_history\": [\n    {\n      \"id\": \"status-001\",\n      \"status\": \"running\",\n      \"created_at\": \"2025-07-03T22:53:57.272Z\"\n    }\n  ]\n}",
+              "body": "{\n  \"id\": \"campaign-001\",\n  \"advertiser_id\": \"advertiser-xyz\",\n  \"name\": \"Sample Campaign Name\",\n  \"description\": \"Sample Campaign Description\",\n  \"status\": \"running\",\n  \"type\": \"on_site\",\n  \"settings\": {\n    \"daily_budget\": 10000,\n    \"cpm\": 1000,\n    \"budget_type\": \"evenly\"\n  },\n  \"start_at\": \"2025-01-01T00:00:00.000Z\",\n  \"end_at\": \"2025-01-31T00:00:00.000Z\",\n  \"created_at\": \"2025-07-14T17:14:56.513Z\",\n  \"updated_at\": \"2025-07-14T17:14:56.513Z\",\n  \"deleted_at\": null,\n  \"ad_type\": \"banner\",\n  \"targeting_type\": \"category\",\n  \"strategy_type\": \"standard\",\n  \"total_budget\": \"0.0000\",\n  \"active\": true,\n  \"publisher_id\": \"publisher-id\",\n  \"seller_id\": null,\n  \"target\": \"target-name\",\n  \"network_id\": null,\n  \"audience_id\": null,\n  \"advertiser_name\": \"advertiser-name\",\n  \"advertiser_account_id\": \"advertiser-account-id\",\n  \"publisher_name\": \"publisher-name\",\n  \"publisher_account_id\": \"publisher-account-id\",\n  \"conversions_quantity\": \"82\",\n  \"consumed_budget\": \"36070.0000\",\n  \"pending\": [],\n  \"metrics\": {\n    \"clicks\": 39,\n    \"conversions\": 4,\n    \"impressions\": 7603,\n    \"views\": 51,\n    \"conversions_click\": \"3\",\n    \"conversions_view\": \"1\",\n    \"conversion_rate\": \"4.44\",\n    \"conversion_rate_click\": \"7.69\",\n    \"conversion_rate_view\": \"1.96\",\n    \"ctr\": \".51\",\n    \"roas\": \"2.64\",\n    \"roas_click\": \"1.80\",\n    \"roas_view\": \"0.84\",\n    \"roas_halo\": \"0.95\",\n    \"roas_overall\": \"3.59\",\n    \"adcost\": \"37.87\",\n    \"income\": \"25747.00\",\n    \"total_spent\": \"9750.00\",\n    \"ecpm\": \"3.3864\",\n    \"cpa\": \"2437.50\",\n    \"avg_cpc\": \"250.00\",\n    \"avg_cpm\": \"1282.39\",\n    \"halo_revenue\": \"9260.00\",\n    \"halo_orders\": \"2\",\n    \"halo_items\": \"5\"\n  },\n  \"ads\": [\n    {\n      \"id\": \"ad-001\",\n      \"campaign_id\": \"ab90a43b-582e-4be9-b126-2067dd8f30a3\",\n      \"url\": \"https://example.com\",\n      \"settings\": {\n        \"ad_size\": \"example-size\",\n        \"media_url\": \"https://cdn.example.com/ad-image.jpeg\",\n        \"type\": \"banner\"\n      },\n      \"disabled_at\": null,\n      \"created_at\": \"2025-07-14T17:14:56.513Z\",\n      \"updated_at\": \"2025-07-14T17:14:56.513Z\",\n      \"deleted_at\": null,\n      \"status\": \"enabled\",\n      \"aid\": 255272,\n      \"asset_type\": \"image\",\n      \"active\": true,\n      \"campaign_name\": \"Sample Campaign Name\",\n      \"ad_type\": \"banner\",\n      \"campaign_status\": \"pending_review\",\n      \"is_running\": true,\n      \"campaign_settings\": {\n        \"daily_budget\": 10000,\n        \"cpm\": 1000,\n        \"budget_type\": \"evenly\"\n      },\n      \"metrics\": {\n        \"clicks\": 39,\n        \"conversions\": 4,\n        \"impressions\": 7603,\n        \"views\": 51,\n        \"conversion_rate\": \"10.26\",\n        \"ctr\": \".51\",\n        \"roas\": \"2.64\",\n        \"adcost\": \"37.87\",\n        \"income\": \"25747.00\",\n        \"total_spent\": \"9750.00\",\n        \"ecpm\": \"3.3864\",\n        \"cpa\": \"2437.50\",\n        \"avg_cpc\": \"250.00\",\n        \"avg_cpm\": \"1282.39\"\n      }\n    }\n  ],\n  \"products\": [\n    {\n      \"id\": \"product-001\",\n      \"name\": \"Example Product Name\",\n      \"sku\": \"123456\",\n      \"image_url\": \"https://example.com/product.jpg\"\n    }\n  ],\n  \"status_history\": [\n    {\n      \"id\": \"status-001\",\n      \"status\": \"running\",\n      \"created_at\": \"2025-07-03T22:53:57.272Z\"\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "230cd370-3f1c-4fe7-8ec4-d57d61cadebd",
+              "id": "8836d42d-6380-4f06-8dc2-38b5df2926e7",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4507,7 +4507,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c1426835-6e78-4504-a4df-2c95bea9cad6",
+              "id": "515109fc-faba-4c05-93ba-651ffcbf25e8",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
@@ -4581,13 +4581,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "c42fae99-8924-402e-b779-c6795c8e45ab",
+                "id": "13c30550-ee34-489a-a486-5b4cffeaa959",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/campaign/:campaign_id - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/campaign/:campaign_id - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique campaign identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Campaign name.\"},\"description\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign description.\"},\"status\":{\"type\":\"string\",\"description\":\"Campaign status.\"},\"type\":{\"type\":\"string\",\"description\":\"Campaign type.\"},\"settings\":{\"type\":\"object\",\"description\":\"Campaign settings object. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpc\":{\"type\":\"number\",\"description\":\"Cost per click value.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"start_at\":{\"type\":\"string\",\"description\":\"Campaign start date in ISO 8601 format.\"},\"end_at\":{\"type\":\"string\",\"description\":\"Campaign end date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Campaign creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Campaign last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign deletion date in ISO 8601 format.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"targeting_type\":{\"type\":\"string\",\"description\":\"Targeting type.\"},\"strategy_type\":{\"type\":\"string\",\"description\":\"Campaign strategy type.\"},\"total_budget\":{\"type\":\"string\",\"description\":\"Total campaign budget.\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the campaign is active.\"},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"seller_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Seller identifier (when applicable).\"},\"target\":{\"type\":\"string\",\"description\":\"Campaign target (when applicable).\"},\"network_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Network identifier (when applicable).\"},\"audience_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Audience identifier (when applicable).\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"advertiser_account_id\":{\"type\":\"string\",\"description\":\"Advertiser account identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"publisher_account_id\":{\"type\":\"string\",\"description\":\"Publisher account identifier.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of conversions.\"},\"consumed_budget\":{\"type\":\"string\",\"description\":\"Amount of budget consumed.\"},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"integer\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"integer\",\"description\":\"Total number of conversions.\"},\"impressions\":{\"type\":\"integer\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"integer\",\"description\":\"Total number of views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Conversion rate percentage.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"integer\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"integer\",\"description\":\"Quantity of halo items sold.\"}}},\"ads\":{\"type\":\"array\",\"description\":\"Array of ad objects associated with the campaign.\",\"items\":{\"type\":\"object\",\"description\":\"Ad object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique ad identifier.\"},\"campaign_id\":{\"type\":\"string\",\"description\":\"Associated campaign identifier.\"},\"url\":{\"type\":\"string\",\"description\":\"Ad destination URL.\"},\"settings\":{\"type\":\"object\",\"description\":\"Ad-specific settings object. The fields are dynamic and may vary depending on the ad type.\",\"properties\":{\"ad_size\":{\"type\":\"string\",\"description\":\"Ad dimensions/size specification.\"},\"media_url\":{\"type\":\"string\",\"description\":\"URL of the ad media asset.\"},\"type\":{\"type\":\"string\",\"description\":\"Ad type.\"}}},\"disabled_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad disabled date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Ad creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Ad last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad deletion date in ISO 8601 format.\"},\"status\":{\"type\":\"string\",\"description\":\"Ad status.\"},\"aid\":{\"type\":\"integer\",\"description\":\"Ad internal ID.\"},\"asset_type\":{\"type\":\"string\",\"description\":\"Asset type (for example, `image`, `video`).\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the ad is active.\"},\"campaign_name\":{\"type\":\"string\",\"description\":\"Associated campaign name.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"campaign_status\":{\"type\":\"string\",\"description\":\"Associated campaign status.\"},\"is_running\":{\"type\":\"boolean\",\"description\":\"Whether the ad is currently running.\"},\"campaign_settings\":{\"type\":\"object\",\"description\":\"Associated campaign settings. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"metrics\":{\"type\":\"object\",\"description\":\"Ad-specific performance metrics. All metric values are returned as strings regardless of their numeric nature.\"}}}},\"products\":{\"type\":\"array\",\"description\":\"Array of products associated with the campaign.\",\"items\":{\"type\":\"object\",\"description\":\"Product object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"}}}},\"status_history\":{\"type\":\"array\",\"description\":\"Array of status change history.\",\"items\":{\"type\":\"object\",\"description\":\"Status change object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique status change identifier.\"},\"status\":{\"type\":\"string\",\"description\":\"Status value.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Status change date in ISO 8601 format.\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/campaign/:campaign_id - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique campaign identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Campaign name.\"},\"description\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign description.\"},\"status\":{\"type\":\"string\",\"description\":\"Campaign status.\"},\"type\":{\"type\":\"string\",\"description\":\"Campaign type.\"},\"settings\":{\"type\":\"object\",\"description\":\"Campaign settings object. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpc\":{\"type\":\"number\",\"description\":\"Cost per click value.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"start_at\":{\"type\":\"string\",\"description\":\"Campaign start date in ISO 8601 format.\"},\"end_at\":{\"type\":\"string\",\"description\":\"Campaign end date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Campaign creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Campaign last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Campaign deletion date in ISO 8601 format.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"targeting_type\":{\"type\":\"string\",\"description\":\"Targeting type.\"},\"strategy_type\":{\"type\":\"string\",\"description\":\"Campaign strategy type.\"},\"total_budget\":{\"type\":\"string\",\"description\":\"Total campaign budget.\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the campaign is active.\"},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"seller_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Seller identifier (when applicable).\"},\"target\":{\"type\":\"string\",\"description\":\"Campaign target (when applicable).\"},\"network_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Network identifier (when applicable).\"},\"audience_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Audience identifier (when applicable).\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"advertiser_account_id\":{\"type\":\"string\",\"description\":\"Advertiser account identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"publisher_account_id\":{\"type\":\"string\",\"description\":\"Publisher account identifier.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of conversions.\"},\"consumed_budget\":{\"type\":\"string\",\"description\":\"Amount of budget consumed.\"},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"integer\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"integer\",\"description\":\"Total number of conversions.\"},\"impressions\":{\"type\":\"integer\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"integer\",\"description\":\"Total number of views.\"},\"conversions_click\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to clicks.\"},\"conversions_view\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Consolidated conversion rate percentage, calculated as total conversions divided by the sum of clicks and views (`total_conversions / (total_clicks + total_views)`). This is the default conversion rate and considers both click- and view-attributed conversions.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only, calculated as `conversions_click / total_clicks`.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only, calculated as `conversions_view / total_views`.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"string\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"string\",\"description\":\"Quantity of halo items sold.\"}}},\"ads\":{\"type\":\"array\",\"description\":\"Array of ad objects associated with the campaign.\",\"items\":{\"type\":\"object\",\"description\":\"Ad object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique ad identifier.\"},\"campaign_id\":{\"type\":\"string\",\"description\":\"Associated campaign identifier.\"},\"url\":{\"type\":\"string\",\"description\":\"Ad destination URL.\"},\"settings\":{\"type\":\"object\",\"description\":\"Ad-specific settings object. The fields are dynamic and may vary depending on the ad type.\",\"properties\":{\"ad_size\":{\"type\":\"string\",\"description\":\"Ad dimensions/size specification.\"},\"media_url\":{\"type\":\"string\",\"description\":\"URL of the ad media asset.\"},\"type\":{\"type\":\"string\",\"description\":\"Ad type.\"}}},\"disabled_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad disabled date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Ad creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Ad last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad deletion date in ISO 8601 format.\"},\"status\":{\"type\":\"string\",\"description\":\"Ad status.\"},\"aid\":{\"type\":\"integer\",\"description\":\"Ad internal ID.\"},\"asset_type\":{\"type\":\"string\",\"description\":\"Asset type (for example, `image`, `video`).\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the ad is active.\"},\"campaign_name\":{\"type\":\"string\",\"description\":\"Associated campaign name.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"campaign_status\":{\"type\":\"string\",\"description\":\"Associated campaign status.\"},\"is_running\":{\"type\":\"boolean\",\"description\":\"Whether the ad is currently running.\"},\"campaign_settings\":{\"type\":\"object\",\"description\":\"Associated campaign settings. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"metrics\":{\"type\":\"object\",\"description\":\"Ad-specific performance metrics. All metric values are returned as strings regardless of their numeric nature.\"}}}},\"products\":{\"type\":\"array\",\"description\":\"Array of products associated with the campaign.\",\"items\":{\"type\":\"object\",\"description\":\"Product object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"}}}},\"status_history\":{\"type\":\"array\",\"description\":\"Array of status change history.\",\"items\":{\"type\":\"object\",\"description\":\"Status change object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique status change identifier.\"},\"status\":{\"type\":\"string\",\"description\":\"Status value.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Status change date in ISO 8601 format.\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/campaign/:campaign_id - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -4597,7 +4597,7 @@
           }
         },
         {
-          "id": "e8541f19-2f34-481d-96ec-f8607fd46521",
+          "id": "e6c539f0-0628-44c9-9f56-932c43b3c53c",
           "name": "Get advertiser campaigns detailed report",
           "request": {
             "name": "Get advertiser campaigns detailed report",
@@ -4821,7 +4821,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a3abb20f-715e-409c-8ca3-c23826b93762",
+              "id": "2d55871f-f011-4387-83a6-1ac448b7a333",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5051,14 +5051,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"total\": 1,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"campaign-id\",\n      \"advertiser_id\": \"advertiser-id\",\n      \"name\": \"Campaign Name\",\n      \"status\": \"partial_running\",\n      \"type\": \"on_site\",\n      \"publisher_id\": \"publisher-id\",\n      \"publisher_name\": \"Publisher Name\",\n      \"advertiser_name\": \"Advertiser Name\",\n      \"sub_publisher_id\": \"subpublisher-id\",\n      \"sub_publisher_name\": \"Subpublisher Name\",\n      \"active\": true,\n      \"daily_budget\": \"10000.00\",\n      \"consumed_budget\": \"1750.0000\",\n      \"pending\": [],\n      \"metrics\": {\n        \"clicks\": 39,\n        \"conversions\": 4,\n        \"total_conversions_items_quantity\": 7,\n        \"impressions\": 7603,\n        \"views\": 51,\n        \"conversion_rate\": \"10.26\",\n        \"conversion_rate_click\": \"8.50\",\n        \"conversion_rate_view\": \"1.76\",\n        \"ctr\": \".51\",\n        \"roas\": \"2.64\",\n        \"roas_click\": \"1.80\",\n        \"roas_view\": \"0.84\",\n        \"roas_halo\": \"0.95\",\n        \"roas_overall\": \"3.59\",\n        \"adcost\": \"37.87\",\n        \"income\": \"25747.00\",\n        \"total_spent\": \"9750.00\",\n        \"ecpm\": \"3.3864\",\n        \"cpa\": \"2437.50\",\n        \"avg_cpc\": \"250.00\",\n        \"avg_cpm\": \"1282.39\",\n        \"halo_revenue\": \"9260.00\",\n        \"halo_orders\": 2,\n        \"halo_items\": 5\n      }\n    }\n  ]\n}",
+              "body": "{\n  \"total\": 1,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"campaign-id\",\n      \"advertiser_id\": \"advertiser-id\",\n      \"name\": \"Campaign Name\",\n      \"status\": \"partial_running\",\n      \"type\": \"on_site\",\n      \"publisher_id\": \"publisher-id\",\n      \"publisher_name\": \"Publisher Name\",\n      \"advertiser_name\": \"Advertiser Name\",\n      \"sub_publisher_id\": \"subpublisher-id\",\n      \"sub_publisher_name\": \"Subpublisher Name\",\n      \"active\": true,\n      \"daily_budget\": \"10000.00\",\n      \"consumed_budget\": \"1750.0000\",\n      \"pending\": [],\n      \"metrics\": {\n        \"clicks\": 39,\n        \"conversions\": 4,\n        \"total_conversions_items_quantity\": 7,\n        \"impressions\": 7603,\n        \"views\": 51,\n        \"conversions_click\": \"3\",\n        \"conversions_view\": \"1\",\n        \"conversion_rate\": \"4.44\",\n        \"conversion_rate_click\": \"7.69\",\n        \"conversion_rate_view\": \"1.96\",\n        \"ctr\": \".51\",\n        \"roas\": \"2.64\",\n        \"roas_click\": \"1.80\",\n        \"roas_view\": \"0.84\",\n        \"roas_halo\": \"0.95\",\n        \"roas_overall\": \"3.59\",\n        \"adcost\": \"37.87\",\n        \"income\": \"25747.00\",\n        \"total_spent\": \"9750.00\",\n        \"ecpm\": \"3.3864\",\n        \"cpa\": \"2437.50\",\n        \"avg_cpc\": \"250.00\",\n        \"avg_cpm\": \"1282.39\",\n        \"halo_revenue\": \"9260.00\",\n        \"halo_orders\": \"2\",\n        \"halo_items\": \"5\"\n      }\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a5ff834f-7d7f-42a5-a985-1ed1c88b3f2d",
+              "id": "31d3d4b2-dfed-4724-8a84-2ea839fda6b0",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5286,13 +5286,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "67c1aace-3045-4d88-8074-ab05f5f8457b",
+                "id": "f94cdf8c-fc11-40d1-8127-abaa91dd41f3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of campaigns.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of detailed campaign objects.\",\"items\":{\"type\":\"object\",\"description\":\"Detailed campaign object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique campaign identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Campaign name.\"},\"status\":{\"type\":\"string\",\"description\":\"Campaign status.\"},\"type\":{\"type\":\"string\",\"description\":\"Campaign type.\"},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"sub_publisher_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Subpublisher identifier (only present for network campaigns).\"},\"sub_publisher_name\":{\"type\":[\"string\",\"null\"],\"description\":\"Subpublisher name (only present for network campaigns).\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the campaign is active.\"},\"daily_budget\":{\"type\":\"string\",\"description\":\"Daily budget amount.\"},\"consumed_budget\":{\"type\":\"string\",\"description\":\"Amount of budget consumed.\"},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"integer\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"integer\",\"description\":\"Total number of conversions.\"},\"total_conversions_items_quantity\":{\"type\":\"integer\",\"description\":\"Total quantity of converted items.\"},\"impressions\":{\"type\":\"integer\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"integer\",\"description\":\"Total number of views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Conversion rate percentage.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"integer\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"integer\",\"description\":\"Quantity of halo items sold.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of campaigns.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of detailed campaign objects.\",\"items\":{\"type\":\"object\",\"description\":\"Detailed campaign object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique campaign identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"name\":{\"type\":\"string\",\"description\":\"Campaign name.\"},\"status\":{\"type\":\"string\",\"description\":\"Campaign status.\"},\"type\":{\"type\":\"string\",\"description\":\"Campaign type.\"},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"sub_publisher_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Subpublisher identifier (only present for network campaigns).\"},\"sub_publisher_name\":{\"type\":[\"string\",\"null\"],\"description\":\"Subpublisher name (only present for network campaigns).\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the campaign is active.\"},\"daily_budget\":{\"type\":\"string\",\"description\":\"Daily budget amount.\"},\"consumed_budget\":{\"type\":\"string\",\"description\":\"Amount of budget consumed.\"},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"integer\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"integer\",\"description\":\"Total number of conversions.\"},\"total_conversions_items_quantity\":{\"type\":\"integer\",\"description\":\"Total quantity of converted items.\"},\"impressions\":{\"type\":\"integer\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"integer\",\"description\":\"Total number of views.\"},\"conversions_click\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to clicks.\"},\"conversions_view\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Consolidated conversion rate percentage, calculated as total conversions divided by the sum of clicks and views (`total_conversions / (total_clicks + total_views)`). This is the default conversion rate and considers both click- and view-attributed conversions.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only, calculated as `conversions_click / total_clicks`.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only, calculated as `conversions_view / total_views`.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"string\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"string\",\"description\":\"Quantity of halo items sold.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -5302,7 +5302,7 @@
           }
         },
         {
-          "id": "fa40970c-0000-419a-85b8-987cbdde6070",
+          "id": "94d08a70-381e-406e-91ff-f3f04de80880",
           "name": "Get advertiser ads detailed report",
           "request": {
             "name": "Get advertiser ads detailed report",
@@ -5544,7 +5544,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8dca42eb-66ed-424c-becc-5e47a3029c23",
+              "id": "dcc7a4c8-944f-44de-93db-8a4108f9a640",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5799,7 +5799,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b7b98967-3284-495e-8606-60e331a8d0bd",
+              "id": "f91b46ee-8adb-40da-b6af-669c7de5119e",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6045,7 +6045,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f8deadca-22d7-4cc5-a6bb-7501d4f4d1a6",
+                "id": "51a3f363-7e84-44c7-8e2e-3113017af66a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/ads-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6061,7 +6061,7 @@
           }
         },
         {
-          "id": "a9a2f15f-9d43-4427-95e7-bd6c1c514a52",
+          "id": "4ada8b9a-6842-4092-ad21-701cfaabf2bb",
           "name": "Get ads performance report",
           "request": {
             "name": "Get ads performance report",
@@ -6267,7 +6267,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "db35ed9b-c20f-4c82-a8d4-316bcb9e58f7",
+              "id": "e1b51e5a-6eda-4ce6-bed2-ee22c0a59ad9",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -6479,14 +6479,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"total\": 1,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"ad-id\",\n      \"campaign_id\": \"campaign-id\",\n      \"url\": \"ad-url\",\n      \"settings\": {\n        \"cpc\": 1.5,\n        \"type\": \"banner\",\n        \"categories\": [],\n        \"keywords\": [\n          \"keyword\",\n          \"other keyword\"\n        ]\n      },\n      \"disabled_at\": null,\n      \"created_at\": \"2025-01-27T23:18:16.330Z\",\n      \"updated_at\": \"2025-01-27T23:18:16.330Z\",\n      \"deleted_at\": null,\n      \"status\": \"enabled\",\n      \"aid\": 1234,\n      \"asset_type\": \"image\",\n      \"active\": true,\n      \"product_id\": null,\n      \"product_sku\": null,\n      \"name\": null,\n      \"image_url\": null,\n      \"categories\": [\n        \"National Beers\",\n        \"National Beers > Drinks\"\n      ],\n      \"campaign_name\": \"Campaign Name\",\n      \"ad_type\": \"banner\",\n      \"campaign_status\": \"running\",\n      \"campaign_settings\": {\n        \"daily_budget\": 185000,\n        \"cpm\": 10000,\n        \"budget_type\": \"evenly\"\n      },\n      \"publisher_id\": \"publisher-id\",\n      \"advertiser_id\": \"advertiser-id\",\n      \"advertiser_name\": \"Advertiser Name\",\n      \"advertiser_account_id\": \"advertiser-account-id\",\n      \"publisher_name\": \"Publisher Name\",\n      \"publisher_account_id\": \"publisher-account-id\",\n      \"ad_id\": \"ad-id\",\n      \"conversions_quantity\": \"1\",\n      \"is_running\": true,\n      \"advertiser_tags\": null,\n      \"pending\": [],\n      \"metrics\": {\n        \"clicks\": \"53\",\n        \"conversions\": \"1\",\n        \"total_conversions_items_quantity\": \"1\",\n        \"impressions\": \"2900\",\n        \"views\": \"2689\",\n        \"conversion_rate\": \"1.89\",\n        \"conversion_rate_click\": \"1.20\",\n        \"conversion_rate_view\": \"0.69\",\n        \"ctr\": \"1.83\",\n        \"roas\": \"0.18\",\n        \"roas_click\": \"0.12\",\n        \"roas_view\": \"0.06\",\n        \"roas_halo\": \"0.07\",\n        \"roas_overall\": \"0.25\",\n        \"adcost\": \"540.94\",\n        \"income\": \"5361.00\",\n        \"total_spent\": \"29000.0000\",\n        \"ecpm\": \"1.85\",\n        \"cpa\": \"29000.00\",\n        \"avg_cpc\": \"547.17\",\n        \"avg_cpm\": \"10000.00\",\n        \"halo_revenue\": \"2100.00\",\n        \"halo_orders\": \"1\",\n        \"halo_items\": \"2\"\n      }\n    }\n  ]\n}",
+              "body": "{\n  \"total\": 1,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"ad-id\",\n      \"campaign_id\": \"campaign-id\",\n      \"url\": \"ad-url\",\n      \"settings\": {\n        \"cpc\": 1.5,\n        \"type\": \"banner\",\n        \"categories\": [],\n        \"keywords\": [\n          \"keyword\",\n          \"other keyword\"\n        ]\n      },\n      \"disabled_at\": null,\n      \"created_at\": \"2025-01-27T23:18:16.330Z\",\n      \"updated_at\": \"2025-01-27T23:18:16.330Z\",\n      \"deleted_at\": null,\n      \"status\": \"enabled\",\n      \"aid\": 1234,\n      \"asset_type\": \"image\",\n      \"active\": true,\n      \"product_id\": null,\n      \"product_sku\": null,\n      \"name\": null,\n      \"image_url\": null,\n      \"categories\": [\n        \"National Beers\",\n        \"National Beers > Drinks\"\n      ],\n      \"campaign_name\": \"Campaign Name\",\n      \"ad_type\": \"banner\",\n      \"campaign_status\": \"running\",\n      \"campaign_settings\": {\n        \"daily_budget\": 185000,\n        \"cpm\": 10000,\n        \"budget_type\": \"evenly\"\n      },\n      \"publisher_id\": \"publisher-id\",\n      \"advertiser_id\": \"advertiser-id\",\n      \"advertiser_name\": \"Advertiser Name\",\n      \"advertiser_account_id\": \"advertiser-account-id\",\n      \"publisher_name\": \"Publisher Name\",\n      \"publisher_account_id\": \"publisher-account-id\",\n      \"ad_id\": \"ad-id\",\n      \"conversions_quantity\": \"1\",\n      \"is_running\": true,\n      \"advertiser_tags\": null,\n      \"pending\": [],\n      \"metrics\": {\n        \"clicks\": \"53\",\n        \"conversions\": \"1\",\n        \"total_conversions_items_quantity\": \"1\",\n        \"impressions\": \"2900\",\n        \"views\": \"2689\",\n        \"conversions_click\": \"1\",\n        \"conversions_view\": \"0\",\n        \"conversion_rate\": \"0.04\",\n        \"conversion_rate_click\": \"1.89\",\n        \"conversion_rate_view\": \"0.00\",\n        \"ctr\": \"1.83\",\n        \"roas\": \"0.18\",\n        \"roas_click\": \"0.12\",\n        \"roas_view\": \"0.06\",\n        \"roas_halo\": \"0.07\",\n        \"roas_overall\": \"0.25\",\n        \"adcost\": \"540.94\",\n        \"income\": \"5361.00\",\n        \"total_spent\": \"29000.0000\",\n        \"ecpm\": \"1.85\",\n        \"cpa\": \"29000.00\",\n        \"avg_cpc\": \"547.17\",\n        \"avg_cpm\": \"10000.00\",\n        \"halo_revenue\": \"2100.00\",\n        \"halo_orders\": \"1\",\n        \"halo_items\": \"2\"\n      }\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "227b0e2f-6f24-44bf-a35a-774f3dd34242",
+              "id": "98368038-53b5-4336-9b47-daf673c72afe",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6696,13 +6696,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "ca83411b-b443-4485-b16d-383b71ab14dc",
+                "id": "b97d193a-4569-4d11-b0f1-321386c25176",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/ad/results/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/ad/results/v2 - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/ad/results/v2 - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of ads.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of ad objects.\",\"items\":{\"type\":\"object\",\"description\":\"Ad object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique ad identifier.\"},\"campaign_id\":{\"type\":\"string\",\"description\":\"Associated campaign identifier.\"},\"url\":{\"type\":\"string\",\"description\":\"Ad destination URL.\"},\"settings\":{\"type\":\"object\",\"description\":\"Ad-specific settings object. The fields are dynamic and may vary depending on the ad type.\",\"properties\":{\"cpc\":{\"type\":\"number\",\"description\":\"Cost per click value.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"type\":{\"type\":\"string\",\"description\":\"Ad type.\"},\"categories\":{\"type\":\"array\",\"description\":\"Targeted categories array.\",\"items\":{\"type\":\"string\",\"description\":\"Category name.\"}},\"keywords\":{\"type\":\"array\",\"description\":\"Targeted keywords array.\",\"items\":{\"type\":\"string\",\"description\":\"Keyword.\"}}}},\"disabled_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad disabled date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Ad creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Ad last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad deletion date in ISO 8601 format.\"},\"status\":{\"type\":\"string\",\"description\":\"Ad status.\"},\"aid\":{\"type\":\"integer\",\"description\":\"Ad internal ID.\"},\"asset_type\":{\"type\":\"string\",\"description\":\"Asset type (for example, `image`, `video`).\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the ad is active.\"},\"product_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Associated product identifier (when applicable).\"},\"product_sku\":{\"type\":[\"string\",\"null\"],\"description\":\"Associated product SKU (when applicable).\"},\"name\":{\"type\":[\"string\",\"null\"],\"description\":\"Product name (when applicable).\"},\"image_url\":{\"type\":[\"string\",\"null\"],\"description\":\"Product image URL (when applicable).\"},\"categories\":{\"type\":\"array\",\"description\":\"Ad categories array (when applicable).\",\"items\":{\"type\":\"string\",\"description\":\"Category name.\"}},\"campaign_name\":{\"type\":\"string\",\"description\":\"Associated campaign name.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"campaign_status\":{\"type\":\"string\",\"description\":\"Associated campaign status.\"},\"campaign_settings\":{\"type\":\"object\",\"description\":\"Associated campaign settings. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"advertiser_account_id\":{\"type\":\"string\",\"description\":\"Advertiser account identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"publisher_account_id\":{\"type\":\"string\",\"description\":\"Publisher account identifier.\"},\"ad_id\":{\"type\":\"string\",\"description\":\"Unique identifier of the ad.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of conversions.\"},\"is_running\":{\"type\":\"boolean\",\"description\":\"Whether the ad is currently running.\"},\"advertiser_tags\":{\"type\":[\"array\",\"null\"],\"description\":\"Tags associated with the advertiser.\",\"items\":{\"type\":\"string\",\"description\":\"Advertiser tag.\"}},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Ad performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversions.\"},\"total_conversions_items_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all ad-driven conversions. Sums the quantities of every item in each conversion event (for example, if a shopper buys two units of a product after clicking an ad, this metric increases by 2).\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Conversion rate percentage.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"string\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"string\",\"description\":\"Quantity of halo items sold.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/ad/results/v2 - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of ads.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of ad objects.\",\"items\":{\"type\":\"object\",\"description\":\"Ad object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique ad identifier.\"},\"campaign_id\":{\"type\":\"string\",\"description\":\"Associated campaign identifier.\"},\"url\":{\"type\":\"string\",\"description\":\"Ad destination URL.\"},\"settings\":{\"type\":\"object\",\"description\":\"Ad-specific settings object. The fields are dynamic and may vary depending on the ad type.\",\"properties\":{\"cpc\":{\"type\":\"number\",\"description\":\"Cost per click value.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"type\":{\"type\":\"string\",\"description\":\"Ad type.\"},\"categories\":{\"type\":\"array\",\"description\":\"Targeted categories array.\",\"items\":{\"type\":\"string\",\"description\":\"Category name.\"}},\"keywords\":{\"type\":\"array\",\"description\":\"Targeted keywords array.\",\"items\":{\"type\":\"string\",\"description\":\"Keyword.\"}}}},\"disabled_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad disabled date in ISO 8601 format.\"},\"created_at\":{\"type\":\"string\",\"description\":\"Ad creation date in ISO 8601 format.\"},\"updated_at\":{\"type\":\"string\",\"description\":\"Ad last update date in ISO 8601 format.\"},\"deleted_at\":{\"type\":[\"string\",\"null\"],\"description\":\"Ad deletion date in ISO 8601 format.\"},\"status\":{\"type\":\"string\",\"description\":\"Ad status.\"},\"aid\":{\"type\":\"integer\",\"description\":\"Ad internal ID.\"},\"asset_type\":{\"type\":\"string\",\"description\":\"Asset type (for example, `image`, `video`).\"},\"active\":{\"type\":\"boolean\",\"description\":\"Whether the ad is active.\"},\"product_id\":{\"type\":[\"string\",\"null\"],\"description\":\"Associated product identifier (when applicable).\"},\"product_sku\":{\"type\":[\"string\",\"null\"],\"description\":\"Associated product SKU (when applicable).\"},\"name\":{\"type\":[\"string\",\"null\"],\"description\":\"Product name (when applicable).\"},\"image_url\":{\"type\":[\"string\",\"null\"],\"description\":\"Product image URL (when applicable).\"},\"categories\":{\"type\":\"array\",\"description\":\"Ad categories array (when applicable).\",\"items\":{\"type\":\"string\",\"description\":\"Category name.\"}},\"campaign_name\":{\"type\":\"string\",\"description\":\"Associated campaign name.\"},\"ad_type\":{\"type\":\"string\",\"description\":\"Advertisement type.\"},\"campaign_status\":{\"type\":\"string\",\"description\":\"Associated campaign status.\"},\"campaign_settings\":{\"type\":\"object\",\"description\":\"Associated campaign settings. The fields are dynamic and may vary depending on the campaign type.\",\"properties\":{\"daily_budget\":{\"type\":\"number\",\"description\":\"Daily budget amount.\",\"format\":\"double\"},\"cpm\":{\"type\":\"number\",\"description\":\"Cost per mille value.\",\"format\":\"double\"},\"budget_type\":{\"type\":\"string\",\"description\":\"Budget distribution type.\"}}},\"publisher_id\":{\"type\":\"string\",\"description\":\"Publisher identifier.\"},\"advertiser_id\":{\"type\":\"string\",\"description\":\"Advertiser identifier.\"},\"advertiser_name\":{\"type\":\"string\",\"description\":\"Advertiser name.\"},\"advertiser_account_id\":{\"type\":\"string\",\"description\":\"Advertiser account identifier.\"},\"publisher_name\":{\"type\":\"string\",\"description\":\"Publisher name.\"},\"publisher_account_id\":{\"type\":\"string\",\"description\":\"Publisher account identifier.\"},\"ad_id\":{\"type\":\"string\",\"description\":\"Unique identifier of the ad.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of conversions.\"},\"is_running\":{\"type\":\"boolean\",\"description\":\"Whether the ad is currently running.\"},\"advertiser_tags\":{\"type\":[\"array\",\"null\"],\"description\":\"Tags associated with the advertiser.\",\"items\":{\"type\":\"string\",\"description\":\"Advertiser tag.\"}},\"pending\":{\"type\":\"array\",\"description\":\"Pending operations awaiting review for this campaign/ad. Empty when there is nothing pending.\",\"items\":{\"type\":\"object\",\"description\":\"Pending operation entry, grouping a `label` with its `quantity`.\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Type of pending operation. Currently, only `ads` is returned, indicating ads awaiting review.\",\"enum\":[\"ads\"]},\"quantity\":{\"type\":\"integer\",\"description\":\"Number of pending items of the given `label`.\"}}}},\"metrics\":{\"type\":\"object\",\"description\":\"Ad performance metrics object. All metric values are returned as strings regardless of their numeric nature.\",\"properties\":{\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversions.\"},\"total_conversions_items_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all ad-driven conversions. Sums the quantities of every item in each conversion event (for example, if a shopper buys two units of a product after clicking an ad, this metric increases by 2).\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of impressions.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of views.\"},\"conversions_click\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to clicks.\"},\"conversions_view\":{\"type\":\"string\",\"description\":\"Number of conversions attributed to views.\"},\"conversion_rate\":{\"type\":\"string\",\"description\":\"Consolidated conversion rate percentage, calculated as total conversions divided by the sum of clicks and views (`total_conversions / (total_clicks + total_views)`). This is the default conversion rate and considers both click- and view-attributed conversions.\"},\"conversion_rate_click\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering click-attributed conversions only, calculated as `conversions_click / total_clicks`.\"},\"conversion_rate_view\":{\"type\":\"string\",\"description\":\"Conversion rate percentage considering view-attributed conversions only, calculated as `conversions_view / total_views`.\"},\"ctr\":{\"type\":\"string\",\"description\":\"Click-through rate percentage.\"},\"roas\":{\"type\":\"string\",\"description\":\"Consolidated return on ad spend, combining click- and view-attributed revenue across all ad formats.\"},\"roas_click\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using click-attributed revenue only.\"},\"roas_view\":{\"type\":\"string\",\"description\":\"Return on ad spend calculated using view-attributed revenue only.\"},\"roas_halo\":{\"type\":\"string\",\"description\":\"Halo return on ad spend: incremental revenue from non-advertised products purchased in the same order as advertised products (the halo effect), divided by ad spend.\"},\"roas_overall\":{\"type\":\"string\",\"description\":\"Total return on ad spend, combining direct revenue from the advertised product with halo revenue from other products in the same order, divided by the ad investment. Measures the campaign's total impact on the whole order.\"},\"adcost\":{\"type\":\"string\",\"description\":\"Ad cost percentage.\"},\"income\":{\"type\":\"string\",\"description\":\"Total income generated.\"},\"total_spent\":{\"type\":\"string\",\"description\":\"Total amount spent.\"},\"ecpm\":{\"type\":\"string\",\"description\":\"Effective cost per mille (CPM).\"},\"cpa\":{\"type\":\"string\",\"description\":\"Cost per acquisition.\"},\"avg_cpc\":{\"type\":\"string\",\"description\":\"Average cost per click.\"},\"avg_cpm\":{\"type\":\"string\",\"description\":\"Average cost per mille.\"},\"halo_revenue\":{\"type\":\"string\",\"description\":\"Incremental revenue from non-advertised products that were purchased in the same order as an advertised product, attributed to the ad's spillover (halo) effect.\"},\"halo_orders\":{\"type\":\"string\",\"description\":\"Number of orders with at least one halo item.\"},\"halo_items\":{\"type\":\"string\",\"description\":\"Quantity of halo items sold.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/ad/results/v2 - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -6715,7 +6715,7 @@
       "event": []
     },
     {
-      "id": "e12ecff5-3550-43d9-8ad8-7969e9f3de49",
+      "id": "0d4ca497-5752-4aa9-9fe3-6869b30475c1",
       "name": "Credit transfer",
       "description": {
         "content": "",
@@ -6723,7 +6723,7 @@
       },
       "item": [
         {
-          "id": "0eb19684-56fe-4dc0-bc46-c147411cfd23",
+          "id": "9865cd77-9ac2-4cb9-aae0-22aefcfd0270",
           "name": "Notify credit transfer status",
           "request": {
             "name": "Notify credit transfer status",
@@ -6816,7 +6816,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1f81d61b-8245-4b9a-a8ed-f3eb82d6760f",
+              "id": "1bb17990-20c2-4499-9b29-6db66f07d768",
               "name": "No Content\n\nNotification accepted.",
               "originalRequest": {
                 "url": {
@@ -6885,7 +6885,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "24d3c1c2-26ea-4fcb-b16c-244dd4a620cf",
+              "id": "d48b5539-d88c-4f55-8bb3-45167de6c805",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6955,7 +6955,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "660612ed-3977-4fe3-8799-f5aa61770757",
+                "id": "2b193b76-ec00-497e-9e5c-9cb5b804bbec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/webhook/marketplace/transfers/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6972,7 +6972,7 @@
       "event": []
     },
     {
-      "id": "d8f425ad-b4e3-4ce2-a5fa-a535d5cd9b5a",
+      "id": "14973168-37ad-45ab-bbca-81467cfd5f46",
       "name": "Single sign-on",
       "description": {
         "content": "",
@@ -6980,7 +6980,7 @@
       },
       "item": [
         {
-          "id": "32603eb9-e27f-4af3-990e-ad653f014454",
+          "id": "c756bab2-e562-4bbb-92cf-9932326b6d92",
           "name": "Generate seller single sign-on URL",
           "request": {
             "name": "Generate seller single sign-on URL",
@@ -7044,7 +7044,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "88d5c987-a240-4833-8541-6479ab01942d",
+              "id": "278ba1a9-ac8f-48de-a2a3-ffcf7ddbe66b",
               "name": "OK\n\nRedirect URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -7121,7 +7121,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fe4dfaf3-1bf5-4092-9b0a-b546766da53a",
+              "id": "44014e1c-7b2d-4b5f-b453-5f6186c6a330",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -7189,7 +7189,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "47c70e91-a0d0-4adb-b2f9-2a7e70b1c421",
+                "id": "84ddc5ec-8ca7-4df2-a1d6-86f15adeeed7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/sso/marketplace - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7237,7 +7237,7 @@
     }
   ],
   "info": {
-    "_postman_id": "de19b574-7025-466b-a759-ed0062948d7f",
+    "_postman_id": "0eb8b10b-41b2-48cc-9715-67164d40d51b",
     "name": "VTEX Ads API",
     "version": {
       "raw": "1.0.0",

--- a/VTEX - Ads API.json
+++ b/VTEX - Ads API.json
@@ -352,7 +352,7 @@
                     "Ads events notification"
                 ],
                 "summary": "Track ad impressions",
-                "description": "Track when an ad is rendered or visible to a user. The event URL must not be constructed manually — always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Track when an ad is rendered on a page. An impression does not determine whether the ad became visible to the user. Visibility is tracked by the separate `view` event. Do not construct the event URL manually. Always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n>ℹ️ Fire this event whenever a page loads that contains rendered ads.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -600,7 +600,7 @@
                     "Ads events notification"
                 ],
                 "summary": "Track ad views",
-                "description": "Track views for banner ads. The event URL must not be constructed manually — always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Track when an ad becomes visible to the user. Do not construct the event URL manually. Always use the URL provided from `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\r\n\r\n>ℹ️ Fire this event when the ad occupies at least 50% of the viewport for at least 1 second.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -724,7 +724,7 @@
                     "Ads events notification"
                 ],
                 "summary": "Track conversions",
-                "description": "Track when an ad leads to a purchase. This endpoint is used to notify one or more orders (sending them in a batch).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Track completed sales for conversion attribution. Send this event for every completed sale, regardless of whether an ad led to the purchase. Notifying all sales enables attribution within time windows after ad-impacted navigation and metrics such as assisted sales. Send one or more orders in a batch request.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"


### PR DESCRIPTION
Clarifies the descriptions for three Ads API event notification endpoints to distinguish impression vs view semantics and improve conversion tracking guidance.

## Changes

- **Track ad impressions**: Clarifies that impressions track rendering on page load, not user visibility (which is handled by the separate `view` event).
- **Track ad views**: Clarifies visibility criteria (50% of viewport for at least 1 second) and when to fire the event.
- **Track conversions**: Expands guidance to send conversion events for all completed sales to enable attribution and assisted sales metrics.

## Related Task

[EDU-18790](https://vtex-dev.atlassian.net/browse/EDU-18790)


[EDU-18790]: https://vtex-dev.atlassian.net/browse/EDU-18790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ