### PR TITLE
fix: update authenticator routes to v1

### DIFF
--- a/PostmanCollections/VTEX - B2B Buyer Data API.json
+++ b/PostmanCollections/VTEX - B2B Buyer Data API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "eaf08468-f1e8-41ce-a946-316c74db37a2"
+    "postman_id": "e895265e-59b6-46f9-8569-0438814d15cd"
   },
   "item": [
     {
-      "id": "8faa2c79-86b0-4766-9c0b-f796ad3c4325",
+      "id": "b306896c-a885-4e1a-b294-64b6b574696f",
       "name": "Buyer data",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "2370c5ee-4f1e-4612-851c-6bc3d256b738",
+          "id": "c8ee6fa8-2928-458b-af7d-11a71102efa7",
           "name": "Get buyer schema",
           "request": {
             "name": "Get buyer schema",
@@ -86,7 +86,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a0816948-64ad-4508-8e97-f6f9d93c4eaf",
+              "id": "1755a314-3a12-4e16-ba82-d46a2929d066",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -154,7 +154,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "60cedc35-68e2-4a17-885f-8b5450eb5c20",
+                "id": "2aeb3c54-8532-4384-bd1c-37e8aea11001",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/schemas/v1 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -170,7 +170,7 @@
           }
         },
         {
-          "id": "821668fb-abdc-49ed-abe9-257890d71f23",
+          "id": "1e91ac44-cca4-43f9-aec9-7c062aa7035c",
           "name": "Create buyer",
           "request": {
             "name": "Create buyer",
@@ -266,7 +266,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5d6189bf-a742-40e5-a7af-18ebd64b403b",
+              "id": "9288a71e-4de1-407f-9a53-979fcf5ca57f",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -356,7 +356,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6d15215c-d48e-4405-be86-f8075064aa84",
+                "id": "8f57e3f3-64cd-49cd-a980-21dac060ab89",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/shopper/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -372,7 +372,7 @@
           }
         },
         {
-          "id": "ef996798-0a5c-4d83-b878-8c4ef17ca470",
+          "id": "36d4e368-c01a-4437-9867-ab2344bfa60c",
           "name": "Get buyer by ID",
           "request": {
             "name": "Get buyer by ID",
@@ -396,7 +396,7 @@
                 {
                   "disabled": false,
                   "description": {
-                    "content": "(Required) Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users).",
+                    "content": "(Required) Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users).",
                     "type": "text/plain"
                   },
                   "type": "any",
@@ -457,7 +457,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b4f0c93b-9f8c-49a3-a907-87fb6a2afb86",
+              "id": "bedad18d-38f9-4003-b2ac-9614b9dcbdd1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -525,13 +525,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "9720db31-81d7-4bf0-af3d-20e665956a47",
+                "id": "80987030-e138-40b7-9670-1919bda32068",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/dataentities/shopper/documents/:buyerId - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/api/dataentities/shopper/documents/:buyerId - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"description\":\"Buyer document. May include additional properties beyond the standard schema if they were previously stored.\",\"properties\":{\"userId\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users).\"},\"email\":{\"type\":\"string\",\"description\":\"Buyer's email.\"},\"firstName\":{\"type\":\"string\",\"description\":\"Buyer's first name.\"},\"lastName\":{\"type\":\"string\",\"description\":\"Buyer's last name.\"},\"document\":{\"type\":\"string\",\"description\":\"Buyer's document number (e.g., CPF number).\"},\"documentType\":{\"type\":\"string\",\"description\":\"Type of the document provided (e.g., `cpf`).\"},\"phone\":{\"type\":\"string\",\"description\":\"Buyer's phone number.\"},\"cards\":{\"type\":\"array\",\"description\":\"List of cards associated with the buyer. This field is used by the checkout module.\",\"items\":{\"type\":\"object\",\"description\":\"Credit card information.\",\"properties\":{\"cardId\":{\"type\":\"string\",\"description\":\"Unique identifier of the saved card.\"},\"paymentSystem\":{\"type\":\"string\",\"description\":\"Code representing the payment system (e.g., `2` for Visa).\"},\"paymentSystemName\":{\"type\":\"string\",\"description\":\"Name of the payment system (e.g., `Visa`).\"},\"cardNumber\":{\"type\":\"string\",\"description\":\"Masked credit card number.\"},\"bin\":{\"type\":\"string\",\"description\":\"Bank Identification Number - the first digits of the card.\"},\"expirationDate\":{\"type\":\"string\",\"description\":\"Expiry date of the card in `MM/YYYY` format.\"},\"useCvvForAuthorization\":{\"type\":\"boolean\",\"description\":\"Indicates if CVV is required for authorization.\"},\"cardLabel\":{\"type\":\"string\",\"description\":\"Label or nickname for the card.\"},\"isCardToken\":{\"type\":\"boolean\",\"description\":\"Indicates whether the card data is tokenized.\"},\"availableAddresses\":{\"type\":\"array\",\"description\":\"Array of address IDs the card is associated with.\",\"items\":{\"type\":\"string\",\"description\":\"Address identifier.\"}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/dataentities/shopper/documents/:buyerId - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"description\":\"Buyer document. May include additional properties beyond the standard schema if they were previously stored.\",\"properties\":{\"userId\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users).\"},\"email\":{\"type\":\"string\",\"description\":\"Buyer's email.\"},\"firstName\":{\"type\":\"string\",\"description\":\"Buyer's first name.\"},\"lastName\":{\"type\":\"string\",\"description\":\"Buyer's last name.\"},\"document\":{\"type\":\"string\",\"description\":\"Buyer's document number (e.g., CPF number).\"},\"documentType\":{\"type\":\"string\",\"description\":\"Type of the document provided (e.g., `cpf`).\"},\"phone\":{\"type\":\"string\",\"description\":\"Buyer's phone number.\"},\"cards\":{\"type\":\"array\",\"description\":\"List of cards associated with the buyer. This field is used by the checkout module.\",\"items\":{\"type\":\"object\",\"description\":\"Credit card information.\",\"properties\":{\"cardId\":{\"type\":\"string\",\"description\":\"Unique identifier of the saved card.\"},\"paymentSystem\":{\"type\":\"string\",\"description\":\"Code representing the payment system (e.g., `2` for Visa).\"},\"paymentSystemName\":{\"type\":\"string\",\"description\":\"Name of the payment system (e.g., `Visa`).\"},\"cardNumber\":{\"type\":\"string\",\"description\":\"Masked credit card number.\"},\"bin\":{\"type\":\"string\",\"description\":\"Bank Identification Number - the first digits of the card.\"},\"expirationDate\":{\"type\":\"string\",\"description\":\"Expiry date of the card in `MM/YYYY` format.\"},\"useCvvForAuthorization\":{\"type\":\"boolean\",\"description\":\"Indicates if CVV is required for authorization.\"},\"cardLabel\":{\"type\":\"string\",\"description\":\"Label or nickname for the card.\"},\"isCardToken\":{\"type\":\"boolean\",\"description\":\"Indicates whether the card data is tokenized.\"},\"availableAddresses\":{\"type\":\"array\",\"description\":\"Array of address IDs the card is associated with.\",\"items\":{\"type\":\"string\",\"description\":\"Address identifier.\"}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/dataentities/shopper/documents/:buyerId - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -541,7 +541,7 @@
           }
         },
         {
-          "id": "8508930e-7edf-4840-af57-d64ee37a4e5b",
+          "id": "160c7fa4-be40-4106-abb3-009975eb9f5f",
           "name": "Update buyer",
           "request": {
             "name": "Update buyer",
@@ -565,7 +565,7 @@
                 {
                   "disabled": false,
                   "description": {
-                    "content": "(Required) Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users).",
+                    "content": "(Required) Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users).",
                     "type": "text/plain"
                   },
                   "type": "any",
@@ -626,7 +626,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0bcc4ee1-34d9-40d6-b889-e7788e799775",
+              "id": "02428ab6-286e-4c1a-b9f9-3847285ef6cd",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -688,7 +688,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e8e7f2bd-04ee-4120-9da0-d2b8064b8528",
+                "id": "ce859a3a-8b48-41c3-9784-d066d5e9218d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -702,7 +702,7 @@
           }
         },
         {
-          "id": "182a93ff-db05-43fa-a14c-dfafd96da938",
+          "id": "6706edf0-7227-4267-a969-a92262917820",
           "name": "Delete buyer",
           "request": {
             "name": "Delete buyer",
@@ -726,7 +726,7 @@
                 {
                   "disabled": false,
                   "description": {
-                    "content": "(Required) Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users).",
+                    "content": "(Required) Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users).",
                     "type": "text/plain"
                   },
                   "type": "any",
@@ -783,7 +783,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3543189a-852a-4fb9-8d50-d1d78aaf2bba",
+              "id": "bec5c0d8-4903-45b7-90c6-f4ec82bf389f",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -840,7 +840,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f3228230-4f3b-4767-a315-1aef8e5e1d4b",
+              "id": "8dcd4e0e-fd15-4fec-961e-2d15bc44494b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "71e9baa8-3b19-492a-adad-be8a498e2ee7",
+                "id": "7e8c27e2-a337-45c6-9044-b19103ab2bd0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -911,7 +911,7 @@
           }
         },
         {
-          "id": "728066a9-ea52-4362-a8cb-e32efbc4ff63",
+          "id": "1adb5b9e-3da0-45b5-ade3-fa131d1c09ff",
           "name": "Search buyers",
           "request": {
             "name": "Search buyers",
@@ -933,7 +933,7 @@
                 {
                   "disabled": true,
                   "description": {
-                    "content": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users). Use the `userId={{userId}}` value.",
+                    "content": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users). Use the `userId={{userId}}` value.",
                     "type": "text/plain"
                   },
                   "key": "_where",
@@ -1003,7 +1003,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "74078701-dcda-4681-bde5-9b3a4ffb6816",
+              "id": "2e319e5f-238c-4d44-863f-d1f14516288e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1020,7 +1020,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users). Use the `userId={{userId}}` value.",
+                        "content": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users). Use the `userId={{userId}}` value.",
                         "type": "text/plain"
                       },
                       "key": "_where",
@@ -1089,13 +1089,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "575d175b-843b-4322-898d-a0f49b2f90f4",
+                "id": "2e9c05ae-52af-44d4-82eb-8a487d46180b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/dataentities/shopper/search - Content-Type is application/vnd.vtex.create-budget+json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/vnd.vtex.create-budget+json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/api/dataentities/shopper/search - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"Buyer document. May include additional properties beyond the standard schema if they were previously stored.\",\"properties\":{\"userId\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users).\"},\"email\":{\"type\":\"string\",\"description\":\"Buyer's email.\"},\"firstName\":{\"type\":\"string\",\"description\":\"Buyer's first name.\"},\"lastName\":{\"type\":\"string\",\"description\":\"Buyer's last name.\"},\"document\":{\"type\":\"string\",\"description\":\"Buyer's document number (e.g., CPF number).\"},\"documentType\":{\"type\":\"string\",\"description\":\"Type of the document provided (e.g., `cpf`).\"},\"phone\":{\"type\":\"string\",\"description\":\"Buyer's phone number.\"},\"cards\":{\"type\":\"array\",\"description\":\"List of cards associated with the buyer. This field is used by the checkout module.\",\"items\":{\"type\":\"object\",\"description\":\"Credit card information.\",\"properties\":{\"cardId\":{\"type\":\"string\",\"description\":\"Unique identifier of the saved card.\"},\"paymentSystem\":{\"type\":\"string\",\"description\":\"Code representing the payment system (e.g., `2` for Visa).\"},\"paymentSystemName\":{\"type\":\"string\",\"description\":\"Name of the payment system (e.g., `Visa`).\"},\"cardNumber\":{\"type\":\"string\",\"description\":\"Masked credit card number.\"},\"bin\":{\"type\":\"string\",\"description\":\"Bank Identification Number - the first digits of the card.\"},\"expirationDate\":{\"type\":\"string\",\"description\":\"Expiry date of the card in `MM/YYYY` format.\"},\"useCvvForAuthorization\":{\"type\":\"boolean\",\"description\":\"Indicates if CVV is required for authorization.\"},\"cardLabel\":{\"type\":\"string\",\"description\":\"Label or nickname for the card.\"},\"isCardToken\":{\"type\":\"boolean\",\"description\":\"Indicates whether the card data is tokenized.\"},\"availableAddresses\":{\"type\":\"array\",\"description\":\"Array of address IDs the card is associated with.\",\"items\":{\"type\":\"string\",\"description\":\"Address identifier.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/dataentities/shopper/search - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"Buyer document. May include additional properties beyond the standard schema if they were previously stored.\",\"properties\":{\"userId\":{\"type\":\"string\",\"format\":\"uuid\",\"description\":\"Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users).\"},\"email\":{\"type\":\"string\",\"description\":\"Buyer's email.\"},\"firstName\":{\"type\":\"string\",\"description\":\"Buyer's first name.\"},\"lastName\":{\"type\":\"string\",\"description\":\"Buyer's last name.\"},\"document\":{\"type\":\"string\",\"description\":\"Buyer's document number (e.g., CPF number).\"},\"documentType\":{\"type\":\"string\",\"description\":\"Type of the document provided (e.g., `cpf`).\"},\"phone\":{\"type\":\"string\",\"description\":\"Buyer's phone number.\"},\"cards\":{\"type\":\"array\",\"description\":\"List of cards associated with the buyer. This field is used by the checkout module.\",\"items\":{\"type\":\"object\",\"description\":\"Credit card information.\",\"properties\":{\"cardId\":{\"type\":\"string\",\"description\":\"Unique identifier of the saved card.\"},\"paymentSystem\":{\"type\":\"string\",\"description\":\"Code representing the payment system (e.g., `2` for Visa).\"},\"paymentSystemName\":{\"type\":\"string\",\"description\":\"Name of the payment system (e.g., `Visa`).\"},\"cardNumber\":{\"type\":\"string\",\"description\":\"Masked credit card number.\"},\"bin\":{\"type\":\"string\",\"description\":\"Bank Identification Number - the first digits of the card.\"},\"expirationDate\":{\"type\":\"string\",\"description\":\"Expiry date of the card in `MM/YYYY` format.\"},\"useCvvForAuthorization\":{\"type\":\"boolean\",\"description\":\"Indicates if CVV is required for authorization.\"},\"cardLabel\":{\"type\":\"string\",\"description\":\"Label or nickname for the card.\"},\"isCardToken\":{\"type\":\"boolean\",\"description\":\"Indicates whether the card data is tokenized.\"},\"availableAddresses\":{\"type\":\"array\",\"description\":\"Array of address IDs the card is associated with.\",\"items\":{\"type\":\"string\",\"description\":\"Address identifier.\"}}}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/dataentities/shopper/search - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -1147,7 +1147,7 @@
     }
   ],
   "info": {
-    "_postman_id": "eaf08468-f1e8-41ce-a946-316c74db37a2",
+    "_postman_id": "e895265e-59b6-46f9-8569-0438814d15cd",
     "name": "B2B Buyer Data API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - B2B Buyer Data API.json
+++ b/PostmanCollections/VTEX - B2B Buyer Data API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "e895265e-59b6-46f9-8569-0438814d15cd"
+    "postman_id": "daa0ba9c-7fbf-4a06-aa40-03a0483c7bba"
   },
   "item": [
     {
-      "id": "b306896c-a885-4e1a-b294-64b6b574696f",
+      "id": "e8c070a7-2b0b-440e-b2da-5a9d4438a236",
       "name": "Buyer data",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "c8ee6fa8-2928-458b-af7d-11a71102efa7",
+          "id": "f021ad68-efd4-48b7-893b-39bf65f04e4c",
           "name": "Get buyer schema",
           "request": {
             "name": "Get buyer schema",
@@ -86,7 +86,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1755a314-3a12-4e16-ba82-d46a2929d066",
+              "id": "9a991c1e-65a0-4fcc-8421-eb3f47f4afc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -154,7 +154,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2aeb3c54-8532-4384-bd1c-37e8aea11001",
+                "id": "4627151b-130f-4b82-a48b-6135cc31031e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/schemas/v1 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -170,7 +170,7 @@
           }
         },
         {
-          "id": "1e91ac44-cca4-43f9-aec9-7c062aa7035c",
+          "id": "a4bf7fcd-714b-489b-a530-c82c4b6baf77",
           "name": "Create buyer",
           "request": {
             "name": "Create buyer",
@@ -266,7 +266,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9288a71e-4de1-407f-9a53-979fcf5ca57f",
+              "id": "8047625c-bc98-41dd-97a1-1e94fd52e1c1",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -356,7 +356,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8f57e3f3-64cd-49cd-a980-21dac060ab89",
+                "id": "c63bb988-88c9-4959-8360-427abf255240",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/shopper/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -372,7 +372,7 @@
           }
         },
         {
-          "id": "36d4e368-c01a-4437-9867-ab2344bfa60c",
+          "id": "c8e23c4b-5e4e-48c7-8ae8-422cfaf743f7",
           "name": "Get buyer by ID",
           "request": {
             "name": "Get buyer by ID",
@@ -457,7 +457,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bedad18d-38f9-4003-b2ac-9614b9dcbdd1",
+              "id": "60b25579-a1d1-4b7d-a161-e4130d0e03ed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -525,7 +525,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "80987030-e138-40b7-9670-1919bda32068",
+                "id": "6d47da67-6662-4c5d-bf1f-294d18b24da1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -541,7 +541,7 @@
           }
         },
         {
-          "id": "160c7fa4-be40-4106-abb3-009975eb9f5f",
+          "id": "876363f3-5b22-4b31-9323-ee5d6cad632f",
           "name": "Update buyer",
           "request": {
             "name": "Update buyer",
@@ -626,7 +626,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "02428ab6-286e-4c1a-b9f9-3847285ef6cd",
+              "id": "894b1f97-bf1d-48bc-8fd9-7fc3206a1159",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -688,7 +688,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ce859a3a-8b48-41c3-9784-d066d5e9218d",
+                "id": "73995bae-00de-4382-949e-8f4c85127cc7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -702,7 +702,7 @@
           }
         },
         {
-          "id": "6706edf0-7227-4267-a969-a92262917820",
+          "id": "7e345b31-9384-4a7f-a441-c6bc70ec2620",
           "name": "Delete buyer",
           "request": {
             "name": "Delete buyer",
@@ -783,7 +783,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bec5c0d8-4903-45b7-90c6-f4ec82bf389f",
+              "id": "15366d90-e0ab-4d7e-8413-7b0376d9db8a",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -840,7 +840,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8dcd4e0e-fd15-4fec-961e-2d15bc44494b",
+              "id": "ec54bee4-8c47-43a5-a1b6-06878ebca3af",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7e8c27e2-a337-45c6-9044-b19103ab2bd0",
+                "id": "b27f2eb9-e78b-4724-bb2b-b4a3cb991967",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -911,7 +911,7 @@
           }
         },
         {
-          "id": "1adb5b9e-3da0-45b5-ade3-fa131d1c09ff",
+          "id": "60a86713-e3e3-49b5-93da-c2a565a68037",
           "name": "Search buyers",
           "request": {
             "name": "Search buyers",
@@ -1003,7 +1003,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2e319e5f-238c-4d44-863f-d1f14516288e",
+              "id": "dc85b81f-5d59-42f7-80a8-e9dab8520a8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1089,7 +1089,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2e9c05ae-52af-44d4-82eb-8a487d46180b",
+                "id": "0886d6b8-2628-43cb-a98e-d17acdb3aff1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1147,7 +1147,7 @@
     }
   ],
   "info": {
-    "_postman_id": "e895265e-59b6-46f9-8569-0438814d15cd",
+    "_postman_id": "daa0ba9c-7fbf-4a06-aa40-03a0483c7bba",
     "name": "B2B Buyer Data API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - B2B Buyer Data API.json
+++ b/PostmanCollections/VTEX - B2B Buyer Data API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "daa0ba9c-7fbf-4a06-aa40-03a0483c7bba"
+    "postman_id": "ee925367-edb2-4a2e-b46f-3797b784850b"
   },
   "item": [
     {
-      "id": "e8c070a7-2b0b-440e-b2da-5a9d4438a236",
+      "id": "a13a9b23-8b8d-45cd-b6eb-5db14623bb3c",
       "name": "Buyer data",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "f021ad68-efd4-48b7-893b-39bf65f04e4c",
+          "id": "b2bdff5b-06d5-45cb-8980-01be3aa033e5",
           "name": "Get buyer schema",
           "request": {
             "name": "Get buyer schema",
@@ -86,7 +86,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9a991c1e-65a0-4fcc-8421-eb3f47f4afc4",
+              "id": "797e0237-b18c-4bec-9ea1-8e8824b5b1a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -154,7 +154,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4627151b-130f-4b82-a48b-6135cc31031e",
+                "id": "a94d121d-11cb-4762-8ba1-0ec28ddd7616",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/schemas/v1 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -170,7 +170,7 @@
           }
         },
         {
-          "id": "a4bf7fcd-714b-489b-a530-c82c4b6baf77",
+          "id": "37c5361d-72fb-40a1-b902-5560b9cf81fd",
           "name": "Create buyer",
           "request": {
             "name": "Create buyer",
@@ -266,7 +266,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8047625c-bc98-41dd-97a1-1e94fd52e1c1",
+              "id": "1f8409ae-1c5f-4cd3-915c-ba3e78f890c9",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -356,7 +356,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c63bb988-88c9-4959-8360-427abf255240",
+                "id": "868e4464-3a67-4f3a-abb6-83391174ecf4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/dataentities/shopper/documents - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -372,7 +372,7 @@
           }
         },
         {
-          "id": "c8e23c4b-5e4e-48c7-8ae8-422cfaf743f7",
+          "id": "be8f4569-453e-45ca-b139-1356fdcd6670",
           "name": "Get buyer by ID",
           "request": {
             "name": "Get buyer by ID",
@@ -457,7 +457,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "60b25579-a1d1-4b7d-a161-e4130d0e03ed",
+              "id": "0a45fda2-b915-4a4a-9417-986126a88719",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -525,7 +525,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6d47da67-6662-4c5d-bf1f-294d18b24da1",
+                "id": "b6f0273d-77d2-472d-851c-ae64c063759a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -541,7 +541,7 @@
           }
         },
         {
-          "id": "876363f3-5b22-4b31-9323-ee5d6cad632f",
+          "id": "de6d659f-9480-419d-b56b-8ecaf42dbdeb",
           "name": "Update buyer",
           "request": {
             "name": "Update buyer",
@@ -626,7 +626,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "894b1f97-bf1d-48bc-8fd9-7fc3206a1159",
+              "id": "8546a7c1-074b-408c-b22f-151eb84e9bf7",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -688,7 +688,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "73995bae-00de-4382-949e-8f4c85127cc7",
+                "id": "ee1fba9f-62dc-4f4c-bfe1-82826065ddaf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -702,7 +702,7 @@
           }
         },
         {
-          "id": "7e345b31-9384-4a7f-a441-c6bc70ec2620",
+          "id": "af93d07b-502b-413a-9007-798bd5b122f5",
           "name": "Delete buyer",
           "request": {
             "name": "Delete buyer",
@@ -783,7 +783,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "15366d90-e0ab-4d7e-8413-7b0376d9db8a",
+              "id": "ac713325-c3ee-4ca4-92ef-fae1d75248c2",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -840,7 +840,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ec54bee4-8c47-43a5-a1b6-06878ebca3af",
+              "id": "d78bb3c8-f203-41b3-8471-b1b68eae1382",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -898,7 +898,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b27f2eb9-e78b-4724-bb2b-b4a3cb991967",
+                "id": "d6fecc3c-c378-4235-a718-19537de01818",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/dataentities/shopper/documents/:buyerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -911,7 +911,7 @@
           }
         },
         {
-          "id": "60a86713-e3e3-49b5-93da-c2a565a68037",
+          "id": "09a30c18-3371-48f5-be48-c1e32df69ef4",
           "name": "Search buyers",
           "request": {
             "name": "Search buyers",
@@ -1003,7 +1003,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dc85b81f-5d59-42f7-80a8-e9dab8520a8c",
+              "id": "b2c34de5-3d9a-4533-aeb1-ced180cb6b63",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1089,7 +1089,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0886d6b8-2628-43cb-a98e-d17acdb3aff1",
+                "id": "ac4e8c96-4cf0-442b-9a5d-ee8d5d317cdb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/dataentities/shopper/search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1147,7 +1147,7 @@
     }
   ],
   "info": {
-    "_postman_id": "daa0ba9c-7fbf-4a06-aa40-03a0483c7bba",
+    "_postman_id": "ee925367-edb2-4a2e-b46f-3797b784850b",
     "name": "B2B Buyer Data API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Punchout API.json
+++ b/PostmanCollections/VTEX - Punchout API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "dc228e7d-6c09-489d-992b-2d02cd18f19e"
+    "postman_id": "c2f5e8d4-d0e0-418c-8235-58a991adf5d8"
   },
   "item": [
     {
-      "id": "c7375e18-daa1-45b3-a72e-e15e1f4ed437",
+      "id": "cf2a2ca5-6496-4878-944e-2ce468cd36a9",
       "name": "Punchout login",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "29ff3b65-3a1c-4da0-981e-90b65a679ff5",
+          "id": "c0bff5bb-b33d-4308-b2d4-e6afa73117f8",
           "name": "Start VTEX user punchout flow",
           "request": {
             "name": "Start VTEX user punchout flow",
@@ -89,7 +89,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4819cf35-decc-49f9-881a-1f60a5c20382",
+              "id": "02ea15fb-ae9c-47a5-a9a5-a41eb62b7f5e",
               "name": "OK - Credentials validated successfully and OTT generated",
               "originalRequest": {
                 "url": {
@@ -171,7 +171,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1aa42bef-54b6-4227-8f69-135783102d36",
+              "id": "ab4cdfc5-8d3c-42b6-b353-0d48805fa9cf",
               "name": "Bad Request - Invalid request payload or missing required fields",
               "originalRequest": {
                 "url": {
@@ -243,7 +243,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f9629ddb-af6a-4c6d-844b-958e36993ee8",
+              "id": "ab5da779-671d-4cc2-adbb-b7f01aeeb711",
               "name": "Unauthorized - Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -315,7 +315,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "44403b67-fa21-4a32-b445-712b0c3fc809",
+              "id": "e899a09c-2cc2-42d0-9dc7-22b8500f8878",
               "name": "Forbidden - Provided returnURL does not match an authorized host",
               "originalRequest": {
                 "url": {
@@ -388,7 +388,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5aabd21c-1b6d-4b50-8024-11b6f1187d08",
+                "id": "2f962d70-1fa8-4b8d-ad53-f7edfaab264a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/punchout/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -404,7 +404,7 @@
           }
         },
         {
-          "id": "6b7e288b-48a9-4b41-a256-4fad5923479c",
+          "id": "2f86e60e-50be-4f29-9f24-7c8c6f1ab70b",
           "name": "Start pre-authenticated user punchout flow",
           "request": {
             "name": "Start pre-authenticated user punchout flow",
@@ -502,7 +502,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "04979e3e-8229-46ff-811f-3f55e82d75e7",
+              "id": "a0c4a837-bb5c-42c9-81b9-24ab52ea650e",
               "name": "OK - Authentication successful and OTT generated",
               "originalRequest": {
                 "url": {
@@ -593,7 +593,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f2a603d9-7a0f-4c61-94d5-5c85a89c75d8",
+              "id": "39ee7b29-81fc-409d-8121-533677b4ad24",
               "name": "Bad Request - Invalid request payload or missing required fields",
               "originalRequest": {
                 "url": {
@@ -674,7 +674,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e244e6f0-d607-48fd-b8c6-f5e6b465eaa8",
+              "id": "d2b44caa-7b5f-406b-b3d1-1e62e4673eb1",
               "name": "Unauthorized - Invalid API credentials",
               "originalRequest": {
                 "url": {
@@ -755,7 +755,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b3333c49-7448-4b97-8659-ff7551b38561",
+              "id": "a6153259-07e4-459f-9ff7-d8aa59ed7510",
               "name": "Forbidden - Provided returnURL does not match an authorized host or missing CanPunchout permission",
               "originalRequest": {
                 "url": {
@@ -837,7 +837,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "573fdd69-0952-4f20-bd58-bc151d2d8b16",
+                "id": "672d716d-6296-439a-98bb-c929961ec420",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/punchout/authenticated/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -853,7 +853,7 @@
           }
         },
         {
-          "id": "4dc9ff23-857d-4c80-bda1-d2c3e39b095b",
+          "id": "17a60689-de12-4b16-9a80-90bacd0ca93d",
           "name": "Finish punchout login flow",
           "request": {
             "name": "Finish punchout login flow",
@@ -913,7 +913,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e6548e39-1cc5-4a33-a400-801792dd35f3",
+              "id": "8c22f562-a2f4-4f55-a19f-3fedc1c4ffde",
               "name": "Found - OTT is valid",
               "originalRequest": {
                 "url": {
@@ -973,7 +973,7 @@
                     "type": "text/plain"
                   },
                   "key": "Set-Cookie",
-                  "value": "aliqua minim"
+                  "value": "amet sed laborum in"
                 }
               ],
               "cookie": []
@@ -982,7 +982,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bc23f5a0-ae87-4847-90e1-440f8ad3c7b6",
+              "id": "3355c800-97d6-46f5-a436-7c285a383422",
               "name": "Bad Request - Missing or invalid token",
               "originalRequest": {
                 "url": {
@@ -1041,7 +1041,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "90220308-06d3-4129-a370-4dd1fdd477ef",
+              "id": "d14b7cc1-70ad-4beb-a06f-8cb1c0ce30b0",
               "name": "Gone - Token expired or already used",
               "originalRequest": {
                 "url": {
@@ -1101,7 +1101,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "345835b1-d679-4f0b-9c2b-475e5f246007",
+                "id": "bdc317c9-df29-4a84-81be-d7e61ef32c4f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/v1/punchout/finish - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1131,7 +1131,7 @@
     }
   ],
   "info": {
-    "_postman_id": "dc228e7d-6c09-489d-992b-2d02cd18f19e",
+    "_postman_id": "c2f5e8d4-d0e0-418c-8235-58a991adf5d8",
     "name": "Punchout API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Punchout API.json
+++ b/PostmanCollections/VTEX - Punchout API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "4beaa18e-54d3-401e-92f7-6d4065321496"
+    "postman_id": "dc228e7d-6c09-489d-992b-2d02cd18f19e"
   },
   "item": [
     {
-      "id": "3c6f6094-971d-4b38-b1eb-3c306dd23a70",
+      "id": "c7375e18-daa1-45b3-a72e-e15e1f4ed437",
       "name": "Punchout login",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "0be6c208-f38f-431f-9d8b-2f32df3da952",
+          "id": "29ff3b65-3a1c-4da0-981e-90b65a679ff5",
           "name": "Start VTEX user punchout flow",
           "request": {
             "name": "Start VTEX user punchout flow",
@@ -24,6 +24,7 @@
               "path": [
                 "api",
                 "authenticator",
+                "v1",
                 "punchout",
                 "start"
               ],
@@ -88,13 +89,14 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "55226f5f-84c9-4d6c-824b-893c65da9780",
+              "id": "4819cf35-decc-49f9-881a-1f60a5c20382",
               "name": "OK - Credentials validated successfully and OTT generated",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "start"
                   ],
@@ -169,13 +171,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "48b06cbe-7d0c-4308-9c2e-393c0d6fca91",
+              "id": "1aa42bef-54b6-4227-8f69-135783102d36",
               "name": "Bad Request - Invalid request payload or missing required fields",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "start"
                   ],
@@ -240,13 +243,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "349bd2f8-af5e-49d5-8b2b-1725ef0ca84f",
+              "id": "f9629ddb-af6a-4c6d-844b-958e36993ee8",
               "name": "Unauthorized - Invalid credentials",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "start"
                   ],
@@ -311,13 +315,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3e417160-829f-4955-a9d4-ece18429f7a8",
+              "id": "44403b67-fa21-4a32-b445-712b0c3fc809",
               "name": "Forbidden - Provided returnURL does not match an authorized host",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "start"
                   ],
@@ -383,13 +388,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "6da3615f-dcfc-45f7-9d17-fbd6e60cc630",
+                "id": "5aabd21c-1b6d-4b50-8024-11b6f1187d08",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/punchout/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
-                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/authenticator/punchout/start - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/authenticator/punchout/start - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\",\"description\":\"URL containing a one-time token for authentication. The token expires after 5 minutes and is single-use to prevent replay attacks.\"}}}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/authenticator/punchout/start - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/punchout/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/authenticator/v1/punchout/start - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/authenticator/v1/punchout/start - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\",\"description\":\"URL containing a one-time token for authentication. The token expires after 5 minutes and is single-use to prevent replay attacks.\"}}}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/authenticator/v1/punchout/start - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -399,7 +404,7 @@
           }
         },
         {
-          "id": "669268eb-9a98-462f-a999-6b97c90fc7ef",
+          "id": "6b7e288b-48a9-4b41-a256-4fad5923479c",
           "name": "Start pre-authenticated user punchout flow",
           "request": {
             "name": "Start pre-authenticated user punchout flow",
@@ -411,6 +416,7 @@
               "path": [
                 "api",
                 "authenticator",
+                "v1",
                 "punchout",
                 "authenticated",
                 "start"
@@ -496,13 +502,14 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "36cd9334-bc5a-4f89-9472-f0a9c56ec27a",
+              "id": "04979e3e-8229-46ff-811f-3f55e82d75e7",
               "name": "OK - Authentication successful and OTT generated",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "authenticated",
                     "start"
@@ -586,13 +593,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a71f4063-0a8c-4fe4-ae1b-a8100500849f",
+              "id": "f2a603d9-7a0f-4c61-94d5-5c85a89c75d8",
               "name": "Bad Request - Invalid request payload or missing required fields",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "authenticated",
                     "start"
@@ -666,13 +674,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8b52737b-f420-44fc-9862-1a9940ed16b1",
+              "id": "e244e6f0-d607-48fd-b8c6-f5e6b465eaa8",
               "name": "Unauthorized - Invalid API credentials",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "authenticated",
                     "start"
@@ -746,13 +755,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "195b1011-7acc-4f1a-ae09-d9994f3ecd0c",
+              "id": "b3333c49-7448-4b97-8659-ff7551b38561",
               "name": "Forbidden - Provided returnURL does not match an authorized host or missing CanPunchout permission",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "authenticated",
                     "start"
@@ -827,13 +837,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "292f2588-1ef3-4675-9ddc-0e67fada7fbb",
+                "id": "573fdd69-0952-4f20-bd58-bc151d2d8b16",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/punchout/authenticated/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
-                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/authenticator/punchout/authenticated/start - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/authenticator/punchout/authenticated/start - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\",\"description\":\"URL containing a one-time token for authentication. The token expires after 5 minutes and is single-use to prevent replay attacks.\"}}}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/authenticator/punchout/authenticated/start - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/punchout/authenticated/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/authenticator/v1/punchout/authenticated/start - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/authenticator/v1/punchout/authenticated/start - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\",\"description\":\"URL containing a one-time token for authentication. The token expires after 5 minutes and is single-use to prevent replay attacks.\"}}}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/authenticator/v1/punchout/authenticated/start - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -843,7 +853,7 @@
           }
         },
         {
-          "id": "992f538a-db46-4a7c-8280-fe8553729bc7",
+          "id": "4dc9ff23-857d-4c80-bda1-d2c3e39b095b",
           "name": "Finish punchout login flow",
           "request": {
             "name": "Finish punchout login flow",
@@ -855,6 +865,7 @@
               "path": [
                 "api",
                 "authenticator",
+                "v1",
                 "punchout",
                 "finish"
               ],
@@ -902,13 +913,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f04a424b-f255-4180-896c-4506a4c806bb",
+              "id": "e6548e39-1cc5-4a33-a400-801792dd35f3",
               "name": "Found - OTT is valid",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "finish"
                   ],
@@ -961,7 +973,7 @@
                     "type": "text/plain"
                   },
                   "key": "Set-Cookie",
-                  "value": "ad in deserunt anim"
+                  "value": "aliqua minim"
                 }
               ],
               "cookie": []
@@ -970,13 +982,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "07eddb69-0896-4434-b4da-17b748527630",
+              "id": "bc23f5a0-ae87-4847-90e1-440f8ad3c7b6",
               "name": "Bad Request - Missing or invalid token",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "finish"
                   ],
@@ -1028,13 +1041,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "10f375e8-818e-4e94-9aa5-60aa94508af4",
+              "id": "90220308-06d3-4129-a370-4dd1fdd477ef",
               "name": "Gone - Token expired or already used",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "punchout",
                     "finish"
                   ],
@@ -1087,10 +1101,10 @@
             {
               "listen": "test",
               "script": {
-                "id": "89cd76ca-218d-40ab-99aa-17198f21f8ab",
+                "id": "345835b1-d679-4f0b-9c2b-475e5f246007",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/punchout/finish - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
+                  "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/v1/punchout/finish - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
                 ]
               }
             }
@@ -1117,7 +1131,7 @@
     }
   ],
   "info": {
-    "_postman_id": "4beaa18e-54d3-401e-92f7-6d4065321496",
+    "_postman_id": "dc228e7d-6c09-489d-992b-2d02cd18f19e",
     "name": "Punchout API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Punchout API.json
+++ b/PostmanCollections/VTEX - Punchout API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "c2f5e8d4-d0e0-418c-8235-58a991adf5d8"
+    "postman_id": "7bb5ee68-a1a9-49da-ab1a-096efd5454b1"
   },
   "item": [
     {
-      "id": "cf2a2ca5-6496-4878-944e-2ce468cd36a9",
+      "id": "1acbb092-e064-438b-81c0-52a44105dcea",
       "name": "Punchout login",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "c0bff5bb-b33d-4308-b2d4-e6afa73117f8",
+          "id": "8ba3b1e2-c21e-412e-9474-fadd0f55f7f8",
           "name": "Start VTEX user punchout flow",
           "request": {
             "name": "Start VTEX user punchout flow",
@@ -89,7 +89,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "02ea15fb-ae9c-47a5-a9a5-a41eb62b7f5e",
+              "id": "23ac657b-4698-46b5-afbd-bb3b0d97d99c",
               "name": "OK - Credentials validated successfully and OTT generated",
               "originalRequest": {
                 "url": {
@@ -171,7 +171,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ab4cdfc5-8d3c-42b6-b353-0d48805fa9cf",
+              "id": "7954abf2-65e3-4235-a381-b4c6ab6b8a3d",
               "name": "Bad Request - Invalid request payload or missing required fields",
               "originalRequest": {
                 "url": {
@@ -243,7 +243,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ab5da779-671d-4cc2-adbb-b7f01aeeb711",
+              "id": "32236112-923a-43a8-8af6-5a0a35b3af86",
               "name": "Unauthorized - Invalid credentials",
               "originalRequest": {
                 "url": {
@@ -315,7 +315,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e899a09c-2cc2-42d0-9dc7-22b8500f8878",
+              "id": "9ff65992-b192-4104-ab73-a4e510cd4c60",
               "name": "Forbidden - Provided returnURL does not match an authorized host",
               "originalRequest": {
                 "url": {
@@ -388,7 +388,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2f962d70-1fa8-4b8d-ad53-f7edfaab264a",
+                "id": "7a26a2ab-bfa5-4977-bd89-af8fd539ae7e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/punchout/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -404,7 +404,7 @@
           }
         },
         {
-          "id": "2f86e60e-50be-4f29-9f24-7c8c6f1ab70b",
+          "id": "7ec94a3b-d403-49df-a990-eac06add0d3b",
           "name": "Start pre-authenticated user punchout flow",
           "request": {
             "name": "Start pre-authenticated user punchout flow",
@@ -502,7 +502,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a0c4a837-bb5c-42c9-81b9-24ab52ea650e",
+              "id": "14776c6e-5a5a-4a34-8761-b653ed504263",
               "name": "OK - Authentication successful and OTT generated",
               "originalRequest": {
                 "url": {
@@ -593,7 +593,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "39ee7b29-81fc-409d-8121-533677b4ad24",
+              "id": "4c11bb9f-367a-488b-9dad-71bac382e2cc",
               "name": "Bad Request - Invalid request payload or missing required fields",
               "originalRequest": {
                 "url": {
@@ -674,7 +674,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d2b44caa-7b5f-406b-b3d1-1e62e4673eb1",
+              "id": "2de8c31d-751d-44e4-b300-16e58549ced6",
               "name": "Unauthorized - Invalid API credentials",
               "originalRequest": {
                 "url": {
@@ -755,7 +755,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a6153259-07e4-459f-9ff7-d8aa59ed7510",
+              "id": "8abdd8bf-dfb2-4c0f-9aab-9d5011e579a8",
               "name": "Forbidden - Provided returnURL does not match an authorized host or missing CanPunchout permission",
               "originalRequest": {
                 "url": {
@@ -837,7 +837,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "672d716d-6296-439a-98bb-c929961ec420",
+                "id": "788c07e3-2db4-4e33-913c-12222ea8d83b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/punchout/authenticated/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -853,7 +853,7 @@
           }
         },
         {
-          "id": "17a60689-de12-4b16-9a80-90bacd0ca93d",
+          "id": "9273eca4-7bf8-4097-9d07-1dd55b677bcd",
           "name": "Finish punchout login flow",
           "request": {
             "name": "Finish punchout login flow",
@@ -913,7 +913,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8c22f562-a2f4-4f55-a19f-3fedc1c4ffde",
+              "id": "4c5344b4-634e-4d47-823c-81fb433d8c17",
               "name": "Found - OTT is valid",
               "originalRequest": {
                 "url": {
@@ -973,7 +973,7 @@
                     "type": "text/plain"
                   },
                   "key": "Set-Cookie",
-                  "value": "amet sed laborum in"
+                  "value": "esse Lorem commodo"
                 }
               ],
               "cookie": []
@@ -982,7 +982,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3355c800-97d6-46f5-a436-7c285a383422",
+              "id": "ebb7faf5-8521-49d2-b4f1-4f2678b3ffe1",
               "name": "Bad Request - Missing or invalid token",
               "originalRequest": {
                 "url": {
@@ -1041,7 +1041,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d14b7cc1-70ad-4beb-a06f-8cb1c0ce30b0",
+              "id": "8a198f85-5f9c-4aa9-9ea4-9eb811a6d408",
               "name": "Gone - Token expired or already used",
               "originalRequest": {
                 "url": {
@@ -1101,7 +1101,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bdc317c9-df29-4a84-81be-d7e61ef32c4f",
+                "id": "c1981e96-b8b1-475c-addb-56adc164febc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/v1/punchout/finish - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1131,7 +1131,7 @@
     }
   ],
   "info": {
-    "_postman_id": "c2f5e8d4-d0e0-418c-8235-58a991adf5d8",
+    "_postman_id": "7bb5ee68-a1a9-49da-ab1a-096efd5454b1",
     "name": "Punchout API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - VTEX ID API.json
+++ b/PostmanCollections/VTEX - VTEX ID API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "ccee10fa-6868-401a-ab2a-3136d3121c4a"
+    "postman_id": "615bdc66-be8e-498a-91cb-381bc66b90f7"
   },
   "item": [
     {
-      "id": "61f7e1cc-463c-427f-9e28-d4e0353a04bd",
+      "id": "708b866b-c0ef-4aec-a9f2-ae5c5ec7aa05",
       "name": "Authentication",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "8f619317-19cc-46bc-9a7b-3e4c2910db20",
+          "id": "79f8f378-4828-4148-b634-a7556d349b8a",
           "name": "Generate authentication token",
           "request": {
             "name": "Generate authentication token",
@@ -88,7 +88,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b3f9ad27-fb17-4a13-9bad-4d92493a549c",
+              "id": "6f2cb64f-111a-49ce-a7bd-a4c5bd9a3c51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -178,7 +178,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e6c70056-6f96-4223-989f-2d75d56037a8",
+                "id": "3c2982f0-a308-42cc-9078-40dc5d341424",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/apptoken/login - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -194,7 +194,7 @@
           }
         },
         {
-          "id": "f63df8e0-db83-487d-bd4f-2f742cd37ff2",
+          "id": "704a3a16-ef0b-4291-a0ca-e60b2ffd0012",
           "name": "Exchange OAuth access token for VTEX credential",
           "request": {
             "name": "Exchange OAuth access token for VTEX credential",
@@ -284,7 +284,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5e8e5b03-e201-49bb-b89c-bf60bc011ff9",
+              "id": "417786fa-c123-4e06-978f-5b7903554293",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -367,7 +367,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45be2d82-03c2-483c-b068-7811ed3bb7d4",
+                "id": "a9bdeea1-2f11-4857-bb44-955b802c8869",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/audience/webstore/provider/oauth/exchange - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -383,7 +383,7 @@
           }
         },
         {
-          "id": "de052043-276a-4208-a649-8126238b4870",
+          "id": "47d01f03-f273-4cac-8a36-2ad95b895662",
           "name": "Check authenticated user",
           "request": {
             "name": "Check authenticated user",
@@ -470,7 +470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b7130784-88ef-4d16-918a-5bf1beca80e3",
+              "id": "9f3c7b9f-3d77-4dd3-b5ac-9f2fc333f7a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -559,7 +559,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "17df0d68-8d71-452a-aaae-5cd877a56d73",
+              "id": "a11da2c5-27da-48d9-b66f-a0e03e6d12e1",
               "name": "Unauthorized",
               "originalRequest": {
                 "url": {
@@ -649,7 +649,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f302ac5f-cffb-4c73-beee-b49d9b39f6f7",
+                "id": "cc590c27-ecbe-46b1-82d6-92f991931194",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/credential/validate - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -665,7 +665,7 @@
           }
         },
         {
-          "id": "6273160a-1bee-4a90-b57d-74decf192e34",
+          "id": "f6f9b2fb-e317-4e6a-b020-4106b470196b",
           "name": "Enable or disable repeated passwords",
           "request": {
             "name": "Enable or disable repeated passwords",
@@ -742,7 +742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9ccf9112-b237-4931-8d9b-7843a459a65a",
+              "id": "c8f9ed4a-5a6c-4d2d-8728-e285f51656d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -816,7 +816,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "580b0823-5e09-41a3-a16f-68c861578edc",
+                "id": "4e29d35b-65df-4141-9169-f110964f860d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/providers/setup/password/webstore/password - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -829,7 +829,7 @@
           }
         },
         {
-          "id": "2a399ed7-4ca7-4fdf-87f9-8f177e2d274a",
+          "id": "6b79af5e-26cd-4919-90f4-b847bec9177a",
           "name": "Expire user password",
           "request": {
             "name": "Expire user password",
@@ -909,7 +909,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0f395acd-b6da-44cd-b65e-975a06337751",
+              "id": "ca564e80-dc81-4e87-a75b-f8ccbca2eed5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -976,7 +976,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d8324976-c33b-42d3-81ee-d4066dd6c898",
+                "id": "c2cc5605-8640-4a34-9ec3-5718e8a0e00e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/password/expire - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -989,7 +989,7 @@
           }
         },
         {
-          "id": "887d4c0f-bca3-40a3-a2ca-de78191a2bac",
+          "id": "b3f2949b-0c07-4e0b-938b-f11641fa2630",
           "name": "Get user ID by email",
           "request": {
             "name": "Get user ID by email",
@@ -1073,7 +1073,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3173a045-53a6-468a-956a-a95c0308b2f8",
+              "id": "c689f89d-9727-45cd-99e9-213befa18e93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1150,7 +1150,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7c792cc7-06c7-4c02-b0a8-f12409e3bcc4",
+              "id": "6fb133aa-1005-42ef-ab62-3ee57fad5feb",
               "name": "Unauthorized\n\nInvalid or missing VtexIdclientAutCookie.",
               "originalRequest": {
                 "url": {
@@ -1218,7 +1218,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2984da79-eb90-4ff2-8987-6ccb382fa0ca",
+                "id": "ac9a38b2-6861-418c-9e31-f6efb96d401c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pvt/user/id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1237,7 +1237,7 @@
       "event": []
     },
     {
-      "id": "afc1c543-4319-44af-97ba-d08d8c4cef91",
+      "id": "3a23cf22-51bb-49d9-bbbf-3c138f3093fb",
       "name": "Token renewal",
       "description": {
         "content": "",
@@ -1245,7 +1245,7 @@
       },
       "item": [
         {
-          "id": "bfad73f3-32cc-4c35-a737-7f7162b17bc6",
+          "id": "9316cbb8-527d-42b6-965b-1de6c139259e",
           "name": "Initiate token renewal",
           "request": {
             "name": "Initiate token renewal",
@@ -1293,7 +1293,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b4225142-08e1-41c8-9ae3-f00dd48f2a27",
+              "id": "e38754a4-8de7-4603-8e4d-cc3aeca58a1f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1343,7 +1343,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ae3a2181-dc37-4e97-b550-eab43f6007ac",
+              "id": "3469a4f2-2ca6-41a0-99e1-48d23b722ccc",
               "name": "Bad Request\n\nInvalid API key or API key not owned by tenant.",
               "originalRequest": {
                 "url": {
@@ -1383,7 +1383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "649ae88a-c42e-4e39-a6c3-69a984e4a1d8",
+              "id": "76199cdf-fb12-4053-aeed-03136f1712fa",
               "name": "Conflict\n\nAlready has a renewed token pending.",
               "originalRequest": {
                 "url": {
@@ -1423,7 +1423,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "61605360-d528-49bd-b1ee-59c33006bc7f",
+              "id": "db50959b-a628-4d00-9ab8-4b5c68ff8511",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1464,7 +1464,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "60439b71-76df-4b6e-a9df-a2618d654a66",
+                "id": "383a3b3b-8764-4399-94f1-0c16f3ba0ae6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/apikey/:apiKey/apitoken/renew - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1480,7 +1480,7 @@
           }
         },
         {
-          "id": "5986ea35-ff7f-464a-aa82-633b8248c1cc",
+          "id": "0aa80fef-582d-45c2-868a-dd31a5811370",
           "name": "Complete token renewal",
           "request": {
             "name": "Complete token renewal",
@@ -1528,7 +1528,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ad04ce11-2f2b-4dcb-bd02-8e157010d31e",
+              "id": "c91e24b2-2246-4609-9fc2-e8933f861bf0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1578,7 +1578,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "72bd1719-0ce7-4ac7-b909-59e630c2a91b",
+              "id": "a4bee551-3996-49c7-af7f-09b6ec0eea14",
               "name": "Bad Request\n\nInvalid API key or API key not owned by tenant.",
               "originalRequest": {
                 "url": {
@@ -1618,7 +1618,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6f069d4a-a687-4756-b4a3-6faa01aff12a",
+              "id": "4b94fafd-e6f9-473e-adbc-c710fbcc7970",
               "name": "Not Found\n\nNo renewed API token was found.",
               "originalRequest": {
                 "url": {
@@ -1658,7 +1658,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0f36cf07-f786-471d-99ff-126b52a2a5c5",
+              "id": "c151cc1b-4274-4c8f-bcf2-ff0d0d669ac2",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1699,7 +1699,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "abd1efb2-dd44-4c41-9316-de2cd0ab2c01",
+                "id": "5fe6bcf2-6c14-4fd9-9d7c-5cdb28f22de7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/apikey/:apiKey/apitoken/finish-renewal - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1718,7 +1718,7 @@
       "event": []
     },
     {
-      "id": "1b040731-264f-4781-add5-61894407ffa4",
+      "id": "941d3423-288f-4a94-8f79-1b4c95c924c9",
       "name": "Refresh token headless",
       "description": {
         "content": "",
@@ -1726,7 +1726,7 @@
       },
       "item": [
         {
-          "id": "aec1b410-65a4-42e2-8ad1-2351cd7f3d21",
+          "id": "0ea046e8-4dc5-4623-bdaa-54d7c4392232",
           "name": "Start authentication",
           "request": {
             "name": "Start authentication",
@@ -1799,7 +1799,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ec264062-bc9c-446a-a3ba-0b35154157a7",
+              "id": "b4bd036d-a65b-4dce-82d8-7c5a837ea397",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1886,7 +1886,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "743ba43d-bb9c-46eb-93af-fed53c1e7f72",
+                "id": "736975a0-e53d-49e6-9e7b-057bd2e2a7b9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pub/authentication/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1902,7 +1902,7 @@
           }
         },
         {
-          "id": "141dac89-4015-4316-ba0f-67de1a16ddb7",
+          "id": "a7270153-67c0-4110-954d-cd33a3adfab5",
           "name": "Send access key",
           "request": {
             "name": "Send access key",
@@ -1967,7 +1967,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "992a8c4f-f6c6-40bb-a0dd-c97b56fe7fc4",
+              "id": "a5c4605b-cb9e-425e-acfe-c552d89ab391",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7eb31a36-5e87-43c7-8a12-100ff2e97c17",
+              "id": "59544ada-38b7-47bb-8a5a-29e9d264e722",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -2114,7 +2114,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7ef452ac-4df5-471e-92e0-d85d57b53d22",
+                "id": "cda23a07-ab73-4238-bc92-47532f184ae2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/authentication/accesskey/send - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2127,7 +2127,7 @@
           }
         },
         {
-          "id": "8f34b993-30bb-4f7c-bcb8-717cbccb8b1b",
+          "id": "e522742d-4f79-4f95-90ea-0340d866f60b",
           "name": "Validate session",
           "request": {
             "name": "Validate session",
@@ -2188,7 +2188,7 @@
                     "type": "text/plain"
                   },
                   "key": "accessKey",
-                  "value": "elit incididunt Lorem sint",
+                  "value": "id sit Lorem sed",
                   "type": "text"
                 },
                 {
@@ -2197,7 +2197,7 @@
                     "type": "text/plain"
                   },
                   "key": "login",
-                  "value": "sint deserunt commodo quis consectetur",
+                  "value": "dolore in id Duis",
                   "type": "text"
                 }
               ]
@@ -2208,7 +2208,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b9f98800-d46a-44e8-9f4a-1b1e71aa1631",
+              "id": "b7fecb3e-ba7a-4398-aa60-6e5f65f75fbf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2272,7 +2272,7 @@
                         "type": "text/plain"
                       },
                       "key": "accessKey",
-                      "value": "elit incididunt Lorem sint",
+                      "value": "id sit Lorem sed",
                       "type": "text"
                     },
                     {
@@ -2281,7 +2281,7 @@
                         "type": "text/plain"
                       },
                       "key": "login",
-                      "value": "sint deserunt commodo quis consectetur",
+                      "value": "dolore in id Duis",
                       "type": "text"
                     }
                   ]
@@ -2311,7 +2311,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dd53080d-7edc-48b1-aa91-2e07a43e5870",
+              "id": "63a7ebe1-82a3-4883-8f66-a47a91c1eb82",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -2375,7 +2375,7 @@
                         "type": "text/plain"
                       },
                       "key": "accessKey",
-                      "value": "elit incididunt Lorem sint",
+                      "value": "id sit Lorem sed",
                       "type": "text"
                     },
                     {
@@ -2384,7 +2384,7 @@
                         "type": "text/plain"
                       },
                       "key": "login",
-                      "value": "sint deserunt commodo quis consectetur",
+                      "value": "dolore in id Duis",
                       "type": "text"
                     }
                   ]
@@ -2406,7 +2406,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "113ef821-5f82-4f90-912c-e37e8262a0b0",
+                "id": "77a9c097-58f6-4f43-bf46-7b9eab3707cc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/authentication/accesskey/validate - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2422,7 +2422,7 @@
           }
         },
         {
-          "id": "473026da-73f8-4d91-a81a-04e3bf81487e",
+          "id": "79e1a110-e9aa-40d0-a3e5-97a4d407eb85",
           "name": "Refresh token",
           "request": {
             "name": "Refresh token",
@@ -2497,7 +2497,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c865edcb-3370-4b83-9ab3-43e0bd119d7a",
+              "id": "61e075b8-6078-4353-864f-23cc515beecf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2584,7 +2584,7 @@
                     "type": "text/plain"
                   },
                   "key": "Set-Cookie",
-                  "value": "eu"
+                  "value": "id et"
                 }
               ],
               "body": "{\n  \"status\": \"Success\",\n  \"userId\": \"1f6c17e5-06f9-44a9-a459-b3686e03fa9d\",\n  \"refreshAfter\": \"2025-03-27T02:36:30+00:00\"\n}",
@@ -2595,7 +2595,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "95a94e89-343f-415c-9e52-1dc939949f08",
+                "id": "c2ed9b3c-b0d7-4818-9d29-9c53df4d7368",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/refreshtoken/webstore - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2614,7 +2614,7 @@
       "event": []
     },
     {
-      "id": "3c780fe6-88d6-4f02-82e2-927db1e679de",
+      "id": "4c220cd7-8579-4c75-8ce9-50152470f333",
       "name": "Storefront users",
       "description": {
         "content": "",
@@ -2622,7 +2622,7 @@
       },
       "item": [
         {
-          "id": "c1446e86-892e-4d98-9d33-8ecade24b5c5",
+          "id": "e048496f-6a24-4362-9e4d-da7e3ca50c61",
           "name": "Create storefront user",
           "request": {
             "name": "Create storefront user",
@@ -2719,7 +2719,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "27aa2d3a-63ee-484b-bacd-04e87db5c456",
+              "id": "146ba61f-362d-45e0-9dd7-326abd790f8a",
               "name": "Created\n\nUser created successfully.",
               "originalRequest": {
                 "url": {
@@ -2809,7 +2809,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "44f7806a-7392-4b4f-8a9d-26eb44f50739",
+              "id": "f50ea932-0122-43a3-be30-456515dcef73",
               "name": "Bad Request\n\nInvalid request format or missing required fields or unsupported identifier type.",
               "originalRequest": {
                 "url": {
@@ -2899,7 +2899,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4399d2bc-b844-45f2-a237-9b2badad7205",
+              "id": "9f70323b-a788-43ee-b9ac-adbeb9bbffef",
               "name": "Unauthorized\n\nInvalid or missing authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2979,7 +2979,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0e8422e7-a6ff-471a-a9a5-333948173000",
+              "id": "6307a6f4-64fa-45ff-859d-7cafe57d34cd",
               "name": "Forbidden\n\nInsufficient permissions to create users.",
               "originalRequest": {
                 "url": {
@@ -3059,7 +3059,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "23417e43-bb4f-47be-865a-04c97d184b99",
+              "id": "89074a70-bfbb-449f-8229-89b2be2746af",
               "name": "Conflict\n\nOne or more of the provided identifiers already exist for another user.",
               "originalRequest": {
                 "url": {
@@ -3150,7 +3150,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "99e3e44f-08f9-47b5-974e-bfab644b9b1c",
+                "id": "b38c2aaa-e262-47ab-9c2c-e5b40617931b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3166,7 +3166,7 @@
           }
         },
         {
-          "id": "70605bcf-2fc0-4bf3-8ebe-60f1b8182160",
+          "id": "f30cda4f-7c7c-4f2a-969f-b602db4f6605",
           "name": "Get storefront user by identifier",
           "request": {
             "name": "Get storefront user by identifier",
@@ -3250,7 +3250,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5d2e16b9-4350-4aaa-8c35-7ed7ba2f0c7e",
+              "id": "3d50d315-5dfc-42c5-a507-b64b9e272959",
               "name": "OK\n\nUser found.",
               "originalRequest": {
                 "url": {
@@ -3327,7 +3327,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e1c6a30d-041d-40e2-b1f8-55aa72d55e91",
+              "id": "7a6b9f11-6d9b-4154-9140-95003a566716",
               "name": "Unauthorized\n\nNot authenticated.",
               "originalRequest": {
                 "url": {
@@ -3395,7 +3395,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8bab387a-e5cb-4e7d-9348-69a0e8daf510",
+                "id": "1640d5e8-04ca-4bf7-9b3e-4384190a90c7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pvt/user/info - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3414,7 +3414,7 @@
       "event": []
     },
     {
-      "id": "d43c7d21-74fe-4bd8-b35f-af1784dbe076",
+      "id": "651e101f-9fcc-4c52-8340-f140adf75d1c",
       "name": "Password migration",
       "description": {
         "content": "",
@@ -3422,7 +3422,7 @@
       },
       "item": [
         {
-          "id": "c1f6063e-7f31-4f7e-a683-3704a6e6b515",
+          "id": "848b102c-9b72-45de-ad3e-29f81946c440",
           "name": "Upsert password migration configuration",
           "request": {
             "name": "Upsert password migration configuration",
@@ -3497,7 +3497,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "57e68af7-b127-45de-9368-223f9c9e66ba",
+              "id": "d87a7fd2-77f7-435f-b149-28e8d97b5fc7",
               "name": "OK\n\nFeature registered or updated successfully.",
               "originalRequest": {
                 "url": {
@@ -3568,7 +3568,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "53204a3a-b13d-4596-b35e-06938cf9a262",
+              "id": "ce035d4b-b9c8-455d-8944-576dca15565f",
               "name": "Bad Request\n\nUnknown feature name or invalid secret format.",
               "originalRequest": {
                 "url": {
@@ -3639,7 +3639,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8231df35-d21c-4b58-a8d7-c825d7857749",
+              "id": "63020033-c977-4dfd-aad4-5df0c2ad9232",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -3711,7 +3711,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1529794b-be68-447a-846f-d378f4ea9df0",
+                "id": "8ee619a2-c654-4177-9b93-bfd793cb7ed5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -3724,7 +3724,7 @@
           }
         },
         {
-          "id": "b9c068a2-eda6-4f62-a218-a0161140faf0",
+          "id": "59e45db0-c03d-43e1-819e-a5d89af14835",
           "name": "Enable or disable password migration",
           "request": {
             "name": "Enable or disable password migration",
@@ -3799,7 +3799,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bc80e968-c88b-4207-b139-c5be88a50fe3",
+              "id": "1e9a0dbb-ba8c-460d-952a-5d5dced146c5",
               "name": "OK\n\nFeature toggled successfully.",
               "originalRequest": {
                 "url": {
@@ -3870,7 +3870,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "eef337e6-8052-4d7a-987c-526e61a09553",
+              "id": "e04ba5ba-62de-49fe-9633-b6e7d3fd7dd8",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -3941,7 +3941,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3cac80b5-103d-42a0-999a-1dd9598ae7c1",
+              "id": "7e6e9683-a0f8-45e5-8a84-4edd63924d86",
               "name": "Not Found\n\nFeature not registered for this tenant.",
               "originalRequest": {
                 "url": {
@@ -4012,7 +4012,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d0ffe815-8a80-42b0-a267-ab5c7b0e3879",
+              "id": "6e4ecfdf-75f8-44a2-9209-f6af9b1c762c",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4084,7 +4084,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1c6dc42e-a5ae-445d-937b-072d9a02a987",
+                "id": "45835e58-1356-41f7-bf9b-3a1007d062eb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4097,7 +4097,7 @@
           }
         },
         {
-          "id": "29718543-7117-4fdb-acd8-f1b5149cda15",
+          "id": "b80d584e-2e2d-4869-9330-55855b2efd0d",
           "name": "Delete password migration configuration",
           "request": {
             "name": "Delete password migration configuration",
@@ -4150,7 +4150,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3fad3520-9d18-478d-ab9b-512c69f1081d",
+              "id": "3f119f8c-c53c-4cdf-a1be-914e02455962",
               "name": "No Content\n\nFeature deleted successfully.",
               "originalRequest": {
                 "url": {
@@ -4199,7 +4199,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e27f922e-a706-4e77-b781-6d29c177c122",
+              "id": "52ae5853-c8e5-401f-a93e-a3fd2c0242d8",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -4248,7 +4248,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "394de74d-ac4f-4eb0-b07e-508024674742",
+              "id": "0019e59c-a536-4c7c-aafc-212a2be88ed6",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4298,7 +4298,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cec8ecf6-b40c-498d-a64f-a98c02cefdb5",
+                "id": "ee241f41-9568-4b4e-9b91-f3805df32530",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4315,7 +4315,7 @@
       "event": []
     },
     {
-      "id": "1bf6135f-a6d6-48e9-a54a-2da396d1d270",
+      "id": "dcff006e-4244-4ee5-899d-a2c4953778df",
       "name": "Organization account authentication",
       "description": {
         "content": "",
@@ -4323,7 +4323,7 @@
       },
       "item": [
         {
-          "id": "eb94f347-64da-432d-b29a-06d0757c9a4e",
+          "id": "760d0df8-188b-4b12-8c8b-d95412a42bc0",
           "name": "Get organization unit authentication settings",
           "request": {
             "name": "Get organization unit authentication settings",
@@ -4399,7 +4399,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4554ba44-af16-4b21-926a-95d058cca29a",
+              "id": "731cd4ce-902f-439b-8d16-d4715aa68d92",
               "name": "OK\n\nAuthentication settings were returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4457,7 +4457,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e5c70274-af3f-404f-a57b-4b1e8676317b",
+              "id": "710e7696-2743-4350-8ffc-6c03856090d0",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -4515,7 +4515,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "afd4d28b-5eec-4565-a6c0-a1ef85b2c89b",
+              "id": "bb455226-cd18-4aac-9493-37f4e4f27df5",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -4573,7 +4573,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "32f6432c-78d9-47b3-a615-d29c983adb8e",
+              "id": "0a33a903-a430-422d-8829-26a7577149f8",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -4631,7 +4631,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9c6bec77-fe3e-46cc-9d1f-fbeb8d681fc8",
+              "id": "a9b270e1-865e-4459-8d64-c13c7f72d53b",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4690,7 +4690,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f93d8c32-61e8-4a90-9959-7ad9d731e7f3",
+                "id": "f93736b0-1d09-4b7d-8cb4-14edfca74ec6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4706,7 +4706,7 @@
           }
         },
         {
-          "id": "e24f534d-6131-451e-b30b-8ceb5a586e01",
+          "id": "cbd5ecb2-253d-4bc9-aefb-a932f27a2959",
           "name": "Set organization unit authentication settings",
           "request": {
             "name": "Set organization unit authentication settings",
@@ -4804,7 +4804,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "30ee7f1e-2990-4b00-97f2-d36783051f8f",
+              "id": "ef98f8d4-684f-4f2f-82cc-133e3b6daf19",
               "name": "OK\n\nSettings were updated successfully.",
               "originalRequest": {
                 "url": {
@@ -4884,7 +4884,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "63f336bd-164a-4f25-a5ab-d6a5d25e2310",
+              "id": "d47140f4-ac17-4bc5-8713-d7de3f432d56",
               "name": "Bad Request\n\nInvalid authentication configuration.",
               "originalRequest": {
                 "url": {
@@ -4964,7 +4964,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e317f885-4249-4c56-b2d7-e7d1dca80197",
+              "id": "7915b6ce-4623-4f42-867d-3848e8f57c43",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -5044,7 +5044,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3ec5207e-e3c2-4f40-8f84-805b0e5cd5f0",
+              "id": "c9fa6e5b-0fb4-45af-b6e0-dc1fe7ed7a8d",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -5124,7 +5124,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "84a778da-57f8-49c8-a796-82d6a08481cf",
+              "id": "483fb458-b386-4eef-833a-35fa0d09cff5",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -5204,7 +5204,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "470fe68b-f991-470f-8a6f-4c76eeb545c9",
+              "id": "f3f9e943-511c-4e8d-b8ad-187457b72a8d",
               "name": "Conflict\n\nAuthentication settings already exist for one or more methods.",
               "originalRequest": {
                 "url": {
@@ -5284,7 +5284,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4d1ce942-972c-49b4-8c94-885c4c9aba81",
+              "id": "17f83eb5-4538-42c4-bcf8-56d975e98ec4",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -5365,7 +5365,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d831a359-3e9c-43d6-8b1b-f25c4718529d",
+                "id": "39bae66e-4ba4-49eb-8202-ffcdb569667b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5381,7 +5381,7 @@
           }
         },
         {
-          "id": "1ed6127e-7304-478d-95d4-50b21d044a11",
+          "id": "75e5f320-afc8-496b-af7e-ef8c4a8934d7",
           "name": "Update organization unit authentication settings",
           "request": {
             "name": "Update organization unit authentication settings",
@@ -5479,7 +5479,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d8796f07-7a56-4e2c-8f85-cab192556606",
+              "id": "b9d762c2-3e1f-4978-87fd-6b1293b734a5",
               "name": "OK\n\nUpdated authentication settings were returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c76fb5fb-e99a-4b5d-880d-93ce50990426",
+              "id": "5273fca9-b15f-4c56-af83-d299bd2ce846",
               "name": "Bad Request\n\nInvalid authentication configuration or authentication settings were not found for update.",
               "originalRequest": {
                 "url": {
@@ -5639,7 +5639,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5696361b-fbaf-4aa8-8816-7417b76a6645",
+              "id": "2a5f365b-f7a7-42f9-bd43-db86b4b24df0",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -5719,7 +5719,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7e59ea1e-9295-4fec-88b5-463e5679622b",
+              "id": "269af514-bf5a-451c-8a49-a87c5b6659a0",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -5799,7 +5799,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1adeceb5-4fe1-42bf-9ec4-ebb251b7d170",
+              "id": "120774b8-9a8b-45d6-939b-8ca421b6ee6b",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -5879,7 +5879,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4b3162ff-dbe4-4a5d-885e-c46111091d90",
+              "id": "4f4d24fd-b481-49e4-9f6e-6c98a1300dab",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -5960,7 +5960,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "76a521a3-3a67-4280-aca0-5a62ba0cf4a0",
+                "id": "3e2faf48-86ee-4e56-b09d-5b8050a1661c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5976,7 +5976,7 @@
           }
         },
         {
-          "id": "4719a6c4-9f2b-475c-84bd-23db156f5c2c",
+          "id": "0fea3fb6-3498-4386-ad1c-4f4e2b5dfd4c",
           "name": "Delete organization unit authentication setting",
           "request": {
             "name": "Delete organization unit authentication setting",
@@ -6074,7 +6074,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "89f43af9-5fcd-4b53-86c0-643d241851db",
+              "id": "5215159f-7e16-4452-8117-a953166fbebc",
               "name": "No Content\n\nThe listed authentication configuration entries were deleted successfully.",
               "originalRequest": {
                 "url": {
@@ -6144,7 +6144,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9d97b113-de96-421d-ba03-6575adf4b4b0",
+              "id": "bbf89ed6-9a4c-4200-b886-3d52b687e71d",
               "name": "Bad Request\n\nInvalid authentication configuration or authentication settings were not found for delete.",
               "originalRequest": {
                 "url": {
@@ -6224,7 +6224,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bca52fda-82a1-4f19-8b0d-54f26019565f",
+              "id": "a5b0708a-cc80-40aa-9144-88199fde2e47",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -6304,7 +6304,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "cf8742a2-685c-488f-8e24-299910a066a2",
+              "id": "76a8b4bb-855d-4335-86c2-20014c3fe266",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -6384,7 +6384,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8c60a605-12dc-4a34-95ac-1b4fa1fe18e9",
+              "id": "0c7e0b63-f33c-4181-a379-c2b79bd3df85",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -6464,7 +6464,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4ea16db3-1085-4bb3-bbd3-3521c05dec8f",
+              "id": "0566dba8-8024-4cca-843b-b550a1a98f81",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -6545,7 +6545,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dcbf5abf-58f3-48e6-9f09-9e2c7700618e",
+                "id": "c4a3f776-cdbb-4b71-b7c1-bd2fde2c9846",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6601,7 +6601,7 @@
     }
   ],
   "info": {
-    "_postman_id": "ccee10fa-6868-401a-ab2a-3136d3121c4a",
+    "_postman_id": "615bdc66-be8e-498a-91cb-381bc66b90f7",
     "name": "VTEX ID",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - VTEX ID API.json
+++ b/PostmanCollections/VTEX - VTEX ID API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "3e5b626b-7839-4e61-9c17-837d58ddbedc"
+    "postman_id": "ccee10fa-6868-401a-ab2a-3136d3121c4a"
   },
   "item": [
     {
-      "id": "08d68cbf-108c-4762-a7ea-728f3642b1ec",
+      "id": "61f7e1cc-463c-427f-9e28-d4e0353a04bd",
       "name": "Authentication",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "1f296067-83ac-45f4-94db-dbefa7ff6d4e",
+          "id": "8f619317-19cc-46bc-9a7b-3e4c2910db20",
           "name": "Generate authentication token",
           "request": {
             "name": "Generate authentication token",
@@ -88,7 +88,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b9888f4a-bc66-4107-bf39-f4553f164fb9",
+              "id": "b3f9ad27-fb17-4a13-9bad-4d92493a549c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -178,7 +178,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "70c23743-32c8-4a7e-b0f1-99e84fd05d9a",
+                "id": "e6c70056-6f96-4223-989f-2d75d56037a8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/apptoken/login - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -194,7 +194,7 @@
           }
         },
         {
-          "id": "3c7b704b-b1fc-4433-996d-4652a617da4e",
+          "id": "f63df8e0-db83-487d-bd4f-2f742cd37ff2",
           "name": "Exchange OAuth access token for VTEX credential",
           "request": {
             "name": "Exchange OAuth access token for VTEX credential",
@@ -284,7 +284,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "83c0ba28-cbc8-4e5c-b87e-94f722c24353",
+              "id": "5e8e5b03-e201-49bb-b89c-bf60bc011ff9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -367,7 +367,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a0fed43e-dece-43c9-a7f5-2f4cf574b3c1",
+                "id": "45be2d82-03c2-483c-b068-7811ed3bb7d4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/audience/webstore/provider/oauth/exchange - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -383,7 +383,7 @@
           }
         },
         {
-          "id": "3ceff5bb-6e05-40a1-8302-141e2f15f601",
+          "id": "de052043-276a-4208-a649-8126238b4870",
           "name": "Check authenticated user",
           "request": {
             "name": "Check authenticated user",
@@ -470,7 +470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "89a77aeb-1c78-478a-b19d-e082edc17c2d",
+              "id": "b7130784-88ef-4d16-918a-5bf1beca80e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -559,7 +559,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c4dcd1cc-2c5d-4f8c-b21e-94357481715b",
+              "id": "17df0d68-8d71-452a-aaae-5cd877a56d73",
               "name": "Unauthorized",
               "originalRequest": {
                 "url": {
@@ -649,7 +649,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1dcd2858-5cf4-44bd-a125-7dd66fdd1f4e",
+                "id": "f302ac5f-cffb-4c73-beee-b49d9b39f6f7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/credential/validate - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -665,7 +665,7 @@
           }
         },
         {
-          "id": "b1ec160c-686a-40c3-9eb7-6ab9fb943686",
+          "id": "6273160a-1bee-4a90-b57d-74decf192e34",
           "name": "Enable or disable repeated passwords",
           "request": {
             "name": "Enable or disable repeated passwords",
@@ -742,7 +742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f84708c9-e115-4cfe-a312-7fd47260f686",
+              "id": "9ccf9112-b237-4931-8d9b-7843a459a65a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -816,7 +816,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a770ab3b-68fc-4867-90fe-8a6441f42962",
+                "id": "580b0823-5e09-41a3-a16f-68c861578edc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/providers/setup/password/webstore/password - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -829,7 +829,7 @@
           }
         },
         {
-          "id": "530965c8-7874-45a4-bdcb-700b9ac21a63",
+          "id": "2a399ed7-4ca7-4fdf-87f9-8f177e2d274a",
           "name": "Expire user password",
           "request": {
             "name": "Expire user password",
@@ -909,7 +909,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f7577a25-1177-44e7-9739-88ae3884c009",
+              "id": "0f395acd-b6da-44cd-b65e-975a06337751",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -976,7 +976,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ddbf85fb-9cef-46e9-a30c-ebcc9fe105bc",
+                "id": "d8324976-c33b-42d3-81ee-d4066dd6c898",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/password/expire - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -989,7 +989,7 @@
           }
         },
         {
-          "id": "6b61f981-9d90-4eeb-a4bc-575c38562de2",
+          "id": "887d4c0f-bca3-40a3-a2ca-de78191a2bac",
           "name": "Get user ID by email",
           "request": {
             "name": "Get user ID by email",
@@ -1073,7 +1073,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dbd35c25-81f4-4b9a-aeb3-080eb37cb217",
+              "id": "3173a045-53a6-468a-956a-a95c0308b2f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1150,7 +1150,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "289d6ec0-4fc9-4019-b92f-dc216b3c9b98",
+              "id": "7c792cc7-06c7-4c02-b0a8-f12409e3bcc4",
               "name": "Unauthorized\n\nInvalid or missing VtexIdclientAutCookie.",
               "originalRequest": {
                 "url": {
@@ -1218,7 +1218,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "57201b7a-4f0b-42e3-b03f-6494125fe278",
+                "id": "2984da79-eb90-4ff2-8987-6ccb382fa0ca",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pvt/user/id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1237,7 +1237,7 @@
       "event": []
     },
     {
-      "id": "f842b10d-79b8-465c-a90b-8e7295eada17",
+      "id": "afc1c543-4319-44af-97ba-d08d8c4cef91",
       "name": "Token renewal",
       "description": {
         "content": "",
@@ -1245,7 +1245,7 @@
       },
       "item": [
         {
-          "id": "f988f0ec-3ae3-4fef-9806-284a3e0cbd48",
+          "id": "bfad73f3-32cc-4c35-a737-7f7162b17bc6",
           "name": "Initiate token renewal",
           "request": {
             "name": "Initiate token renewal",
@@ -1293,7 +1293,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "737c0e2c-edf6-4878-b41c-252f056c7e33",
+              "id": "b4225142-08e1-41c8-9ae3-f00dd48f2a27",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1343,7 +1343,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8756b3b8-56ba-426d-9feb-7eb671694893",
+              "id": "ae3a2181-dc37-4e97-b550-eab43f6007ac",
               "name": "Bad Request\n\nInvalid API key or API key not owned by tenant.",
               "originalRequest": {
                 "url": {
@@ -1383,7 +1383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ce28d41e-022c-4536-a80e-8e79a1f30383",
+              "id": "649ae88a-c42e-4e39-a6c3-69a984e4a1d8",
               "name": "Conflict\n\nAlready has a renewed token pending.",
               "originalRequest": {
                 "url": {
@@ -1423,7 +1423,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2326321c-c52e-4da5-b6b4-5f5974f7749d",
+              "id": "61605360-d528-49bd-b1ee-59c33006bc7f",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1464,7 +1464,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d3886980-8861-4a6a-a95d-d4938880a9a1",
+                "id": "60439b71-76df-4b6e-a9df-a2618d654a66",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/apikey/:apiKey/apitoken/renew - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1480,7 +1480,7 @@
           }
         },
         {
-          "id": "6ce93e7d-ee48-49e7-92d5-a2f11ccf76a4",
+          "id": "5986ea35-ff7f-464a-aa82-633b8248c1cc",
           "name": "Complete token renewal",
           "request": {
             "name": "Complete token renewal",
@@ -1528,7 +1528,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9e197469-711a-466c-9701-ddc33875b447",
+              "id": "ad04ce11-2f2b-4dcb-bd02-8e157010d31e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1578,7 +1578,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0df0766c-3bd0-4034-89c7-f01f491768f0",
+              "id": "72bd1719-0ce7-4ac7-b909-59e630c2a91b",
               "name": "Bad Request\n\nInvalid API key or API key not owned by tenant.",
               "originalRequest": {
                 "url": {
@@ -1618,7 +1618,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "031407f1-b73e-4dd6-a51c-88eddb297782",
+              "id": "6f069d4a-a687-4756-b4a3-6faa01aff12a",
               "name": "Not Found\n\nNo renewed API token was found.",
               "originalRequest": {
                 "url": {
@@ -1658,7 +1658,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ea82c655-b237-49ff-b2e5-c4a02cdae884",
+              "id": "0f36cf07-f786-471d-99ff-126b52a2a5c5",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1699,7 +1699,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "21a31693-5fa5-4364-92d6-20d67760d644",
+                "id": "abd1efb2-dd44-4c41-9316-de2cd0ab2c01",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/apikey/:apiKey/apitoken/finish-renewal - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1718,7 +1718,7 @@
       "event": []
     },
     {
-      "id": "722b355f-d627-4e4b-ba6b-7d10bdd94295",
+      "id": "1b040731-264f-4781-add5-61894407ffa4",
       "name": "Refresh token headless",
       "description": {
         "content": "",
@@ -1726,7 +1726,7 @@
       },
       "item": [
         {
-          "id": "f020a243-6df1-4199-a387-865f710bcb4e",
+          "id": "aec1b410-65a4-42e2-8ad1-2351cd7f3d21",
           "name": "Start authentication",
           "request": {
             "name": "Start authentication",
@@ -1799,7 +1799,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d56f50f1-cf9f-493f-a997-aa696b4f3041",
+              "id": "ec264062-bc9c-446a-a3ba-0b35154157a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1886,7 +1886,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f09bf8af-0b49-4ca3-bdba-f51f3b887421",
+                "id": "743ba43d-bb9c-46eb-93af-fed53c1e7f72",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pub/authentication/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1902,7 +1902,7 @@
           }
         },
         {
-          "id": "297423ec-fddc-4301-8e1c-2478207c9a30",
+          "id": "141dac89-4015-4316-ba0f-67de1a16ddb7",
           "name": "Send access key",
           "request": {
             "name": "Send access key",
@@ -1967,7 +1967,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7c933208-c63a-4f8e-9f75-26162517a2e5",
+              "id": "992a8c4f-f6c6-40bb-a0dd-c97b56fe7fc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "791a56b1-e5ef-43ea-9404-508cee6ce47e",
+              "id": "7eb31a36-5e87-43c7-8a12-100ff2e97c17",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -2114,7 +2114,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8868a0b4-6af5-40bb-9837-eeea0064b7cd",
+                "id": "7ef452ac-4df5-471e-92e0-d85d57b53d22",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/authentication/accesskey/send - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2127,7 +2127,7 @@
           }
         },
         {
-          "id": "3d5e7256-8f13-4dba-8bfe-e517f92b347a",
+          "id": "8f34b993-30bb-4f7c-bcb8-717cbccb8b1b",
           "name": "Validate session",
           "request": {
             "name": "Validate session",
@@ -2188,7 +2188,7 @@
                     "type": "text/plain"
                   },
                   "key": "accessKey",
-                  "value": "qui officia",
+                  "value": "elit incididunt Lorem sint",
                   "type": "text"
                 },
                 {
@@ -2197,7 +2197,7 @@
                     "type": "text/plain"
                   },
                   "key": "login",
-                  "value": "cillum culpa",
+                  "value": "sint deserunt commodo quis consectetur",
                   "type": "text"
                 }
               ]
@@ -2208,7 +2208,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7e46c3eb-7a4f-4c22-bb0a-3aa9e5902943",
+              "id": "b9f98800-d46a-44e8-9f4a-1b1e71aa1631",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2272,7 +2272,7 @@
                         "type": "text/plain"
                       },
                       "key": "accessKey",
-                      "value": "qui officia",
+                      "value": "elit incididunt Lorem sint",
                       "type": "text"
                     },
                     {
@@ -2281,7 +2281,7 @@
                         "type": "text/plain"
                       },
                       "key": "login",
-                      "value": "cillum culpa",
+                      "value": "sint deserunt commodo quis consectetur",
                       "type": "text"
                     }
                   ]
@@ -2311,7 +2311,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "19c781d1-b8c8-470a-9aff-b0920830a228",
+              "id": "dd53080d-7edc-48b1-aa91-2e07a43e5870",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -2375,7 +2375,7 @@
                         "type": "text/plain"
                       },
                       "key": "accessKey",
-                      "value": "qui officia",
+                      "value": "elit incididunt Lorem sint",
                       "type": "text"
                     },
                     {
@@ -2384,7 +2384,7 @@
                         "type": "text/plain"
                       },
                       "key": "login",
-                      "value": "cillum culpa",
+                      "value": "sint deserunt commodo quis consectetur",
                       "type": "text"
                     }
                   ]
@@ -2406,7 +2406,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "566708c7-6f1f-4f09-b2a4-8ac73c80e4a4",
+                "id": "113ef821-5f82-4f90-912c-e37e8262a0b0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/authentication/accesskey/validate - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2422,7 +2422,7 @@
           }
         },
         {
-          "id": "0a59c5ab-e0af-41a9-8e9b-8aa2b22063d3",
+          "id": "473026da-73f8-4d91-a81a-04e3bf81487e",
           "name": "Refresh token",
           "request": {
             "name": "Refresh token",
@@ -2497,7 +2497,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e57743bd-816c-4ffe-bff0-8703842dd6cb",
+              "id": "c865edcb-3370-4b83-9ab3-43e0bd119d7a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2584,7 +2584,7 @@
                     "type": "text/plain"
                   },
                   "key": "Set-Cookie",
-                  "value": "eiusmod ea magna"
+                  "value": "eu"
                 }
               ],
               "body": "{\n  \"status\": \"Success\",\n  \"userId\": \"1f6c17e5-06f9-44a9-a459-b3686e03fa9d\",\n  \"refreshAfter\": \"2025-03-27T02:36:30+00:00\"\n}",
@@ -2595,7 +2595,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e42c303d-a2e2-4a14-af1e-172982a91186",
+                "id": "95a94e89-343f-415c-9e52-1dc939949f08",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/refreshtoken/webstore - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2614,7 +2614,7 @@
       "event": []
     },
     {
-      "id": "3a6d35f4-f0cf-42a4-bae3-1d00a1593904",
+      "id": "3c780fe6-88d6-4f02-82e2-927db1e679de",
       "name": "Storefront users",
       "description": {
         "content": "",
@@ -2622,7 +2622,7 @@
       },
       "item": [
         {
-          "id": "eaf22a09-7bd1-420e-8673-22e66c295b94",
+          "id": "c1446e86-892e-4d98-9d33-8ecade24b5c5",
           "name": "Create storefront user",
           "request": {
             "name": "Create storefront user",
@@ -2719,7 +2719,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "34019fb4-0428-468a-8be0-65cf261599cf",
+              "id": "27aa2d3a-63ee-484b-bacd-04e87db5c456",
               "name": "Created\n\nUser created successfully.",
               "originalRequest": {
                 "url": {
@@ -2809,7 +2809,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "12dd1edc-2118-4cc2-a4e5-a6940cd30861",
+              "id": "44f7806a-7392-4b4f-8a9d-26eb44f50739",
               "name": "Bad Request\n\nInvalid request format or missing required fields or unsupported identifier type.",
               "originalRequest": {
                 "url": {
@@ -2899,7 +2899,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "232abad1-f199-42b0-82ee-8b33ff0e3a25",
+              "id": "4399d2bc-b844-45f2-a237-9b2badad7205",
               "name": "Unauthorized\n\nInvalid or missing authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2979,7 +2979,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f201dcbf-29be-4a22-9331-d1f47e606514",
+              "id": "0e8422e7-a6ff-471a-a9a5-333948173000",
               "name": "Forbidden\n\nInsufficient permissions to create users.",
               "originalRequest": {
                 "url": {
@@ -3059,7 +3059,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "23cdbe65-ca8a-4527-8139-b9ff5060cd31",
+              "id": "23417e43-bb4f-47be-865a-04c97d184b99",
               "name": "Conflict\n\nOne or more of the provided identifiers already exist for another user.",
               "originalRequest": {
                 "url": {
@@ -3150,7 +3150,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c6d30fc9-fc86-4e54-8f89-28a68c0a6826",
+                "id": "99e3e44f-08f9-47b5-974e-bfab644b9b1c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3166,7 +3166,7 @@
           }
         },
         {
-          "id": "25baa9d6-eb5f-401d-adca-29dbe604a4c4",
+          "id": "70605bcf-2fc0-4bf3-8ebe-60f1b8182160",
           "name": "Get storefront user by identifier",
           "request": {
             "name": "Get storefront user by identifier",
@@ -3250,7 +3250,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0127a2d6-2bbe-4ce4-9174-f1c4d857f4a4",
+              "id": "5d2e16b9-4350-4aaa-8c35-7ed7ba2f0c7e",
               "name": "OK\n\nUser found.",
               "originalRequest": {
                 "url": {
@@ -3327,7 +3327,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "17bbc647-22ce-4aa5-9175-e3c5f6fd5f81",
+              "id": "e1c6a30d-041d-40e2-b1f8-55aa72d55e91",
               "name": "Unauthorized\n\nNot authenticated.",
               "originalRequest": {
                 "url": {
@@ -3395,7 +3395,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6c91d060-e1dc-4d1b-a480-7ad35cf09e71",
+                "id": "8bab387a-e5cb-4e7d-9348-69a0e8daf510",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pvt/user/info - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3414,7 +3414,7 @@
       "event": []
     },
     {
-      "id": "8e1def75-9508-4a62-a140-c64c6a72166d",
+      "id": "d43c7d21-74fe-4bd8-b35f-af1784dbe076",
       "name": "Password migration",
       "description": {
         "content": "",
@@ -3422,7 +3422,7 @@
       },
       "item": [
         {
-          "id": "981f7fe1-915e-4ebd-8f04-49feace89025",
+          "id": "c1f6063e-7f31-4f7e-a683-3704a6e6b515",
           "name": "Upsert password migration configuration",
           "request": {
             "name": "Upsert password migration configuration",
@@ -3497,7 +3497,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e80b20a6-4c95-4e5f-9c3f-f3b505470cdc",
+              "id": "57e68af7-b127-45de-9368-223f9c9e66ba",
               "name": "OK\n\nFeature registered or updated successfully.",
               "originalRequest": {
                 "url": {
@@ -3568,7 +3568,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ca6033e7-b2c8-4e4a-ac2e-ad50353bd93a",
+              "id": "53204a3a-b13d-4596-b35e-06938cf9a262",
               "name": "Bad Request\n\nUnknown feature name or invalid secret format.",
               "originalRequest": {
                 "url": {
@@ -3639,7 +3639,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5772fcb3-0aab-47c1-b488-8648de112dc1",
+              "id": "8231df35-d21c-4b58-a8d7-c825d7857749",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -3711,7 +3711,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "28536591-7003-4942-a731-185b0653fc77",
+                "id": "1529794b-be68-447a-846f-d378f4ea9df0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -3724,7 +3724,7 @@
           }
         },
         {
-          "id": "04914e0f-b846-4652-8296-3a0dcda8e81b",
+          "id": "b9c068a2-eda6-4f62-a218-a0161140faf0",
           "name": "Enable or disable password migration",
           "request": {
             "name": "Enable or disable password migration",
@@ -3799,7 +3799,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "88ce2298-20b2-4f0e-8eb8-5febb7c98885",
+              "id": "bc80e968-c88b-4207-b139-c5be88a50fe3",
               "name": "OK\n\nFeature toggled successfully.",
               "originalRequest": {
                 "url": {
@@ -3870,7 +3870,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "37d38fbd-b0ec-409c-8007-7e2d3d41976e",
+              "id": "eef337e6-8052-4d7a-987c-526e61a09553",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -3941,7 +3941,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7f771326-9b71-4dfe-9117-7414224b992a",
+              "id": "3cac80b5-103d-42a0-999a-1dd9598ae7c1",
               "name": "Not Found\n\nFeature not registered for this tenant.",
               "originalRequest": {
                 "url": {
@@ -4012,7 +4012,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "09ba756c-5482-4520-b8c4-4860746c4843",
+              "id": "d0ffe815-8a80-42b0-a267-ab5c7b0e3879",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4084,7 +4084,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e4f325a5-e6a2-433e-9988-30e357fc5b0e",
+                "id": "1c6dc42e-a5ae-445d-937b-072d9a02a987",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4097,7 +4097,7 @@
           }
         },
         {
-          "id": "b8eb4a0a-75c4-4503-9fae-0b2bd4d4bc11",
+          "id": "29718543-7117-4fdb-acd8-f1b5149cda15",
           "name": "Delete password migration configuration",
           "request": {
             "name": "Delete password migration configuration",
@@ -4150,7 +4150,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "321606d1-eeb4-4296-b53b-200554474686",
+              "id": "3fad3520-9d18-478d-ab9b-512c69f1081d",
               "name": "No Content\n\nFeature deleted successfully.",
               "originalRequest": {
                 "url": {
@@ -4199,7 +4199,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "37923d21-1a7d-4c46-859f-e9aee0badfa6",
+              "id": "e27f922e-a706-4e77-b781-6d29c177c122",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -4248,7 +4248,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "10ed0ca8-775b-4905-a1b8-1ec661082c17",
+              "id": "394de74d-ac4f-4eb0-b07e-508024674742",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4298,7 +4298,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "04ca4b56-4c4c-417f-9ff0-7d23f09f0dce",
+                "id": "cec8ecf6-b40c-498d-a64f-a98c02cefdb5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4315,7 +4315,7 @@
       "event": []
     },
     {
-      "id": "ffd6537c-b77e-4a6e-b8b7-884def2095f8",
+      "id": "1bf6135f-a6d6-48e9-a54a-2da396d1d270",
       "name": "Organization account authentication",
       "description": {
         "content": "",
@@ -4323,7 +4323,7 @@
       },
       "item": [
         {
-          "id": "2727399e-1c35-4793-8df1-8657bf09104c",
+          "id": "eb94f347-64da-432d-b29a-06d0757c9a4e",
           "name": "Get organization unit authentication settings",
           "request": {
             "name": "Get organization unit authentication settings",
@@ -4399,7 +4399,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ce699b32-0303-4873-892f-6c6ceb193c7d",
+              "id": "4554ba44-af16-4b21-926a-95d058cca29a",
               "name": "OK\n\nAuthentication settings were returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4457,7 +4457,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5e8df9c5-0080-456c-b1a0-ff45146a4114",
+              "id": "e5c70274-af3f-404f-a57b-4b1e8676317b",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -4515,7 +4515,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "76afa916-08dc-4871-a10a-f2ed2ec76c77",
+              "id": "afd4d28b-5eec-4565-a6c0-a1ef85b2c89b",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -4573,7 +4573,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b013e261-e8c1-46a3-b842-2cf52b210cff",
+              "id": "32f6432c-78d9-47b3-a615-d29c983adb8e",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -4631,7 +4631,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7e1b26e3-2cd9-451e-8c7f-d93bb0657d8d",
+              "id": "9c6bec77-fe3e-46cc-9d1f-fbeb8d681fc8",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4690,7 +4690,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "74ebec04-88e4-4ae0-bea3-3c3981f0485b",
+                "id": "f93d8c32-61e8-4a90-9959-7ad9d731e7f3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4706,7 +4706,7 @@
           }
         },
         {
-          "id": "8297c141-da47-430d-8fb0-be4f08836ab6",
+          "id": "e24f534d-6131-451e-b30b-8ceb5a586e01",
           "name": "Set organization unit authentication settings",
           "request": {
             "name": "Set organization unit authentication settings",
@@ -4804,7 +4804,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "833fb8fe-8155-452a-852a-0ac53fcf14ab",
+              "id": "30ee7f1e-2990-4b00-97f2-d36783051f8f",
               "name": "OK\n\nSettings were updated successfully.",
               "originalRequest": {
                 "url": {
@@ -4884,7 +4884,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1fd29d26-d32f-453a-bafd-2e66019a9a80",
+              "id": "63f336bd-164a-4f25-a5ab-d6a5d25e2310",
               "name": "Bad Request\n\nInvalid authentication configuration.",
               "originalRequest": {
                 "url": {
@@ -4964,7 +4964,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "768aed88-cb99-4f6e-a4b7-0ef51aca92f1",
+              "id": "e317f885-4249-4c56-b2d7-e7d1dca80197",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -5044,7 +5044,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "14eb0fd1-7e12-4f53-b44b-9fd70db803b7",
+              "id": "3ec5207e-e3c2-4f40-8f84-805b0e5cd5f0",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -5124,7 +5124,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5d9bddf8-7fdd-4b7a-b4f6-7b9d748e67cb",
+              "id": "84a778da-57f8-49c8-a796-82d6a08481cf",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -5204,7 +5204,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "08be1cd2-46e2-49ae-9e15-6d7b9c1c54aa",
+              "id": "470fe68b-f991-470f-8a6f-4c76eeb545c9",
               "name": "Conflict\n\nAuthentication settings already exist for one or more methods.",
               "originalRequest": {
                 "url": {
@@ -5284,7 +5284,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "68da9303-82d1-4584-87b9-77f376cea9f5",
+              "id": "4d1ce942-972c-49b4-8c94-885c4c9aba81",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -5365,7 +5365,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fc3519f4-5318-43a9-8600-0845f058f00a",
+                "id": "d831a359-3e9c-43d6-8b1b-f25c4718529d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5381,7 +5381,7 @@
           }
         },
         {
-          "id": "5a23520d-45a1-4826-b878-0fc31332da26",
+          "id": "1ed6127e-7304-478d-95d4-50b21d044a11",
           "name": "Update organization unit authentication settings",
           "request": {
             "name": "Update organization unit authentication settings",
@@ -5479,7 +5479,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3294d185-2d2a-43a1-9149-55ee17cc6f16",
+              "id": "d8796f07-7a56-4e2c-8f85-cab192556606",
               "name": "OK\n\nUpdated authentication settings were returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5559,7 +5559,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ce4e3b6c-34c5-4f4b-828f-c0e16a03bf90",
+              "id": "c76fb5fb-e99a-4b5d-880d-93ce50990426",
               "name": "Bad Request\n\nInvalid authentication configuration or authentication settings were not found for update.",
               "originalRequest": {
                 "url": {
@@ -5639,7 +5639,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9a77a1b1-d4e5-4f96-8111-67697258befd",
+              "id": "5696361b-fbaf-4aa8-8816-7417b76a6645",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -5719,7 +5719,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "32416092-2bd9-4247-859e-3ae11741a67f",
+              "id": "7e59ea1e-9295-4fec-88b5-463e5679622b",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -5799,7 +5799,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "04326067-3825-4578-bb54-2ab44af758cb",
+              "id": "1adeceb5-4fe1-42bf-9ec4-ebb251b7d170",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -5879,7 +5879,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "75ebdb85-c6f7-471a-b93e-199769f6edbf",
+              "id": "4b3162ff-dbe4-4a5d-885e-c46111091d90",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -5960,7 +5960,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d0024785-41a0-45cc-9f17-cd90e36c92ba",
+                "id": "76a521a3-3a67-4280-aca0-5a62ba0cf4a0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5976,7 +5976,7 @@
           }
         },
         {
-          "id": "5f657989-cfa5-4d26-9820-fad9caea45b7",
+          "id": "4719a6c4-9f2b-475c-84bd-23db156f5c2c",
           "name": "Delete organization unit authentication setting",
           "request": {
             "name": "Delete organization unit authentication setting",
@@ -6074,7 +6074,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "91b96da4-544e-406a-bdac-72170b42e27f",
+              "id": "89f43af9-5fcd-4b53-86c0-643d241851db",
               "name": "No Content\n\nThe listed authentication configuration entries were deleted successfully.",
               "originalRequest": {
                 "url": {
@@ -6144,7 +6144,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f70bd770-549f-4e39-bf87-ae22f9f55fd4",
+              "id": "9d97b113-de96-421d-ba03-6575adf4b4b0",
               "name": "Bad Request\n\nInvalid authentication configuration or authentication settings were not found for delete.",
               "originalRequest": {
                 "url": {
@@ -6224,7 +6224,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7466b8b3-90f6-4938-9bcf-2420318feaff",
+              "id": "bca52fda-82a1-4f19-8b0d-54f26019565f",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -6304,7 +6304,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "caf2e82f-c788-49c3-ac01-86ef8cf69193",
+              "id": "cf8742a2-685c-488f-8e24-299910a066a2",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -6384,7 +6384,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "69bb8c34-7128-486c-862a-bad11f70bc86",
+              "id": "8c60a605-12dc-4a34-95ac-1b4fa1fe18e9",
               "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
               "originalRequest": {
                 "url": {
@@ -6464,7 +6464,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "629471be-86e2-41d9-9917-6393a7b62c17",
+              "id": "4ea16db3-1085-4bb3-bbd3-3521c05dec8f",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -6545,7 +6545,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "93de9155-e6ef-41bf-b256-f2b596d1d044",
+                "id": "dcbf5abf-58f3-48e6-9f09-9e2c7700618e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6601,7 +6601,7 @@
     }
   ],
   "info": {
-    "_postman_id": "3e5b626b-7839-4e61-9c17-837d58ddbedc",
+    "_postman_id": "ccee10fa-6868-401a-ab2a-3136d3121c4a",
     "name": "VTEX ID",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - VTEX ID API.json
+++ b/PostmanCollections/VTEX - VTEX ID API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "785a862c-03cb-464a-987a-d7d599e1490f"
+    "postman_id": "3e5b626b-7839-4e61-9c17-837d58ddbedc"
   },
   "item": [
     {
-      "id": "32ab01d0-62c6-448f-a63c-2fb0fe1aa4f9",
+      "id": "08d68cbf-108c-4762-a7ea-728f3642b1ec",
       "name": "Authentication",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "ea270283-b02d-4274-8814-a706f94c94e5",
+          "id": "1f296067-83ac-45f4-94db-dbefa7ff6d4e",
           "name": "Generate authentication token",
           "request": {
             "name": "Generate authentication token",
@@ -88,7 +88,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6dabeb23-4530-4a4d-a833-c80eae29dc61",
+              "id": "b9888f4a-bc66-4107-bf39-f4553f164fb9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -178,7 +178,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4589534b-aef6-4823-a3f6-b53f89445e8f",
+                "id": "70c23743-32c8-4a7e-b0f1-99e84fd05d9a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/apptoken/login - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -194,7 +194,7 @@
           }
         },
         {
-          "id": "dd7ea228-67ae-4f86-8af7-9225c4ef4a57",
+          "id": "3c7b704b-b1fc-4433-996d-4652a617da4e",
           "name": "Exchange OAuth access token for VTEX credential",
           "request": {
             "name": "Exchange OAuth access token for VTEX credential",
@@ -284,7 +284,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0980f201-abcb-44dc-8c64-022f7deb64d9",
+              "id": "83c0ba28-cbc8-4e5c-b87e-94f722c24353",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -367,7 +367,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "de3f9918-aeb2-4969-96c3-e4173c5c4e58",
+                "id": "a0fed43e-dece-43c9-a7f5-2f4cf574b3c1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/audience/webstore/provider/oauth/exchange - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -383,7 +383,7 @@
           }
         },
         {
-          "id": "421a8104-04c5-41c1-a750-b27cba958992",
+          "id": "3ceff5bb-6e05-40a1-8302-141e2f15f601",
           "name": "Check authenticated user",
           "request": {
             "name": "Check authenticated user",
@@ -470,7 +470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7d1c85b7-94d9-4062-9522-a72d2ef37176",
+              "id": "89a77aeb-1c78-478a-b19d-e082edc17c2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -559,7 +559,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4e2abab0-6eb8-4139-a78b-081778b600f4",
+              "id": "c4dcd1cc-2c5d-4f8c-b21e-94357481715b",
               "name": "Unauthorized",
               "originalRequest": {
                 "url": {
@@ -649,7 +649,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "53693c26-8120-4ab6-b7e4-d910fb9ee997",
+                "id": "1dcd2858-5cf4-44bd-a125-7dd66fdd1f4e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/credential/validate - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -665,7 +665,7 @@
           }
         },
         {
-          "id": "b4c4a230-d904-445b-92fe-1863f4d9b6d2",
+          "id": "b1ec160c-686a-40c3-9eb7-6ab9fb943686",
           "name": "Enable or disable repeated passwords",
           "request": {
             "name": "Enable or disable repeated passwords",
@@ -742,7 +742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e2ee72e0-e5e0-4458-89e8-494d44342b57",
+              "id": "f84708c9-e115-4cfe-a312-7fd47260f686",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -816,7 +816,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7bd34649-78a4-40df-b9dc-cbe661979a12",
+                "id": "a770ab3b-68fc-4867-90fe-8a6441f42962",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/providers/setup/password/webstore/password - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -829,7 +829,7 @@
           }
         },
         {
-          "id": "188ba090-a7c9-443f-aec4-d111e11950e2",
+          "id": "530965c8-7874-45a4-bdcb-700b9ac21a63",
           "name": "Expire user password",
           "request": {
             "name": "Expire user password",
@@ -909,7 +909,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7380b4e2-febb-4b66-9520-d8709bce4b43",
+              "id": "f7577a25-1177-44e7-9739-88ae3884c009",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -976,7 +976,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "664ce842-2de9-4dbb-a2fc-b0b137d04d66",
+                "id": "ddbf85fb-9cef-46e9-a30c-ebcc9fe105bc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/password/expire - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -989,7 +989,7 @@
           }
         },
         {
-          "id": "ea454ad8-5715-499d-aa4f-62f593d39069",
+          "id": "6b61f981-9d90-4eeb-a4bc-575c38562de2",
           "name": "Get user ID by email",
           "request": {
             "name": "Get user ID by email",
@@ -1073,7 +1073,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bc5608f9-318f-47bd-a1a3-4ae225f32b84",
+              "id": "dbd35c25-81f4-4b9a-aeb3-080eb37cb217",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1150,7 +1150,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "329ad518-61d3-403e-bf5a-6eace14bf7a1",
+              "id": "289d6ec0-4fc9-4019-b92f-dc216b3c9b98",
               "name": "Unauthorized\n\nInvalid or missing VtexIdclientAutCookie.",
               "originalRequest": {
                 "url": {
@@ -1218,7 +1218,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ff31c022-f2f5-4cc6-be87-572fd21dce76",
+                "id": "57201b7a-4f0b-42e3-b03f-6494125fe278",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pvt/user/id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1237,7 +1237,7 @@
       "event": []
     },
     {
-      "id": "8db44745-4529-4e09-a583-fc291ffe90f5",
+      "id": "f842b10d-79b8-465c-a90b-8e7295eada17",
       "name": "Token renewal",
       "description": {
         "content": "",
@@ -1245,7 +1245,7 @@
       },
       "item": [
         {
-          "id": "eedaa725-4977-4f73-90de-b616a423a57e",
+          "id": "f988f0ec-3ae3-4fef-9806-284a3e0cbd48",
           "name": "Initiate token renewal",
           "request": {
             "name": "Initiate token renewal",
@@ -1293,7 +1293,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "04de5cd2-e8c9-4ae5-9e5e-5cfa51000b03",
+              "id": "737c0e2c-edf6-4878-b41c-252f056c7e33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1343,7 +1343,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a29a33e3-4ded-4289-bfd8-ad5ad190a92e",
+              "id": "8756b3b8-56ba-426d-9feb-7eb671694893",
               "name": "Bad Request\n\nInvalid API key or API key not owned by tenant.",
               "originalRequest": {
                 "url": {
@@ -1383,7 +1383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0679b9dd-0f0b-4785-8ba9-6e774c09ebbc",
+              "id": "ce28d41e-022c-4536-a80e-8e79a1f30383",
               "name": "Conflict\n\nAlready has a renewed token pending.",
               "originalRequest": {
                 "url": {
@@ -1423,7 +1423,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "04f6cdaa-a9a7-4047-a1e8-9fb9c2a5f377",
+              "id": "2326321c-c52e-4da5-b6b4-5f5974f7749d",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1464,7 +1464,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dcbc8bc2-9e97-45d2-90e7-296e08e4295d",
+                "id": "d3886980-8861-4a6a-a95d-d4938880a9a1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/apikey/:apiKey/apitoken/renew - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1480,7 +1480,7 @@
           }
         },
         {
-          "id": "529fcd17-2a8b-46ec-af04-9f843966d322",
+          "id": "6ce93e7d-ee48-49e7-92d5-a2f11ccf76a4",
           "name": "Complete token renewal",
           "request": {
             "name": "Complete token renewal",
@@ -1528,7 +1528,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b8faea1b-dcc7-47cc-ab54-de43feb7cea4",
+              "id": "9e197469-711a-466c-9701-ddc33875b447",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1578,7 +1578,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6bb14b8a-47ca-472b-9a91-cb8338c80c22",
+              "id": "0df0766c-3bd0-4034-89c7-f01f491768f0",
               "name": "Bad Request\n\nInvalid API key or API key not owned by tenant.",
               "originalRequest": {
                 "url": {
@@ -1618,7 +1618,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "df292589-c58e-42e5-ae2f-41fd792de75c",
+              "id": "031407f1-b73e-4dd6-a51c-88eddb297782",
               "name": "Not Found\n\nNo renewed API token was found.",
               "originalRequest": {
                 "url": {
@@ -1658,7 +1658,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d585b99c-7da0-44f5-9847-d94bcd65dce4",
+              "id": "ea82c655-b237-49ff-b2e5-c4a02cdae884",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1699,7 +1699,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fdd57e57-e6a4-47e8-aa3f-f0c857bdaea2",
+                "id": "21a31693-5fa5-4364-92d6-20d67760d644",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/apikey/:apiKey/apitoken/finish-renewal - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1718,15 +1718,15 @@
       "event": []
     },
     {
-      "id": "de81dda5-0173-4614-8787-3c70ccfc6a61",
-      "name": "Refresh token (Headless)",
+      "id": "722b355f-d627-4e4b-ba6b-7d10bdd94295",
+      "name": "Refresh token headless",
       "description": {
         "content": "",
         "type": "text/plain"
       },
       "item": [
         {
-          "id": "73bb3792-4c91-475d-a076-d4f96a95134f",
+          "id": "f020a243-6df1-4199-a387-865f710bcb4e",
           "name": "Start authentication",
           "request": {
             "name": "Start authentication",
@@ -1799,7 +1799,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9fee28da-b1ed-402b-8387-cb4ee73cfbb3",
+              "id": "d56f50f1-cf9f-493f-a997-aa696b4f3041",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1886,7 +1886,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "47f6b633-b874-4903-a4f8-24c0013a9750",
+                "id": "f09bf8af-0b49-4ca3-bdba-f51f3b887421",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pub/authentication/start - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1902,7 +1902,7 @@
           }
         },
         {
-          "id": "c7bc6979-268f-4863-afc0-17c10f074401",
+          "id": "297423ec-fddc-4301-8e1c-2478207c9a30",
           "name": "Send access key",
           "request": {
             "name": "Send access key",
@@ -1967,7 +1967,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9ff29bcb-084c-460a-8d1c-24620946cb8c",
+              "id": "7c933208-c63a-4f8e-9f75-26162517a2e5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2035,7 +2035,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b8dd6558-35e3-4147-9404-559f28fd0dcf",
+              "id": "791a56b1-e5ef-43ea-9404-508cee6ce47e",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -2114,7 +2114,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7f224efb-34bf-4bc5-b061-07642d29e88b",
+                "id": "8868a0b4-6af5-40bb-9837-eeea0064b7cd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/authentication/accesskey/send - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2127,7 +2127,7 @@
           }
         },
         {
-          "id": "d03f6949-e9d9-4bde-91cf-8ebeebea46e1",
+          "id": "3d5e7256-8f13-4dba-8bfe-e517f92b347a",
           "name": "Validate session",
           "request": {
             "name": "Validate session",
@@ -2188,7 +2188,7 @@
                     "type": "text/plain"
                   },
                   "key": "accessKey",
-                  "value": "Ut magna aute",
+                  "value": "qui officia",
                   "type": "text"
                 },
                 {
@@ -2197,7 +2197,7 @@
                     "type": "text/plain"
                   },
                   "key": "login",
-                  "value": "labore consequat laboris",
+                  "value": "cillum culpa",
                   "type": "text"
                 }
               ]
@@ -2208,7 +2208,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "224431be-613d-47b9-b0c8-9ec0fec072ad",
+              "id": "7e46c3eb-7a4f-4c22-bb0a-3aa9e5902943",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2272,7 +2272,7 @@
                         "type": "text/plain"
                       },
                       "key": "accessKey",
-                      "value": "Ut magna aute",
+                      "value": "qui officia",
                       "type": "text"
                     },
                     {
@@ -2281,7 +2281,7 @@
                         "type": "text/plain"
                       },
                       "key": "login",
-                      "value": "labore consequat laboris",
+                      "value": "cillum culpa",
                       "type": "text"
                     }
                   ]
@@ -2311,7 +2311,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d711f2de-786e-456d-88ee-208abcebf53b",
+              "id": "19c781d1-b8c8-470a-9aff-b0920830a228",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -2375,7 +2375,7 @@
                         "type": "text/plain"
                       },
                       "key": "accessKey",
-                      "value": "Ut magna aute",
+                      "value": "qui officia",
                       "type": "text"
                     },
                     {
@@ -2384,7 +2384,7 @@
                         "type": "text/plain"
                       },
                       "key": "login",
-                      "value": "labore consequat laboris",
+                      "value": "cillum culpa",
                       "type": "text"
                     }
                   ]
@@ -2406,7 +2406,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0bbfc1c8-0816-44e1-8c5e-20288a2f3643",
+                "id": "566708c7-6f1f-4f09-b2a4-8ac73c80e4a4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/pub/authentication/accesskey/validate - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2422,7 +2422,7 @@
           }
         },
         {
-          "id": "55238173-58f6-4466-a264-4eb996bcf159",
+          "id": "0a59c5ab-e0af-41a9-8e9b-8aa2b22063d3",
           "name": "Refresh token",
           "request": {
             "name": "Refresh token",
@@ -2497,7 +2497,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "046dd4ee-16ca-4941-ae39-fe83c8958712",
+              "id": "e57743bd-816c-4ffe-bff0-8703842dd6cb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2584,7 +2584,7 @@
                     "type": "text/plain"
                   },
                   "key": "Set-Cookie",
-                  "value": "vid_rt=QiEOQKuzdRjukvSnsn7F8h1wwkrqq8wWlkk7bXA5LSbTHkbKbYEfDJ7MGb6_pllGWd1VQ-JxQI7UDLvYrCUH9o7i1rOSeSG8zJewZw"
+                  "value": "eiusmod ea magna"
                 }
               ],
               "body": "{\n  \"status\": \"Success\",\n  \"userId\": \"1f6c17e5-06f9-44a9-a459-b3686e03fa9d\",\n  \"refreshAfter\": \"2025-03-27T02:36:30+00:00\"\n}",
@@ -2595,7 +2595,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5b407755-0bb9-43dd-9c01-8932f25b8e06",
+                "id": "e42c303d-a2e2-4a14-af1e-172982a91186",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/refreshtoken/webstore - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2614,7 +2614,7 @@
       "event": []
     },
     {
-      "id": "f9f39f02-a77e-4050-9a2a-ecb6851fc3e6",
+      "id": "3a6d35f4-f0cf-42a4-bae3-1d00a1593904",
       "name": "Storefront users",
       "description": {
         "content": "",
@@ -2622,7 +2622,7 @@
       },
       "item": [
         {
-          "id": "5f6a144c-79a8-482a-ba65-1e30c18400f7",
+          "id": "eaf22a09-7bd1-420e-8673-22e66c295b94",
           "name": "Create storefront user",
           "request": {
             "name": "Create storefront user",
@@ -2634,6 +2634,7 @@
               "path": [
                 "api",
                 "authenticator",
+                "v1",
                 "storefront",
                 "users"
               ],
@@ -2718,13 +2719,14 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "db0feb40-4e0c-494b-8810-0d7882f97734",
+              "id": "34019fb4-0428-468a-8be0-65cf261599cf",
               "name": "Created\n\nUser created successfully.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "storefront",
                     "users"
                   ],
@@ -2807,13 +2809,14 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f1447d15-adf4-48f4-a77d-bc269a3cd3f6",
-              "name": "Bad Request \n\n Invalid request format, missing required fields, or unsupported identifier type.",
+              "id": "12dd1edc-2118-4cc2-a4e5-a6940cd30861",
+              "name": "Bad Request\n\nInvalid request format or missing required fields or unsupported identifier type.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "storefront",
                     "users"
                   ],
@@ -2896,13 +2899,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ff4a6da4-d091-4c64-9565-a20850592d8c",
+              "id": "232abad1-f199-42b0-82ee-8b33ff0e3a25",
               "name": "Unauthorized\n\nInvalid or missing authentication credentials.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "storefront",
                     "users"
                   ],
@@ -2975,13 +2979,14 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fd887ea0-2a75-40df-adad-8d12b717aa43",
+              "id": "f201dcbf-29be-4a22-9331-d1f47e606514",
               "name": "Forbidden\n\nInsufficient permissions to create users.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "storefront",
                     "users"
                   ],
@@ -3054,13 +3059,14 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7ac14aaf-d4af-4c4e-a911-4aa07f8e883b",
+              "id": "23cdbe65-ca8a-4527-8139-b9ff5060cd31",
               "name": "Conflict\n\nOne or more of the provided identifiers already exist for another user.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "api",
                     "authenticator",
+                    "v1",
                     "storefront",
                     "users"
                   ],
@@ -3144,13 +3150,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "4156fb60-a76a-4fd3-86b6-ab27259f88d5",
+                "id": "c6d30fc9-fc86-4e54-8f89-28a68c0a6826",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/storefront/users - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
-                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/authenticator/storefront/users - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/authenticator/storefront/users - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"userId\":{\"type\":\"string\",\"description\":\"Unique user identifier (GUID).\"},\"identifier\":{\"type\":\"string\",\"description\":\"Primary identifier used for the user (typically the first one provided in the request).\"}}}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/authenticator/storefront/users - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"userId\":{\"type\":\"string\",\"description\":\"Unique user identifier (GUID).\"},\"identifier\":{\"type\":\"string\",\"description\":\"Primary identifier used for the user (typically the first one provided in the request).\"}}}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -3160,7 +3166,7 @@
           }
         },
         {
-          "id": "a7e1e3fb-8f43-46a7-a43c-e7aec3792085",
+          "id": "25baa9d6-eb5f-401d-adca-29dbe604a4c4",
           "name": "Get storefront user by identifier",
           "request": {
             "name": "Get storefront user by identifier",
@@ -3244,7 +3250,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d79fb12a-a334-44a0-9c32-120792379902",
+              "id": "0127a2d6-2bbe-4ce4-9174-f1c4d857f4a4",
               "name": "OK\n\nUser found.",
               "originalRequest": {
                 "url": {
@@ -3321,7 +3327,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "588f9627-9a81-484c-ac84-c5ebb53b4e1b",
+              "id": "17bbc647-22ce-4aa5-9175-e3c5f6fd5f81",
               "name": "Unauthorized\n\nNot authenticated.",
               "originalRequest": {
                 "url": {
@@ -3389,7 +3395,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2690e854-b8fc-410a-8820-f3a422129b52",
+                "id": "6c91d060-e1dc-4d1b-a480-7ad35cf09e71",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/pvt/user/info - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3408,7 +3414,7 @@
       "event": []
     },
     {
-      "id": "03cd5b24-ade7-47aa-86f7-1ec20951892e",
+      "id": "8e1def75-9508-4a62-a140-c64c6a72166d",
       "name": "Password migration",
       "description": {
         "content": "",
@@ -3416,12 +3422,12 @@
       },
       "item": [
         {
-          "id": "6c263f8c-c223-4786-a7fb-916b54a38635",
+          "id": "981f7fe1-915e-4ebd-8f04-49feace89025",
           "name": "Upsert password migration configuration",
           "request": {
             "name": "Upsert password migration configuration",
             "description": {
-              "content": "Configures or updates the external authentication middleware settings for B2B password migration. This endpoint registers the middleware URL and HMAC credentials that VTEX will use to validate legacy user credentials during their first login.\r\n\r\nOnce configured, users with the `isLegacyPassword` flag set to `true` will have their credentials validated against the configured middleware endpoint on their first login attempt.\r\n\r\nFor more information, see the [B2B password migration guide](https://developers.vtex.com/docs/guides/b2b-password-migration).\r\n\r\n> ⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/docs/tutorials/b2b-buyer-portal), which is currently available to selected accounts.\r\n\r\n## Notes and limitations\r\n\r\n- The middleware endpoint must be accessible via HTTPS with a valid TLS certificate.\r\n- The middleware must respond within 3 seconds (p95 ≤ 1s, p99 ≤ 2.5s recommended).\r\n- The `clientId` and `Secret` are used for HMAC-SHA256 request signing.\r\n- The `Secret` is treated as a sensitive credential and should not be logged or shared.\r\n- Don't reuse secrets across environments (for example, staging vs. production).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [authentication](https://developers.vtex.com/docs/guides/authentication) or [permissions](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3).",
+              "content": "Configures or updates the external authentication middleware settings for B2B password migration. This endpoint registers the middleware URL and HMAC credentials that VTEX will use to validate legacy user credentials during their first login.\r\n\r\nOnce configured, users with the `isLegacyPassword` flag set to `true` will have their credentials validated against the configured middleware endpoint on their first login attempt.\r\n\r\nFor more information, see the [B2B password migration guide](https://developers.vtex.com/docs/guides/b2b-password-migration).\r\n\r\n> ⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/docs/tutorials/b2b-buyer-portal), which is currently available to selected accounts.\r\n\r\n## Notes and limitations\r\n\r\n- The middleware endpoint must be accessible via HTTPS with a valid TLS certificate.\r\n- The middleware must respond within 3 seconds (p95 ≤ 1s, p99 ≤ 2.5s recommended).\r\n- The `clientId` and `secret` are used for HMAC-SHA256 request signing.\r\n- The `secret` is treated as a sensitive credential and should not be logged or shared.\r\n- Don't reuse secrets across environments (for example, staging vs. production).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [authentication](https://developers.vtex.com/docs/guides/authentication) or [permissions](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3).",
               "type": "text/plain"
             },
             "url": {
@@ -3477,7 +3483,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"IdpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"Secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
+              "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"idpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -3491,7 +3497,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "28437896-f156-467e-960f-2068a49df436",
+              "id": "e80b20a6-4c95-4e5f-9c3f-f3b505470cdc",
               "name": "OK\n\nFeature registered or updated successfully.",
               "originalRequest": {
                 "url": {
@@ -3544,7 +3550,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"IdpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"Secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
+                  "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"idpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3562,7 +3568,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6ecaf13b-6751-410f-9c3a-c104587745ec",
+              "id": "ca6033e7-b2c8-4e4a-ac2e-ad50353bd93a",
               "name": "Bad Request\n\nUnknown feature name or invalid secret format.",
               "originalRequest": {
                 "url": {
@@ -3615,7 +3621,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"IdpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"Secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
+                  "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"idpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3633,7 +3639,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e0c2727d-5699-4921-8b9d-2fb7f64ee231",
+              "id": "5772fcb3-0aab-47c1-b488-8648de112dc1",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -3686,7 +3692,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"IdpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"Secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
+                  "raw": "{\n  \"clientId\": \"vtex-b2b-store\",\n  \"idpEndpoint\": \"https://auth-middleware.example.com/authentication\",\n  \"secret\": \"aGlnaC1lbnRyb3B5LXNlY3JldC1rZXktZXhhbXBsZQ==\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -3705,7 +3711,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "91b37aa9-873f-4637-92da-030d79d01672",
+                "id": "28536591-7003-4942-a731-185b0653fc77",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -3718,7 +3724,7 @@
           }
         },
         {
-          "id": "14a7d52c-cbc6-4520-9311-ec20cf14528f",
+          "id": "04914e0f-b846-4652-8296-3a0dcda8e81b",
           "name": "Enable or disable password migration",
           "request": {
             "name": "Enable or disable password migration",
@@ -3793,7 +3799,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c3ea978f-e544-4b97-8fbe-9f459de84308",
+              "id": "88ce2298-20b2-4f0e-8eb8-5febb7c98885",
               "name": "OK\n\nFeature toggled successfully.",
               "originalRequest": {
                 "url": {
@@ -3864,7 +3870,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4298c2cd-e8c1-4a01-9707-4fe2d2e763a9",
+              "id": "37d38fbd-b0ec-409c-8007-7e2d3d41976e",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -3935,7 +3941,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8d247383-3339-42e6-92e3-02e1f1b2c9b4",
+              "id": "7f771326-9b71-4dfe-9117-7414224b992a",
               "name": "Not Found\n\nFeature not registered for this tenant.",
               "originalRequest": {
                 "url": {
@@ -4006,7 +4012,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "949072d5-614f-4d10-b360-9880a41ce5db",
+              "id": "09ba756c-5482-4520-b8c4-4860746c4843",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4078,7 +4084,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d20255e1-29fc-4800-83a5-3b1ea696b777",
+                "id": "e4f325a5-e6a2-433e-9988-30e357fc5b0e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4091,7 +4097,7 @@
           }
         },
         {
-          "id": "d3f37a61-7691-43db-85c9-413779f22cfb",
+          "id": "b8eb4a0a-75c4-4503-9fae-0b2bd4d4bc11",
           "name": "Delete password migration configuration",
           "request": {
             "name": "Delete password migration configuration",
@@ -4144,7 +4150,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b5c3f101-9165-48d7-a271-a11ced43658b",
+              "id": "321606d1-eeb4-4296-b53b-200554474686",
               "name": "No Content\n\nFeature deleted successfully.",
               "originalRequest": {
                 "url": {
@@ -4193,7 +4199,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "55eb458e-e041-475b-9d82-cdcc5577444f",
+              "id": "37923d21-1a7d-4c46-859f-e9aee0badfa6",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -4242,7 +4248,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "11e075c9-f3fe-42ab-bc76-b95c7a513d3c",
+              "id": "10ed0ca8-775b-4905-a1b8-1ec661082c17",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -4292,11 +4298,2258 @@
             {
               "listen": "test",
               "script": {
-                "id": "9e2badba-722e-426a-98f5-8d8b5698d92f",
+                "id": "04ca4b56-4c4c-417f-9ff0-7d23f09f0dce",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response has empty Body \npm.test(\"[DELETE]::/api/authenticator/v1/tenants/features/:name - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        }
+      ],
+      "event": []
+    },
+    {
+      "id": "ffd6537c-b77e-4a6e-b8b7-884def2095f8",
+      "name": "Organization account authentication",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "2727399e-1c35-4793-8df1-8657bf09104c",
+          "name": "Get organization unit authentication settings",
+          "request": {
+            "name": "Get organization unit authentication settings",
+            "description": {
+              "content": "Returns the authentication methods configured for an organization unit, such as password login and external identity provider (SSO), including whether each method is enabled.\r\n\r\n>⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available to select accounts.\r\n\r\n>ℹ️ These endpoints configure authentication methods for an organization unit (for example password or SSO). To manage unit hierarchy and membership, use the [Organization Units API](https://developers.vtex.com/docs/api-reference/organization-units-api). For more information about organization units, see [Organization units](https://help.vtex.com/docs/tutorials/organizational-units). Send the `VtexIdclientAutCookie` user token header, or the `X-VTEX-API-AppKey` and `X-VTEX-API-AppToken` headers.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise, they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| Organization Units | units | **View_Organization_Unit** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\n\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "api",
+                "vtexid",
+                "organization-units",
+                ":unitId",
+                "settings"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) Unique identifier (GUID) of the organization unit whose authentication settings are being read.",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "8d8b68e2-89e1-4d9f-b7c3-3a7f2c8e9d1a",
+                  "key": "unitId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                  "type": "text/plain"
+                },
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "body": {},
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "type": "any",
+                  "value": "X-VTEX-API-AppKey",
+                  "key": "key"
+                },
+                {
+                  "type": "any",
+                  "value": "{{apiKey}}",
+                  "key": "value"
+                },
+                {
+                  "type": "any",
+                  "value": "header",
+                  "key": "in"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "ce699b32-0303-4873-892f-6c6ceb193c7d",
+              "name": "OK\n\nAuthentication settings were returned successfully.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"authenticationMethods\": [\n    {\n      \"type\": \"Password\",\n      \"name\": \"Password\",\n      \"status\": \"Enabled\"\n    },\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Enabled\"\n    }\n  ]\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "5e8df9c5-0080-456c-b1a0-ff45146a4114",
+              "name": "Unauthorized\n\nThe current user could not be resolved.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"The current user could not be resolved.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "76afa916-08dc-4871-a10a-f2ed2ec76c77",
+              "name": "Forbidden\n\nAccess denied.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Access denied.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "b013e261-e8c1-46a3-b842-2cf52b210cff",
+              "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Organization unit not found.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "7e1b26e3-2cd9-451e-8c7f-d93bb0657d8d",
+              "name": "Internal Server Error\n\nUnknown server error.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"An unexpected error occurred.\"\n}",
+              "cookie": []
+            }
+          ],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "74ebec04-88e4-4ae0-bea3-3c3981f0485b",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate status 2xx \npm.test(\"[GET]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/vtexid/organization-units/:unitId/settings - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/api/vtexid/organization-units/:unitId/settings - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"description\":\"Authentication settings for the organization unit.\",\"required\":[\"authenticationMethods\"],\"properties\":{\"authenticationMethods\":{\"type\":\"array\",\"description\":\"List of authentication methods available for the organization unit.\",\"items\":{\"type\":\"object\",\"description\":\"Single authentication method entry.\",\"required\":[\"type\",\"name\",\"status\"],\"properties\":{\"type\":{\"type\":\"string\",\"description\":\"Machine-readable authentication method type: `Password` for password login or `OAuth` for SSO through an external identity provider.\",\"enum\":[\"Password\",\"OAuth\"]},\"name\":{\"type\":\"string\",\"description\":\"Human-readable label of the method, such as the configured identity provider name.\"},\"status\":{\"type\":\"string\",\"description\":\"Whether the method is enabled for this organization unit.\",\"enum\":[\"Enabled\",\"Disabled\"]}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/vtexid/organization-units/:unitId/settings - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "8297c141-da47-430d-8fb0-be4f08836ab6",
+          "name": "Set organization unit authentication settings",
+          "request": {
+            "name": "Set organization unit authentication settings",
+            "description": {
+              "content": "Defines authentication settings for an organization unit, for example enabling or disabling SSO for a configured external identity provider. Send each method to change using its display `name` and desired `status`.\r\n\r\n>⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available to select accounts.\r\n\r\n>ℹ️ These endpoints configure authentication methods for an organization unit (for example password or SSO). To manage unit hierarchy and membership, use the [Organization Units API](https://developers.vtex.com/docs/api-reference/organization-units-api). For more information about organization units, see [Organization units](https://help.vtex.com/docs/tutorials/organizational-units). Send the `VtexIdclientAutCookie` user token header, or the `X-VTEX-API-AppKey` and `X-VTEX-API-AppToken` headers.\r\n\r\n## Prerequisites\r\n\r\nBefore enabling login via external IdP, ensure the following requirements are met:\r\n\r\n- The identity provider must be previously configured in the VTEX Admin. Learn more in [Login (SSO)](https://developers.vtex.com/docs/guides/login-integration-guide) and [Webstore (OAuth 2.0)](https://developers.vtex.com/docs/guides/login-integration-guide-webstore-oauth2).\r\n- The [vtex.login-alternative-key](https://developers.vtex.com/docs/apps/vtex.login-alternative-key) app must be installed in the store.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise, they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| Organization Units | units | **Edit_Organization_Unit** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\n\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "api",
+                "vtexid",
+                "organization-units",
+                ":unitId",
+                "settings"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) Unique identifier (GUID) of the organization unit whose authentication settings are being updated.",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "8d8b68e2-89e1-4d9f-b7c3-3a7f2c8e9d1a",
+                  "key": "unitId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) Type of the content being sent.",
+                  "type": "text/plain"
+                },
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                  "type": "text/plain"
+                },
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "type": "any",
+                  "value": "X-VTEX-API-AppKey",
+                  "key": "key"
+                },
+                {
+                  "type": "any",
+                  "value": "{{apiKey}}",
+                  "key": "value"
+                },
+                {
+                  "type": "any",
+                  "value": "header",
+                  "key": "in"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "833fb8fe-8155-452a-852a-0ac53fcf14ab",
+              "name": "OK\n\nSettings were updated successfully.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"success\": true\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "1fd29d26-d32f-453a-bafd-2e66019a9a80",
+              "name": "Bad Request\n\nInvalid authentication configuration.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Bad Request",
+              "code": 400,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Invalid authentication configuration.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "768aed88-cb99-4f6e-a4b7-0ef51aca92f1",
+              "name": "Unauthorized\n\nThe current user could not be resolved.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"The current user could not be resolved.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "14eb0fd1-7e12-4f53-b44b-9fd70db803b7",
+              "name": "Forbidden\n\nAccess denied.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Access denied.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "5d9bddf8-7fdd-4b7a-b4f6-7b9d748e67cb",
+              "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Organization unit not found.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "08be1cd2-46e2-49ae-9e15-6d7b9c1c54aa",
+              "name": "Conflict\n\nAuthentication settings already exist for one or more methods.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Conflict",
+              "code": 409,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Authentication settings already exist for one or more methods.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "68da9303-82d1-4584-87b9-77f376cea9f5",
+              "name": "Internal Server Error\n\nUnknown server error.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"An unexpected error occurred.\"\n}",
+              "cookie": []
+            }
+          ],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "fc3519f4-5318-43a9-8600-0845f058f00a",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate status 2xx \npm.test(\"[POST]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/vtexid/organization-units/:unitId/settings - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/vtexid/organization-units/:unitId/settings - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"description\":\"Acknowledgement of a successful update.\",\"properties\":{\"success\":{\"type\":\"boolean\",\"description\":\"Indicates that the update completed without errors.\"}}}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/vtexid/organization-units/:unitId/settings - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "5a23520d-45a1-4826-b878-0fc31332da26",
+          "name": "Update organization unit authentication settings",
+          "request": {
+            "name": "Update organization unit authentication settings",
+            "description": {
+              "content": "Partially updates authentication configurations that already exist for the organization unit (for example changing `status`). This endpoint doesn't create new authentication methods; use `POST` [Set organization unit authentication settings](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/organization-units/-unitId-/settings) to define or add them.\r\n\r\nSend a `settings` array in which each object specifies the configuration `type` (for example `OAuth`) and the desired `status` for that existing configuration.\r\n\r\n>⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available to select accounts.\r\n\r\n>ℹ️ These endpoints configure authentication methods for an organization unit (for example password or SSO). To manage unit hierarchy and membership, use the [Organization Units API](https://developers.vtex.com/docs/api-reference/organization-units-api). For more information about organization units, see [Organization units](https://help.vtex.com/docs/tutorials/organizational-units). Send the `VtexIdclientAutCookie` user token header, or the `X-VTEX-API-AppKey` and `X-VTEX-API-AppToken` headers.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise, they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| Organization Units | units | **Edit_Organization_Unit** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\n\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "api",
+                "vtexid",
+                "organization-units",
+                ":unitId",
+                "settings"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) Unique identifier (GUID) of the organization unit whose authentication settings are being patched.",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "8d8b68e2-89e1-4d9f-b7c3-3a7f2c8e9d1a",
+                  "key": "unitId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) Type of the content being sent.",
+                  "type": "text/plain"
+                },
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                  "type": "text/plain"
+                },
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "type": "any",
+                  "value": "X-VTEX-API-AppKey",
+                  "key": "key"
+                },
+                {
+                  "type": "any",
+                  "value": "{{apiKey}}",
+                  "key": "value"
+                },
+                {
+                  "type": "any",
+                  "value": "header",
+                  "key": "in"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "3294d185-2d2a-43a1-9149-55ee17cc6f16",
+              "name": "OK\n\nUpdated authentication settings were returned successfully.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"authenticationMethods\": [\n    {\n      \"type\": \"Password\",\n      \"name\": \"Password\",\n      \"status\": \"Enabled\"\n    },\n    {\n      \"type\": \"OAuth\",\n      \"name\": \"PingFederate\",\n      \"status\": \"Enabled\"\n    }\n  ]\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "ce4e3b6c-34c5-4f4b-828f-c0e16a03bf90",
+              "name": "Bad Request\n\nInvalid authentication configuration or authentication settings were not found for update.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Bad Request",
+              "code": 400,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Authentication settings were not found for update.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "9a77a1b1-d4e5-4f96-8111-67697258befd",
+              "name": "Unauthorized\n\nThe current user could not be resolved.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"The current user could not be resolved.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "32416092-2bd9-4247-859e-3ae11741a67f",
+              "name": "Forbidden\n\nAccess denied.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Access denied.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "04326067-3825-4578-bb54-2ab44af758cb",
+              "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Organization unit not found.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "75ebdb85-c6f7-471a-b93e-199769f6edbf",
+              "name": "Internal Server Error\n\nUnknown server error.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "PATCH",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\",\n      \"status\": \"Disabled\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"An unexpected error occurred.\"\n}",
+              "cookie": []
+            }
+          ],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "d0024785-41a0-45cc-9f17-cd90e36c92ba",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate status 2xx \npm.test(\"[PATCH]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[PATCH]::/api/vtexid/organization-units/:unitId/settings - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[PATCH]::/api/vtexid/organization-units/:unitId/settings - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"description\":\"Authentication settings for the organization unit.\",\"required\":[\"authenticationMethods\"],\"properties\":{\"authenticationMethods\":{\"type\":\"array\",\"description\":\"List of authentication methods available for the organization unit.\",\"items\":{\"type\":\"object\",\"description\":\"Single authentication method entry.\",\"required\":[\"type\",\"name\",\"status\"],\"properties\":{\"type\":{\"type\":\"string\",\"description\":\"Machine-readable authentication method type: `Password` for password login or `OAuth` for SSO through an external identity provider.\",\"enum\":[\"Password\",\"OAuth\"]},\"name\":{\"type\":\"string\",\"description\":\"Human-readable label of the method, such as the configured identity provider name.\"},\"status\":{\"type\":\"string\",\"description\":\"Whether the method is enabled for this organization unit.\",\"enum\":[\"Enabled\",\"Disabled\"]}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[PATCH]::/api/vtexid/organization-units/:unitId/settings - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "5f657989-cfa5-4d26-9820-fad9caea45b7",
+          "name": "Delete organization unit authentication setting",
+          "request": {
+            "name": "Delete organization unit authentication setting",
+            "description": {
+              "content": "Deletes only the authentication configuration entries listed in the request body `settings` array (each entry is identified by `type`, for example `OAuth`). Other organization unit authentication configuration is not removed. Use with care when deleting unit-specific SSO configuration.\r\n\r\n>⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available to select accounts.\r\n\r\n>ℹ️ These endpoints configure authentication methods for an organization unit (for example password or SSO). To manage unit hierarchy and membership, use the [Organization Units API](https://developers.vtex.com/docs/api-reference/organization-units-api). For more information about organization units, see [Organization units](https://help.vtex.com/docs/tutorials/organizational-units). Send the `VtexIdclientAutCookie` user token header, or the `X-VTEX-API-AppKey` and `X-VTEX-API-AppToken` headers.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise, they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| Organization Units | units | **Edit_Organization_Unit** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\n\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "api",
+                "vtexid",
+                "organization-units",
+                ":unitId",
+                "settings"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) Unique identifier (GUID) of the organization unit from which the listed authentication settings will be deleted.",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "8d8b68e2-89e1-4d9f-b7c3-3a7f2c8e9d1a",
+                  "key": "unitId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) Type of the content being sent.",
+                  "type": "text/plain"
+                },
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                  "type": "text/plain"
+                },
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "DELETE",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\"\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            },
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "type": "any",
+                  "value": "X-VTEX-API-AppKey",
+                  "key": "key"
+                },
+                {
+                  "type": "any",
+                  "value": "{{apiKey}}",
+                  "key": "value"
+                },
+                {
+                  "type": "any",
+                  "value": "header",
+                  "key": "in"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "91b96da4-544e-406a-bdac-72170b42e27f",
+              "name": "No Content\n\nThe listed authentication configuration entries were deleted successfully.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "No Content",
+              "code": 204,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "f70bd770-549f-4e39-bf87-ae22f9f55fd4",
+              "name": "Bad Request\n\nInvalid authentication configuration or authentication settings were not found for delete.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Bad Request",
+              "code": 400,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Authentication settings were not found for delete.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "7466b8b3-90f6-4938-9bcf-2420318feaff",
+              "name": "Unauthorized\n\nThe current user could not be resolved.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"The current user could not be resolved.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "caf2e82f-c788-49c3-ac01-86ef8cf69193",
+              "name": "Forbidden\n\nAccess denied.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Access denied.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "69bb8c34-7128-486c-862a-bad11f70bc86",
+              "name": "Not Found\n\nInvalid organization unit ID or the organization unit was not found.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"Organization unit not found.\"\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "629471be-86e2-41d9-9917-6393a7b62c17",
+              "name": "Internal Server Error\n\nUnknown server error.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "vtexid",
+                    "organization-units",
+                    ":unitId",
+                    "settings"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "DELETE",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"settings\": [\n    {\n      \"type\": \"OAuth\"\n    }\n  ]\n}",
+                  "options": {
+                    "raw": {
+                      "headerFamily": "json",
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"message\": \"An unexpected error occurred.\"\n}",
+              "cookie": []
+            }
+          ],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "93de9155-e6ef-41bf-b256-f2b596d1d044",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate status 2xx \npm.test(\"[DELETE]::/api/vtexid/organization-units/:unitId/settings - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response has empty Body \npm.test(\"[DELETE]::/api/vtexid/organization-units/:unitId/settings - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
                 ]
               }
             }
@@ -4348,11 +6601,11 @@
     }
   ],
   "info": {
-    "_postman_id": "785a862c-03cb-464a-987a-d7d599e1490f",
+    "_postman_id": "3e5b626b-7839-4e61-9c17-837d58ddbedc",
     "name": "VTEX ID",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {
-      "content": "VTEX ID API provides endpoints to manage user authentication in your VTEX store. Check the [Authentication](https://developers.vtex.com/docs/guides/authentication) guide for more information.\r\n\r\n## Index\r\n\r\n### Storefront users\r\n\r\n- `POST` [Create storefront user with username](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users): Registers a new storefront user in VTEX ID using a unique login key (username).\r\n- `GET` [Get storefront user by identifier](https://developers.vtex.com/docs/api-reference/vtex-id-api#get-/api/vtexid/pvt/user/info): Fetches a storefront user by their identifier (username or email).\r\n\r\n### Authentication\r\n\r\n- `POST` [Generate authentication token](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/apptoken/login)\r\n- `POST` [Check authenticated user](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/credential/validate)\r\n- `POST` [Enable or disable repeated passwords](https://developers.vtex.com/docs/api-reference/vtex-id-api#get-/api/vtexid/pub/providers/setup/password/webstore/password)\r\n- `POST` [Expire user password](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/password/expire)\r\n- `GET` [Get user ID by email](https://developers.vtex.com/docs/api-reference/vtex-id-api#get-/api/vtexid/pvt/user/id) \r\n\r\n### Token renewal\r\n- `PATCH` [Initiate token renewal](https://developers.vtex.com/docs/api-reference/vtex-id-api#patch-/api/vtexid/apikey/-apiKey-/apitoken/renew)\r\n- `PATCH` [Complete token renewal](https://developers.vtex.com/docs/api-reference/vtex-id-api#patch-/api/vtexid/apikey/-apiKey-/apitoken/finish-renewal)\r\n\r\n### Refresh token (Headless)\r\n- `GET` [Start authentication](https://developers.vtex.com/docs/api-reference/vtex-id-api#get-/api/vtexid/pub/authentication/start)\r\n- `POST` [Send access key](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/pub/authentication/accesskey/send)\r\n- `POST` [Validate session](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/pub/authentication/accesskey/validate)\r\n- `POST` [Refresh token](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/vtexid/refreshtoken/webstore)\r\n\r\n### Password migration\r\n- `PUT` [Upsert password migration configuration](https://developers.vtex.com/docs/api-reference/vtex-id-api#put-/api/authenticator/v1/tenants/features/-name-): Configures or updates external authentication middleware settings for B2B password migration.\r\n- `PATCH` [Enable or disable password migration](https://developers.vtex.com/docs/api-reference/vtex-id-api#patch-/api/authenticator/v1/tenants/features/-name-): Enables or disables password migration without removing configuration.\r\n- `DELETE` [Delete password migration configuration](https://developers.vtex.com/docs/api-reference/vtex-id-api#delete-/api/authenticator/v1/tenants/features/-name-): Removes password migration configuration entirely.",
+      "content": "VTEX ID API provides endpoints to manage user authentication in your VTEX store. Check the [Authentication](https://developers.vtex.com/docs/guides/authentication) guide for more information.",
       "type": "text/plain"
     }
   }

--- a/VTEX - B2B Buyer Data API.json
+++ b/VTEX - B2B Buyer Data API.json
@@ -238,7 +238,7 @@
                             "type": "string",
                             "example": "buyer-8abea412-4702-46fb-b835-3edb29d8a261"
                         },
-                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users)."
+                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users)."
                     },
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -309,7 +309,7 @@
                             "type": "string",
                             "example": "buyer-8abea412-4702-46fb-b835-3edb29d8a261"
                         },
-                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users)."
+                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users)."
                     }
                 ],
                 "requestBody": {
@@ -360,7 +360,7 @@
                     {
                         "name": "buyerId",
                         "in": "path",
-                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users).",
+                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users).",
                         "required": true,
                         "style": "simple",
                         "schema": {
@@ -400,7 +400,7 @@
                             "type": "string",
                             "example": "userId=8abea412-4702-46fb-b835-3edb29d8a261"
                         },
-                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users). Use the `userId={{userId}}` value."
+                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users). Use the `userId={{userId}}` value."
                     },
                     {
                         "name": "_schema",
@@ -796,7 +796,7 @@
                     "userId": {
                         "type": "string",
                         "format": "uuid",
-                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users)."
+                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users)."
                     },
                     "email": {
                         "type": "string",
@@ -831,7 +831,7 @@
                     "userId": {
                         "type": "string",
                         "format": "uuid",
-                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/storefront/users)."
+                        "description": "Unique identifier for the buyer created by [VTEX ID API](https://developers.vtex.com/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users)."
                     },
                     "email": {
                         "type": "string",

--- a/VTEX - Punchout API.json
+++ b/VTEX - Punchout API.json
@@ -18,7 +18,7 @@
         }
     ],
     "paths": {
-        "/api/authenticator/punchout/start": {
+        "/api/authenticator/v1/punchout/start": {
             "post": {
                 "tags": [
                     "Punchout login"
@@ -98,7 +98,7 @@
                 }
             }
         },
-        "/api/authenticator/punchout/authenticated/start": {
+        "/api/authenticator/v1/punchout/authenticated/start": {
             "post": {
                 "tags": [
                     "Punchout login"
@@ -178,7 +178,7 @@
                 }
             }
         },
-        "/api/authenticator/punchout/finish": {
+        "/api/authenticator/v1/punchout/finish": {
             "get": {
                 "tags": [
                     "Punchout login"

--- a/VTEX - VTEX ID API.json
+++ b/VTEX - VTEX ID API.json
@@ -52,7 +52,7 @@
         }
     ],
     "paths": {
-        "/api/authenticator/storefront/users": {
+        "/api/authenticator/v1/storefront/users": {
             "post": {
                 "tags": [
                     "Storefront users"


### PR DESCRIPTION
Updated all Authenticator API route references from `/api/authenticator/` to `/api/authenticator/v1/` following the API versioning rollout.

[EDU-18991](https://vtex-dev.atlassian.net/browse/EDU-18991)

relates to https://github.com/vtexdocs/dev-portal-content/pull/2847

[EDU-18991]: https://vtex-dev.atlassian.net/browse/EDU-18991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ