### PR TITLE
fix: exclude PostmanCollections files from OpenAPI preview workflow

### DIFF
--- a/.github/workflows/openapi-preview.yml
+++ b/.github/workflows/openapi-preview.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - '*.json'
+      - '!PostmanCollections/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -55,7 +56,7 @@ jobs:
       - name: Get changed JSON files
         id: changed
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ steps.pr.outputs.base_ref }}...HEAD -- '*.json' \
+          FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ steps.pr.outputs.base_ref }}...HEAD -- '*.json' ':(exclude)PostmanCollections/**' \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "files=$FILES" >> $GITHUB_OUTPUT
           echo "count=$(echo $FILES | jq length)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- The OpenAPI Preview workflow's trigger `paths` and its `git diff` file glob both matched `PostmanCollections/**`, even though those files are auto-generated by the "Convert to Postman" action and aren't real OpenAPI specs.
- This meant the bot's own commit to `PostmanCollections/` inside a PR could re-trigger the workflow and get listed as a "changed spec" in the preview comment (observed while testing in #1742).
- Excludes `PostmanCollections/**` from both the trigger paths and the diff pathspec.

## Test plan
- [x] Verified via test PR #1742 that PostmanCollections changes were previously showing up in the preview comment
- [ ] Confirm on this PR (or a follow-up) that a Postman-only change no longer triggers the workflow / appears in the comment