### PR TITLE
feat: add dpPreview query parameter to product-search (v1)

### DIFF
--- a/PostmanCollections/VTEX - Intelligent Search API - v1.json
+++ b/PostmanCollections/VTEX - Intelligent Search API - v1.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "7d2b3a1d-55ac-4a0a-bc6e-327abcf9da78"
+    "postman_id": "66e3e07f-04b8-4e77-b9c6-64b63d57f07e"
   },
   "item": [
     {
-      "id": "208b1496-a624-4998-885d-742b884688fc",
+      "id": "223e3e33-bf9b-479d-b1a8-80693fb440ae",
       "name": "Autocomplete",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "bf49bd02-94ca-467c-bc4e-e05e42598af2",
+          "id": "b5f5ea98-ef4c-4fec-8130-a6b90c34a27d",
           "name": "Get list of the 10 most searched terms",
           "request": {
             "name": "Get list of the 10 most searched terms",
@@ -54,7 +54,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9ac85fe6-2ca0-41bb-9b36-69720c042d91",
+              "id": "a43d3c90-4bcb-4a2c-82c2-9c3b104b022b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -100,7 +100,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"home\",\n      \"count\": 14\n    },\n    {\n      \"term\": \"shirt\",\n      \"count\": 10\n    },\n    {\n      \"term\": \"top\",\n      \"count\": 9\n    },\n    {\n      \"term\": \"tops\",\n      \"count\": 6\n    },\n    {\n      \"term\": \"camera\",\n      \"count\": 5\n    },\n    {\n      \"term\": \"kit\",\n      \"count\": 5\n    },\n    {\n      \"term\": \"work shirt\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"shirts\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"clothing\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"classic shoes\",\n      \"count\": 1\n    }\n  ]\n}",
@@ -110,7 +110,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5e6b69b0-b8b5-4576-8449-bfdfa6dbc1e8",
+              "id": "230d0a84-548a-47cf-94c2-2deb8fcf27b0",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -145,7 +145,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dfdc4d59-9946-4bbb-a6b5-891965086684",
+              "id": "cb759358-e417-4a4b-85f5-557b71186341",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -181,7 +181,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "efe3d2b4-f403-4b09-86e8-29020a940eb4",
+                "id": "3afa7e1f-adfd-492b-9942-b8cbcf380a6d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/top-searches - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -197,7 +197,7 @@
           }
         },
         {
-          "id": "af3054d1-dd74-4613-91b7-4c560588c4fd",
+          "id": "2c1e2d25-f8ad-47d8-b8c1-183e9eca5536",
           "name": "Get list of suggested terms and attributes similar to the search term",
           "request": {
             "name": "Get list of suggested terms and attributes similar to the search term",
@@ -248,7 +248,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5d82e6ba-d4b6-4bf8-b70f-770b3b270ccc",
+              "id": "80301612-da57-4ff5-b95b-dbdd9d5564a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -303,7 +303,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"tv\",\n      \"count\": 28861,\n      \"attributes\": [\n        {\n          \"key\": \"department\",\n          \"value\": \"tvs-and-video\",\n          \"labelKey\": \"Department\",\n          \"labelValue\": \"TVs and Video\"\n        }\n      ]\n    },\n    {\n      \"term\": \"smarth tv\",\n      \"count\": 2308\n    },\n    {\n      \"term\": \"rack tv\",\n      \"count\": 589\n    }\n  ]\n}",
@@ -313,7 +313,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ada43eaf-0f63-434d-9b99-88e9b7e22c9d",
+              "id": "68f8d08e-3c1f-48a1-b7f5-69f55c5c7ddf",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -357,7 +357,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a24651d3-a64a-4475-80f3-9ca2438fc7f4",
+              "id": "0ef315ef-c575-41b5-b823-dafba89f0065",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -402,7 +402,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cb6e12fd-a2e1-4836-9f33-34b5fddf10ac",
+                "id": "f4249e3b-585e-4c5e-9405-73411ff3c1f2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/autocomplete-suggestions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -418,7 +418,7 @@
           }
         },
         {
-          "id": "cb49f955-eb23-41ef-8edd-08585116f2db",
+          "id": "1681d33a-8da6-4c8f-a6a1-32f560036e3c",
           "name": "Get list of suggested terms similar to the search term",
           "request": {
             "name": "Get list of suggested terms similar to the search term",
@@ -469,7 +469,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f6b4e5c1-4a75-4dea-a2df-d7a41c44afb1",
+              "id": "19d040c6-8bb6-46c3-8b9d-7423880ee1a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -524,7 +524,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"mountain bike\",\n      \"count\": 66\n    },\n    {\n      \"term\": \"bike helmet\",\n      \"count\": 121\n    },\n    {\n      \"term\": \"electric bike\",\n      \"count\": 78\n    }\n  ]\n}",
@@ -534,7 +534,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1c0389b5-3eb1-44db-b01a-6cdb6db4276e",
+              "id": "376c4ffa-31fa-4e69-9104-6e698e34b611",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -578,7 +578,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "362b8be0-353c-4081-97ce-37f2b18a341c",
+              "id": "8cde1354-7180-498c-bff5-a11da7d132b4",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -623,7 +623,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c6eb881c-4d84-46e9-a26a-8312886e26cb",
+                "id": "74eb9edf-1a56-42a7-8daa-a02e459b728a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/search-suggestions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -642,7 +642,7 @@
       "event": []
     },
     {
-      "id": "fa33af86-1c87-4a5b-8ec5-d31852227385",
+      "id": "ecddf6f3-8601-4c43-b8a8-6d34d9b25654",
       "name": "Product list page",
       "description": {
         "content": "",
@@ -650,7 +650,7 @@
       },
       "item": [
         {
-          "id": "c774c439-a58b-4027-b790-d516e82cb2eb",
+          "id": "4fef5d73-0b1f-4aa7-a8ca-28ea7b82da68",
           "name": "Get attempt of correction of a misspelled term",
           "request": {
             "name": "Get attempt of correction of a misspelled term",
@@ -701,7 +701,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fef0adfe-d38c-48cd-8a4b-9f4a9db536e1",
+              "id": "bd5b0040-591b-41b1-bec4-33edaf6b08a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -756,7 +756,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"correction\": {\n    \"correction\": true,\n    \"misspelled\": true,\n    \"text\": \"mountain bike\",\n    \"highlighted\": \"mountain <em>bike</em>\"\n  }\n}",
@@ -766,7 +766,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6432ead5-f8c0-4450-b157-223a1a215559",
+              "id": "642a5d34-d718-4e7d-bcfd-e2dbca4fc4d4",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -810,7 +810,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "af5910c3-e660-4244-b15f-677e7478b3e1",
+              "id": "d6d635ba-7616-4804-826a-4039e6683051",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -855,7 +855,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "baf229b2-93e3-48df-86ac-24e5ea0439a1",
+                "id": "31a3e0fa-0ced-425a-ab60-bfd141ea56f2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/correction-search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -871,7 +871,7 @@
           }
         },
         {
-          "id": "a9f609b9-787b-4133-9ffb-bfece6dfdd33",
+          "id": "89b0d3a2-74f2-4182-8350-264d27acdd33",
           "name": "Get list of banners registered for query",
           "request": {
             "name": "Get list of banners registered for query",
@@ -934,7 +934,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "20ee47c6-8616-4e82-bc09-1e4501426de6",
+              "id": "6f4c28ee-8b11-4d7d-85b4-37a7ce8e5374",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -990,7 +990,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"banners\": [\n    {\n      \"id\": \"summersale\",\n      \"name\": \"Summer Sale\",\n      \"area\": \"1\",\n      \"html\": \"<h1>This is a test</h1>\"\n    }\n  ]\n}",
@@ -1000,7 +1000,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7b66a8df-7187-4c03-a5ed-a9493bc4c921",
+              "id": "2e7e7089-166f-4143-83e5-993d12c985a2",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -1045,7 +1045,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fdb03fa2-8372-4b2f-84b8-4777e5db4067",
+              "id": "d6d7aead-c19f-4870-b29d-025ebddb9b3b",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -1091,7 +1091,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1249d9e3-970b-4c71-9d02-6f46c1a54504",
+                "id": "d69183c4-3b42-445d-8047-84a5d9dc25be",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/banners/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1107,7 +1107,7 @@
           }
         },
         {
-          "id": "4590c707-cb89-4546-bdfc-e74ac7ba6a7e",
+          "id": "92bbef99-426d-43b0-a53a-490fd0655ea9",
           "name": "Search products",
           "request": {
             "name": "Search products",
@@ -1203,7 +1203,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -1239,7 +1239,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -1275,7 +1275,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmSource",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -1284,7 +1284,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmCampaign",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -1293,7 +1293,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmiCampaign",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -1302,7 +1302,7 @@
                     "type": "text/plain"
                   },
                   "key": "campaigns",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -1311,7 +1311,7 @@
                     "type": "text/plain"
                   },
                   "key": "priceTables",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -1377,7 +1377,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2197a784-c484-4c20-9515-815b65ef4207",
+              "id": "46102450-a04a-4d3e-9203-1250df59d29c",
               "name": "OK\r\n\r\nList of products for the given query.",
               "originalRequest": {
                 "url": {
@@ -1468,7 +1468,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1504,7 +1504,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1540,7 +1540,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1549,7 +1549,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1558,7 +1558,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1567,7 +1567,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1576,7 +1576,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1640,7 +1640,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"products\": [\n    {\n      \"cacheId\": \"sp-2000003\",\n      \"productId\": \"2000003\",\n      \"description\": \"Introducing our exquisite Top Wood Clock.\",\n      \"productName\": \"Top Wood Clock\",\n      \"productReference\": \"clock120\",\n      \"linkText\": \"wood-clock\",\n      \"brand\": \"Sony\",\n      \"brandId\": 2000005,\n      \"link\": \"/wood-clock/p\",\n      \"categories\": [\n        \"/Home & Decor/\"\n      ],\n      \"categoryId\": \"40\",\n      \"categoriesIds\": [\n        \"/40/\"\n      ],\n      \"priceRange\": {\n        \"sellingPrice\": {\n          \"highPrice\": 197.99,\n          \"lowPrice\": 197.99\n        },\n        \"listPrice\": {\n          \"highPrice\": 197.99,\n          \"lowPrice\": 197.99\n        }\n      },\n      \"specificationGroups\": [],\n      \"skuSpecifications\": [],\n      \"productClusters\": [],\n      \"clusterHighlights\": [],\n      \"properties\": [],\n      \"items\": [\n        {\n          \"sellers\": [\n            {\n              \"sellerId\": \"1\",\n              \"sellerName\": \"VTEX\",\n              \"addToCartLink\": \"\",\n              \"sellerDefault\": true,\n              \"commertialOffer\": {\n                \"AvailableQuantity\": 10000,\n                \"Price\": 197.99,\n                \"ListPrice\": 197.99,\n                \"spotPrice\": 197.99,\n                \"Tax\": 0,\n                \"PriceValidUntil\": \"2025-04-01T13:13:20Z\"\n              }\n            }\n          ],\n          \"images\": [],\n          \"itemId\": \"2000534\",\n          \"name\": \"1\",\n          \"nameComplete\": \"Top Wood Clock 1\",\n          \"measurementUnit\": \"un\",\n          \"unitMultiplier\": 1,\n          \"variations\": [],\n          \"ean\": \"16001\",\n          \"modalType\": \"\",\n          \"videos\": [],\n          \"attachments\": [],\n          \"isKit\": false\n        }\n      ],\n      \"origin\": \"intelligent-search\"\n    }\n  ],\n  \"recordsFiltered\": 5,\n  \"correction\": {\n    \"misspelled\": false\n  },\n  \"fuzzy\": \"0\",\n  \"operator\": \"and\",\n  \"translated\": false,\n  \"pagination\": {\n    \"count\": 1,\n    \"current\": {\n      \"index\": 1\n    },\n    \"before\": [],\n    \"after\": [],\n    \"perPage\": 24,\n    \"next\": {\n      \"index\": 2\n    },\n    \"previous\": {\n      \"index\": 0\n    },\n    \"first\": {\n      \"index\": 1\n    },\n    \"last\": {\n      \"index\": 1\n    }\n  },\n  \"options\": {\n    \"sorts\": [],\n    \"counts\": [],\n    \"deliveryPromisesEnabled\": false\n  },\n  \"searchId\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"\n}",
@@ -1650,7 +1650,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "13787911-0ee8-479d-862f-2dcea961fdb2",
+              "id": "a8eef9ea-4cdb-462d-8002-8ce6d8afd269",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -1741,7 +1741,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1777,7 +1777,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1813,7 +1813,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1822,7 +1822,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1831,7 +1831,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1840,7 +1840,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1849,7 +1849,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -1914,7 +1914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b29083e2-d1ea-429d-baa0-7cf420ed021e",
+              "id": "81c2a3f0-f2be-493b-b382-27a8dde1bb64",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -2005,7 +2005,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2041,7 +2041,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2077,7 +2077,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2086,7 +2086,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2095,7 +2095,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2104,7 +2104,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2113,7 +2113,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2167,7 +2167,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0db9389f-fce7-46ed-9f47-347db6a960fb",
+                "id": "9587d982-8687-4e60-a90f-e9c3de214b06",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/product-search/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2183,7 +2183,7 @@
           }
         },
         {
-          "id": "8fd40b82-4918-49dc-96d7-726aea2265a2",
+          "id": "9c0941de-f31e-4c0d-a491-397505511ec1",
           "name": "List filters for a search",
           "request": {
             "name": "List filters for a search",
@@ -2234,7 +2234,7 @@
                     "type": "text/plain"
                   },
                   "key": "removeHiddenFacets",
-                  "value": "false"
+                  "value": "true"
                 },
                 {
                   "disabled": true,
@@ -2252,7 +2252,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2288,7 +2288,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2336,7 +2336,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "db2ef0e8-79c8-478c-af1d-68dd550491c4",
+              "id": "988bb32a-6b67-4e83-9ff9-0bba47c0046a",
               "name": "OK\r\n\r\nList of facets for the given query.",
               "originalRequest": {
                 "url": {
@@ -2382,7 +2382,7 @@
                         "type": "text/plain"
                       },
                       "key": "removeHiddenFacets",
-                      "value": "false"
+                      "value": "true"
                     },
                     {
                       "disabled": true,
@@ -2400,7 +2400,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2436,7 +2436,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2482,7 +2482,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"facets\": [\n    {\n      \"values\": [\n        {\n          \"id\": \"47\",\n          \"quantity\": 1,\n          \"name\": \"Clothing\",\n          \"key\": \"category-2\",\n          \"value\": \"clothing\",\n          \"selected\": false,\n          \"href\": \"shirt/blue/clothing?map=ft,color,category\"\n        }\n      ],\n      \"type\": \"TEXT\",\n      \"name\": \"Category\",\n      \"hidden\": false,\n      \"key\": \"category-2\",\n      \"quantity\": 1\n    },\n    {\n      \"values\": [\n        {\n          \"quantity\": 1,\n          \"name\": \"\",\n          \"key\": \"price\",\n          \"selected\": false,\n          \"range\": {\n            \"from\": 45,\n            \"to\": 50\n          }\n        }\n      ],\n      \"type\": \"PRICERANGE\",\n      \"name\": \"Price\",\n      \"hidden\": false,\n      \"key\": \"price\",\n      \"quantity\": 1\n    }\n  ],\n  \"sampling\": false,\n  \"breadcrumb\": [\n    {\n      \"name\": \"shirt\",\n      \"href\": \"/shirt?map=ft\"\n    }\n  ],\n  \"queryArgs\": {\n    \"query\": \"shirt\",\n    \"selectedFacets\": [\n      {\n        \"key\": \"ft\",\n        \"value\": \"shirt\"\n      }\n    ]\n  },\n  \"translated\": false\n}",
@@ -2493,7 +2493,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a6bc59ad-dd63-41e2-b852-68c23d76457a",
+                "id": "35a35729-6243-43d8-aef4-ef63477a6101",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/facets/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2512,7 +2512,7 @@
       "event": []
     },
     {
-      "id": "7782c9c0-fa40-49ff-9218-681006e200eb",
+      "id": "c24d59c7-f660-44e5-888b-de6ab89d8a75",
       "name": "Product details page (PDP)",
       "description": {
         "content": "",
@@ -2520,7 +2520,7 @@
       },
       "item": [
         {
-          "id": "14ecab64-46d8-4c51-8879-21054675f245",
+          "id": "e7a1c80e-c2db-4ec1-adcf-4b4cc428ca6f",
           "name": "Get product",
           "request": {
             "name": "Get product",
@@ -2597,7 +2597,7 @@
                     "type": "text/plain"
                   },
                   "key": "productClusterId",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2624,7 +2624,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2660,7 +2660,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2687,7 +2687,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmSource",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2696,7 +2696,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmCampaign",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2705,7 +2705,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmiCampaign",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2714,7 +2714,7 @@
                     "type": "text/plain"
                   },
                   "key": "campaigns",
-                  "value": "id officia"
+                  "value": "Dui"
                 },
                 {
                   "disabled": true,
@@ -2723,7 +2723,7 @@
                     "type": "text/plain"
                   },
                   "key": "priceTables",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "variable": []
@@ -2742,7 +2742,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8d985999-6359-403b-83f1-412afb176ad7",
+              "id": "75077d07-ed13-47ae-b8f0-9ed7da96037b",
               "name": "OK\r\n\r\nSingle product object. The response is the product itself; there is no `recordsFiltered`, `pagination`, or `searchId` wrapper.",
               "originalRequest": {
                 "url": {
@@ -2814,7 +2814,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2841,7 +2841,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2877,7 +2877,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2904,7 +2904,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2913,7 +2913,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2922,7 +2922,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2931,7 +2931,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -2940,7 +2940,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -2968,7 +2968,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"productId\": \"123456\",\n  \"productName\": \"Smartphone XYZ\",\n  \"brand\": \"TechBrand\",\n  \"brandId\": 9001,\n  \"linkText\": \"smartphone-xyz\",\n  \"link\": \"/smartphone-xyz/p\",\n  \"categories\": [\n    \"/Electronics/\"\n  ],\n  \"categoryId\": \"10\",\n  \"categoriesIds\": [\n    \"/10/\"\n  ],\n  \"priceRange\": {\n    \"sellingPrice\": {\n      \"highPrice\": 999.99,\n      \"lowPrice\": 999.99\n    },\n    \"listPrice\": {\n      \"highPrice\": 1299.99,\n      \"lowPrice\": 1299.99\n    }\n  },\n  \"specificationGroups\": [],\n  \"skuSpecifications\": [],\n  \"productClusters\": [],\n  \"clusterHighlights\": [],\n  \"properties\": [],\n  \"items\": [\n    {\n      \"sellers\": [\n        {\n          \"sellerId\": \"1\",\n          \"sellerDefault\": true,\n          \"commertialOffer\": {\n            \"Price\": 999.99,\n            \"ListPrice\": 1299.99,\n            \"AvailableQuantity\": 50\n          }\n        }\n      ],\n      \"images\": [],\n      \"itemId\": \"789\",\n      \"name\": \"Smartphone XYZ - 128GB - Black\",\n      \"nameComplete\": \"Smartphone XYZ - 128GB - Black\",\n      \"measurementUnit\": \"un\",\n      \"unitMultiplier\": 1,\n      \"variations\": [],\n      \"ean\": \"7891234567890\",\n      \"modalType\": \"\",\n      \"videos\": [],\n      \"attachments\": [],\n      \"isKit\": false\n    }\n  ],\n  \"origin\": \"intelligent-search\"\n}",
@@ -2978,7 +2978,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e292e125-29d5-49bb-8333-2e0513c242a8",
+              "id": "96f5467a-dd37-495c-b188-5d820c6a6afc",
               "name": "Bad Request: missing or invalid parameters (for example, missing `sc` or `value`).",
               "originalRequest": {
                 "url": {
@@ -3050,7 +3050,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3077,7 +3077,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3113,7 +3113,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3140,7 +3140,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3149,7 +3149,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3158,7 +3158,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3167,7 +3167,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3176,7 +3176,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -3193,7 +3193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "977a99ba-3bcb-4af5-9dbe-72a00199a52d",
+              "id": "377b9b6e-4d93-4b3b-925f-c36b936800e6",
               "name": "Unauthorized: private sales channel requires valid authentication.",
               "originalRequest": {
                 "url": {
@@ -3265,7 +3265,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3292,7 +3292,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3328,7 +3328,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3355,7 +3355,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3364,7 +3364,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3373,7 +3373,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3382,7 +3382,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3391,7 +3391,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -3408,7 +3408,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "460fa002-64e5-41ee-b78a-121823ea704b",
+              "id": "dcc447ee-82ee-4b2f-aab8-2c79a13377b4",
               "name": "Forbidden: user is not allowed to access this resource.",
               "originalRequest": {
                 "url": {
@@ -3480,7 +3480,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3507,7 +3507,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3543,7 +3543,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3570,7 +3570,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3579,7 +3579,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3588,7 +3588,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3597,7 +3597,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3606,7 +3606,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -3623,7 +3623,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1d8ad9ff-ab7b-416d-93ba-e6641b98d81a",
+              "id": "919a42f6-7244-4192-a515-ca7c551efbd6",
               "name": "Not Found: product not found, or not in the requested `productClusterId`.",
               "originalRequest": {
                 "url": {
@@ -3695,7 +3695,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3722,7 +3722,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3758,7 +3758,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3785,7 +3785,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3794,7 +3794,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3803,7 +3803,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3812,7 +3812,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3821,7 +3821,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -3838,7 +3838,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a2e68ede-4747-4d3d-9c63-390794601734",
+              "id": "653760c6-149a-4e44-b1d2-eb993c75ad91",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -3910,7 +3910,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3937,7 +3937,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -3973,7 +3973,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -4000,7 +4000,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -4009,7 +4009,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -4018,7 +4018,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -4027,7 +4027,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "id officia"
+                      "value": "Dui"
                     },
                     {
                       "disabled": true,
@@ -4036,7 +4036,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -4054,7 +4054,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e5b1c382-ac6c-440b-8d58-391767add467",
+                "id": "4af7d034-9506-4186-bf06-933ba1ff2302",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4073,7 +4073,7 @@
       "event": []
     },
     {
-      "id": "b4dcc012-14d7-49f8-99f6-ebd5d5bf44bb",
+      "id": "2881effd-b00b-4629-a898-a28fcf3a4aa0",
       "name": "Delivery Promise",
       "description": {
         "content": "",
@@ -4081,7 +4081,7 @@
       },
       "item": [
         {
-          "id": "6d69dcd3-87ad-46e3-9568-69287d157d39",
+          "id": "1403cdda-76d6-4588-979e-2340468e4de2",
           "name": "Get pickup point availability for Delivery Promise",
           "request": {
             "name": "Get pickup point availability for Delivery Promise",
@@ -4168,7 +4168,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "variable": [
@@ -4198,7 +4198,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c0d41c64-1310-4e6a-b597-a72d311f6dd8",
+              "id": "ef9e8d57-31b0-4e37-b1ce-cb0427b94f5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4280,7 +4280,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -4308,7 +4308,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "id officia"
+                  "value": "Dui"
                 }
               ],
               "body": "{\n  \"pickupPointDistances\": [\n    {\n      \"pickupId\": \"fulfillmentqa_vtexsp\",\n      \"distance\": 4.99,\n      \"pickupName\": \"VTEX SP\",\n      \"isActive\": true,\n      \"address\": {\n        \"city\": \"New York\",\n        \"neighborhood\": \"Manhattan\",\n        \"number\": \"350\",\n        \"postalCode\": \"10001\",\n        \"street\": \"5th Avenue\",\n        \"state\": \"NY\"\n      },\n      \"businessHours\": [\n        {\n          \"dayOfWeek\": 1,\n          \"openingTime\": \"09:00:00\",\n          \"closingTime\": \"18:00:00\"\n        }\n      ]\n    }\n  ]\n}",
@@ -4318,7 +4318,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4390b388-acf7-4213-ac6e-541f9178481a",
+              "id": "e0b83249-780e-472e-a452-5bd25383945c",
               "name": "Bad Request: delivery context could not be resolved (neither hashes nor country + ZIP code were usable), or invalid parameters.",
               "originalRequest": {
                 "url": {
@@ -4400,7 +4400,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -4417,7 +4417,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "af66d5d1-11d3-438e-bb7a-35206cdedc0a",
+              "id": "018fa46f-4798-427e-ae3f-274579545831",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -4499,7 +4499,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "id officia"
+                      "value": "Dui"
                     }
                   ],
                   "variable": []
@@ -4517,7 +4517,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "500602b8-d58f-4ea0-a2c5-054b418bc37f",
+                "id": "5888fad8-3992-46e9-ab03-6fd36063e7ec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/pickup-point-availability/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4555,7 +4555,7 @@
     }
   ],
   "info": {
-    "_postman_id": "7d2b3a1d-55ac-4a0a-bc6e-327abcf9da78",
+    "_postman_id": "66e3e07f-04b8-4e77-b9c6-64b63d57f07e",
     "name": "Intelligent Search API v1",
     "version": {
       "raw": "0.1.0",

--- a/PostmanCollections/VTEX - Intelligent Search API - v1.json
+++ b/PostmanCollections/VTEX - Intelligent Search API - v1.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "66e3e07f-04b8-4e77-b9c6-64b63d57f07e"
+    "postman_id": "531b7ca3-e830-4db5-a46c-c8efdca43a09"
   },
   "item": [
     {
-      "id": "223e3e33-bf9b-479d-b1a8-80693fb440ae",
+      "id": "df4b188d-0b13-44c9-8ec0-474410608cf1",
       "name": "Autocomplete",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "b5f5ea98-ef4c-4fec-8130-a6b90c34a27d",
+          "id": "dffad985-be8d-4e60-bf00-aee7cda034a4",
           "name": "Get list of the 10 most searched terms",
           "request": {
             "name": "Get list of the 10 most searched terms",
@@ -54,7 +54,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a43d3c90-4bcb-4a2c-82c2-9c3b104b022b",
+              "id": "8cb528fa-33b4-4479-b045-f669cd011893",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -100,7 +100,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"home\",\n      \"count\": 14\n    },\n    {\n      \"term\": \"shirt\",\n      \"count\": 10\n    },\n    {\n      \"term\": \"top\",\n      \"count\": 9\n    },\n    {\n      \"term\": \"tops\",\n      \"count\": 6\n    },\n    {\n      \"term\": \"camera\",\n      \"count\": 5\n    },\n    {\n      \"term\": \"kit\",\n      \"count\": 5\n    },\n    {\n      \"term\": \"work shirt\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"shirts\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"clothing\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"classic shoes\",\n      \"count\": 1\n    }\n  ]\n}",
@@ -110,7 +110,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "230d0a84-548a-47cf-94c2-2deb8fcf27b0",
+              "id": "41ef0286-83a2-4f07-b96f-37368918f5ef",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -145,7 +145,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cb759358-e417-4a4b-85f5-557b71186341",
+              "id": "7b46f186-ca56-4499-abe4-5fba9b5e74f0",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -181,7 +181,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3afa7e1f-adfd-492b-9942-b8cbcf380a6d",
+                "id": "84dc006e-0ae2-47bf-b2bc-0e7cc29e5abe",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/top-searches - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -197,7 +197,7 @@
           }
         },
         {
-          "id": "2c1e2d25-f8ad-47d8-b8c1-183e9eca5536",
+          "id": "b35da17f-cadc-4d1c-b672-aa16e77dc1b2",
           "name": "Get list of suggested terms and attributes similar to the search term",
           "request": {
             "name": "Get list of suggested terms and attributes similar to the search term",
@@ -248,7 +248,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "80301612-da57-4ff5-b95b-dbdd9d5564a5",
+              "id": "68773a57-6f4a-4f9a-9988-aa5630fbb402",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -303,7 +303,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"tv\",\n      \"count\": 28861,\n      \"attributes\": [\n        {\n          \"key\": \"department\",\n          \"value\": \"tvs-and-video\",\n          \"labelKey\": \"Department\",\n          \"labelValue\": \"TVs and Video\"\n        }\n      ]\n    },\n    {\n      \"term\": \"smarth tv\",\n      \"count\": 2308\n    },\n    {\n      \"term\": \"rack tv\",\n      \"count\": 589\n    }\n  ]\n}",
@@ -313,7 +313,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "68f8d08e-3c1f-48a1-b7f5-69f55c5c7ddf",
+              "id": "094b2cac-270f-46e8-900e-e492ece265da",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -357,7 +357,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0ef315ef-c575-41b5-b823-dafba89f0065",
+              "id": "0e0d1099-a49d-4616-aa42-3e82c29f2d0e",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -402,7 +402,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f4249e3b-585e-4c5e-9405-73411ff3c1f2",
+                "id": "9c8c2274-fcf4-4035-bf08-9949c943edce",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/autocomplete-suggestions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -418,7 +418,7 @@
           }
         },
         {
-          "id": "1681d33a-8da6-4c8f-a6a1-32f560036e3c",
+          "id": "24f51246-7b6b-4266-a374-cf23c8b434c3",
           "name": "Get list of suggested terms similar to the search term",
           "request": {
             "name": "Get list of suggested terms similar to the search term",
@@ -469,7 +469,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "19d040c6-8bb6-46c3-8b9d-7423880ee1a8",
+              "id": "d3653095-6e1f-48a7-9212-7d3d9c8d9b49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -524,7 +524,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"mountain bike\",\n      \"count\": 66\n    },\n    {\n      \"term\": \"bike helmet\",\n      \"count\": 121\n    },\n    {\n      \"term\": \"electric bike\",\n      \"count\": 78\n    }\n  ]\n}",
@@ -534,7 +534,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "376c4ffa-31fa-4e69-9104-6e698e34b611",
+              "id": "596f5ea2-cfcc-4238-a7e0-e9b5ce02b747",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -578,7 +578,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8cde1354-7180-498c-bff5-a11da7d132b4",
+              "id": "de186177-7030-40f0-84fb-fbe793482988",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -623,7 +623,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "74eb9edf-1a56-42a7-8daa-a02e459b728a",
+                "id": "7656f338-5424-4710-a2e9-8d67ab20db1d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/search-suggestions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -642,7 +642,7 @@
       "event": []
     },
     {
-      "id": "ecddf6f3-8601-4c43-b8a8-6d34d9b25654",
+      "id": "941a3254-73e7-4b5e-82e0-e1fc79670705",
       "name": "Product list page",
       "description": {
         "content": "",
@@ -650,7 +650,7 @@
       },
       "item": [
         {
-          "id": "4fef5d73-0b1f-4aa7-a8ca-28ea7b82da68",
+          "id": "87dff194-8b0b-4de0-913f-5ff69d74b18a",
           "name": "Get attempt of correction of a misspelled term",
           "request": {
             "name": "Get attempt of correction of a misspelled term",
@@ -701,7 +701,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bd5b0040-591b-41b1-bec4-33edaf6b08a2",
+              "id": "6399eec5-36e2-4600-ad84-07a8a4241cf6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -756,7 +756,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"correction\": {\n    \"correction\": true,\n    \"misspelled\": true,\n    \"text\": \"mountain bike\",\n    \"highlighted\": \"mountain <em>bike</em>\"\n  }\n}",
@@ -766,7 +766,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "642a5d34-d718-4e7d-bcfd-e2dbca4fc4d4",
+              "id": "dd4001b9-2ffd-4f6d-b4e9-a8917ff42cf7",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -810,7 +810,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d6d635ba-7616-4804-826a-4039e6683051",
+              "id": "5c35c153-a90b-4dc2-b785-b8107ac4fbfb",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -855,7 +855,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "31a3e0fa-0ced-425a-ab60-bfd141ea56f2",
+                "id": "d8e3ca46-225e-4eea-ba2d-c4bb2c83ba98",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/correction-search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -871,7 +871,7 @@
           }
         },
         {
-          "id": "89b0d3a2-74f2-4182-8350-264d27acdd33",
+          "id": "1e87185f-aa6e-4004-83bf-6edf7e7176bb",
           "name": "Get list of banners registered for query",
           "request": {
             "name": "Get list of banners registered for query",
@@ -934,7 +934,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6f4c28ee-8b11-4d7d-85b4-37a7ce8e5374",
+              "id": "937e1865-a472-4c60-a678-adf59fc200b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -990,7 +990,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"banners\": [\n    {\n      \"id\": \"summersale\",\n      \"name\": \"Summer Sale\",\n      \"area\": \"1\",\n      \"html\": \"<h1>This is a test</h1>\"\n    }\n  ]\n}",
@@ -1000,7 +1000,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2e7e7089-166f-4143-83e5-993d12c985a2",
+              "id": "35c482aa-7890-4066-b470-2bc6dd8cb418",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -1045,7 +1045,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d6d7aead-c19f-4870-b29d-025ebddb9b3b",
+              "id": "69b2e6bd-2892-4361-bba5-3435586392f6",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -1091,7 +1091,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d69183c4-3b42-445d-8047-84a5d9dc25be",
+                "id": "5f310c87-83e3-4bcf-a721-5b8dc70d9f69",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/banners/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1107,7 +1107,7 @@
           }
         },
         {
-          "id": "92bbef99-426d-43b0-a53a-490fd0655ea9",
+          "id": "96e3cd7a-d42a-44bf-9a48-a5cc2cc92292",
           "name": "Search products",
           "request": {
             "name": "Search products",
@@ -1203,7 +1203,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -1239,7 +1239,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -1262,7 +1262,7 @@
                 {
                   "disabled": true,
                   "description": {
-                    "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                    "content": "Previews [Delivery Promise](https://developers.vtex.com/docs/guides/delivery-promise) behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
                     "type": "text/plain"
                   },
                   "key": "dpPreview",
@@ -1275,7 +1275,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmSource",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -1284,7 +1284,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmCampaign",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -1293,7 +1293,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmiCampaign",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -1302,7 +1302,7 @@
                     "type": "text/plain"
                   },
                   "key": "campaigns",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -1311,7 +1311,7 @@
                     "type": "text/plain"
                   },
                   "key": "priceTables",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -1377,7 +1377,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "46102450-a04a-4d3e-9203-1250df59d29c",
+              "id": "26a0e141-205d-40eb-8f3a-4a4de0acdd87",
               "name": "OK\r\n\r\nList of products for the given query.",
               "originalRequest": {
                 "url": {
@@ -1468,7 +1468,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1504,7 +1504,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1527,7 +1527,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                        "content": "Previews [Delivery Promise](https://developers.vtex.com/docs/guides/delivery-promise) behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
                         "type": "text/plain"
                       },
                       "key": "dpPreview",
@@ -1540,7 +1540,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1549,7 +1549,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1558,7 +1558,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1567,7 +1567,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1576,7 +1576,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1640,7 +1640,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"products\": [\n    {\n      \"cacheId\": \"sp-2000003\",\n      \"productId\": \"2000003\",\n      \"description\": \"Introducing our exquisite Top Wood Clock.\",\n      \"productName\": \"Top Wood Clock\",\n      \"productReference\": \"clock120\",\n      \"linkText\": \"wood-clock\",\n      \"brand\": \"Sony\",\n      \"brandId\": 2000005,\n      \"link\": \"/wood-clock/p\",\n      \"categories\": [\n        \"/Home & Decor/\"\n      ],\n      \"categoryId\": \"40\",\n      \"categoriesIds\": [\n        \"/40/\"\n      ],\n      \"priceRange\": {\n        \"sellingPrice\": {\n          \"highPrice\": 197.99,\n          \"lowPrice\": 197.99\n        },\n        \"listPrice\": {\n          \"highPrice\": 197.99,\n          \"lowPrice\": 197.99\n        }\n      },\n      \"specificationGroups\": [],\n      \"skuSpecifications\": [],\n      \"productClusters\": [],\n      \"clusterHighlights\": [],\n      \"properties\": [],\n      \"items\": [\n        {\n          \"sellers\": [\n            {\n              \"sellerId\": \"1\",\n              \"sellerName\": \"VTEX\",\n              \"addToCartLink\": \"\",\n              \"sellerDefault\": true,\n              \"commertialOffer\": {\n                \"AvailableQuantity\": 10000,\n                \"Price\": 197.99,\n                \"ListPrice\": 197.99,\n                \"spotPrice\": 197.99,\n                \"Tax\": 0,\n                \"PriceValidUntil\": \"2025-04-01T13:13:20Z\"\n              }\n            }\n          ],\n          \"images\": [],\n          \"itemId\": \"2000534\",\n          \"name\": \"1\",\n          \"nameComplete\": \"Top Wood Clock 1\",\n          \"measurementUnit\": \"un\",\n          \"unitMultiplier\": 1,\n          \"variations\": [],\n          \"ean\": \"16001\",\n          \"modalType\": \"\",\n          \"videos\": [],\n          \"attachments\": [],\n          \"isKit\": false\n        }\n      ],\n      \"origin\": \"intelligent-search\"\n    }\n  ],\n  \"recordsFiltered\": 5,\n  \"correction\": {\n    \"misspelled\": false\n  },\n  \"fuzzy\": \"0\",\n  \"operator\": \"and\",\n  \"translated\": false,\n  \"pagination\": {\n    \"count\": 1,\n    \"current\": {\n      \"index\": 1\n    },\n    \"before\": [],\n    \"after\": [],\n    \"perPage\": 24,\n    \"next\": {\n      \"index\": 2\n    },\n    \"previous\": {\n      \"index\": 0\n    },\n    \"first\": {\n      \"index\": 1\n    },\n    \"last\": {\n      \"index\": 1\n    }\n  },\n  \"options\": {\n    \"sorts\": [],\n    \"counts\": [],\n    \"deliveryPromisesEnabled\": false\n  },\n  \"searchId\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"\n}",
@@ -1650,7 +1650,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a8eef9ea-4cdb-462d-8002-8ce6d8afd269",
+              "id": "b6af0986-d31b-4d04-a084-b568a2bbd4cf",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -1741,7 +1741,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1777,7 +1777,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1800,7 +1800,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                        "content": "Previews [Delivery Promise](https://developers.vtex.com/docs/guides/delivery-promise) behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
                         "type": "text/plain"
                       },
                       "key": "dpPreview",
@@ -1813,7 +1813,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1822,7 +1822,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1831,7 +1831,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1840,7 +1840,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1849,7 +1849,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -1914,7 +1914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "81c2a3f0-f2be-493b-b382-27a8dde1bb64",
+              "id": "999e23a5-98e9-4176-9c61-d85a9dad9916",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -2005,7 +2005,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2041,7 +2041,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2064,7 +2064,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                        "content": "Previews [Delivery Promise](https://developers.vtex.com/docs/guides/delivery-promise) behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
                         "type": "text/plain"
                       },
                       "key": "dpPreview",
@@ -2077,7 +2077,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2086,7 +2086,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2095,7 +2095,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2104,7 +2104,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2113,7 +2113,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2167,7 +2167,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9587d982-8687-4e60-a90f-e9c3de214b06",
+                "id": "3ed3a1af-da54-4c3d-a427-d495fcb04da6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/product-search/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2183,7 +2183,7 @@
           }
         },
         {
-          "id": "9c0941de-f31e-4c0d-a491-397505511ec1",
+          "id": "16f3cbe8-9e49-40b5-ae65-29cc633b8675",
           "name": "List filters for a search",
           "request": {
             "name": "List filters for a search",
@@ -2234,7 +2234,7 @@
                     "type": "text/plain"
                   },
                   "key": "removeHiddenFacets",
-                  "value": "true"
+                  "value": "false"
                 },
                 {
                   "disabled": true,
@@ -2252,7 +2252,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2288,7 +2288,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2336,7 +2336,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "988bb32a-6b67-4e83-9ff9-0bba47c0046a",
+              "id": "57f1af40-12c4-4d5f-81df-907d4af27245",
               "name": "OK\r\n\r\nList of facets for the given query.",
               "originalRequest": {
                 "url": {
@@ -2382,7 +2382,7 @@
                         "type": "text/plain"
                       },
                       "key": "removeHiddenFacets",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -2400,7 +2400,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2436,7 +2436,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2482,7 +2482,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"facets\": [\n    {\n      \"values\": [\n        {\n          \"id\": \"47\",\n          \"quantity\": 1,\n          \"name\": \"Clothing\",\n          \"key\": \"category-2\",\n          \"value\": \"clothing\",\n          \"selected\": false,\n          \"href\": \"shirt/blue/clothing?map=ft,color,category\"\n        }\n      ],\n      \"type\": \"TEXT\",\n      \"name\": \"Category\",\n      \"hidden\": false,\n      \"key\": \"category-2\",\n      \"quantity\": 1\n    },\n    {\n      \"values\": [\n        {\n          \"quantity\": 1,\n          \"name\": \"\",\n          \"key\": \"price\",\n          \"selected\": false,\n          \"range\": {\n            \"from\": 45,\n            \"to\": 50\n          }\n        }\n      ],\n      \"type\": \"PRICERANGE\",\n      \"name\": \"Price\",\n      \"hidden\": false,\n      \"key\": \"price\",\n      \"quantity\": 1\n    }\n  ],\n  \"sampling\": false,\n  \"breadcrumb\": [\n    {\n      \"name\": \"shirt\",\n      \"href\": \"/shirt?map=ft\"\n    }\n  ],\n  \"queryArgs\": {\n    \"query\": \"shirt\",\n    \"selectedFacets\": [\n      {\n        \"key\": \"ft\",\n        \"value\": \"shirt\"\n      }\n    ]\n  },\n  \"translated\": false\n}",
@@ -2493,7 +2493,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "35a35729-6243-43d8-aef4-ef63477a6101",
+                "id": "8ab420f0-b59b-4b87-b729-b52bae31deca",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/facets/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2512,7 +2512,7 @@
       "event": []
     },
     {
-      "id": "c24d59c7-f660-44e5-888b-de6ab89d8a75",
+      "id": "254fd8f5-956f-458c-899c-b860d5297229",
       "name": "Product details page (PDP)",
       "description": {
         "content": "",
@@ -2520,7 +2520,7 @@
       },
       "item": [
         {
-          "id": "e7a1c80e-c2db-4ec1-adcf-4b4cc428ca6f",
+          "id": "71b33de1-0dae-4d5d-82d1-45c8288b1072",
           "name": "Get product",
           "request": {
             "name": "Get product",
@@ -2597,7 +2597,7 @@
                     "type": "text/plain"
                   },
                   "key": "productClusterId",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2615,7 +2615,7 @@
                     "type": "text/plain"
                   },
                   "key": "show-invisible-items",
-                  "value": "false"
+                  "value": "true"
                 },
                 {
                   "disabled": true,
@@ -2624,7 +2624,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2660,7 +2660,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2687,7 +2687,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmSource",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2696,7 +2696,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmCampaign",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2705,7 +2705,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmiCampaign",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2714,7 +2714,7 @@
                     "type": "text/plain"
                   },
                   "key": "campaigns",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 },
                 {
                   "disabled": true,
@@ -2723,7 +2723,7 @@
                     "type": "text/plain"
                   },
                   "key": "priceTables",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "variable": []
@@ -2742,7 +2742,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "75077d07-ed13-47ae-b8f0-9ed7da96037b",
+              "id": "34d73d5b-1950-4c00-a5c4-7acdb2bbea76",
               "name": "OK\r\n\r\nSingle product object. The response is the product itself; there is no `recordsFiltered`, `pagination`, or `searchId` wrapper.",
               "originalRequest": {
                 "url": {
@@ -2814,7 +2814,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2832,7 +2832,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "false"
+                      "value": "true"
                     },
                     {
                       "disabled": true,
@@ -2841,7 +2841,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2877,7 +2877,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2904,7 +2904,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2913,7 +2913,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2922,7 +2922,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2931,7 +2931,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -2940,7 +2940,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -2968,7 +2968,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"productId\": \"123456\",\n  \"productName\": \"Smartphone XYZ\",\n  \"brand\": \"TechBrand\",\n  \"brandId\": 9001,\n  \"linkText\": \"smartphone-xyz\",\n  \"link\": \"/smartphone-xyz/p\",\n  \"categories\": [\n    \"/Electronics/\"\n  ],\n  \"categoryId\": \"10\",\n  \"categoriesIds\": [\n    \"/10/\"\n  ],\n  \"priceRange\": {\n    \"sellingPrice\": {\n      \"highPrice\": 999.99,\n      \"lowPrice\": 999.99\n    },\n    \"listPrice\": {\n      \"highPrice\": 1299.99,\n      \"lowPrice\": 1299.99\n    }\n  },\n  \"specificationGroups\": [],\n  \"skuSpecifications\": [],\n  \"productClusters\": [],\n  \"clusterHighlights\": [],\n  \"properties\": [],\n  \"items\": [\n    {\n      \"sellers\": [\n        {\n          \"sellerId\": \"1\",\n          \"sellerDefault\": true,\n          \"commertialOffer\": {\n            \"Price\": 999.99,\n            \"ListPrice\": 1299.99,\n            \"AvailableQuantity\": 50\n          }\n        }\n      ],\n      \"images\": [],\n      \"itemId\": \"789\",\n      \"name\": \"Smartphone XYZ - 128GB - Black\",\n      \"nameComplete\": \"Smartphone XYZ - 128GB - Black\",\n      \"measurementUnit\": \"un\",\n      \"unitMultiplier\": 1,\n      \"variations\": [],\n      \"ean\": \"7891234567890\",\n      \"modalType\": \"\",\n      \"videos\": [],\n      \"attachments\": [],\n      \"isKit\": false\n    }\n  ],\n  \"origin\": \"intelligent-search\"\n}",
@@ -2978,7 +2978,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "96f5467a-dd37-495c-b188-5d820c6a6afc",
+              "id": "eed03bc6-9b2d-4080-b1cc-9b17a46ed71e",
               "name": "Bad Request: missing or invalid parameters (for example, missing `sc` or `value`).",
               "originalRequest": {
                 "url": {
@@ -3050,7 +3050,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3068,7 +3068,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "false"
+                      "value": "true"
                     },
                     {
                       "disabled": true,
@@ -3077,7 +3077,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3113,7 +3113,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3140,7 +3140,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3149,7 +3149,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3158,7 +3158,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3167,7 +3167,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3176,7 +3176,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -3193,7 +3193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "377b9b6e-4d93-4b3b-925f-c36b936800e6",
+              "id": "da376df2-ee22-4280-8484-5b4b217b8f31",
               "name": "Unauthorized: private sales channel requires valid authentication.",
               "originalRequest": {
                 "url": {
@@ -3265,7 +3265,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3283,7 +3283,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "false"
+                      "value": "true"
                     },
                     {
                       "disabled": true,
@@ -3292,7 +3292,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3328,7 +3328,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3355,7 +3355,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3364,7 +3364,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3373,7 +3373,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3382,7 +3382,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3391,7 +3391,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -3408,7 +3408,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dcc447ee-82ee-4b2f-aab8-2c79a13377b4",
+              "id": "7191c3df-83f5-4c39-b816-03f60f809152",
               "name": "Forbidden: user is not allowed to access this resource.",
               "originalRequest": {
                 "url": {
@@ -3480,7 +3480,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3498,7 +3498,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "false"
+                      "value": "true"
                     },
                     {
                       "disabled": true,
@@ -3507,7 +3507,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3543,7 +3543,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3570,7 +3570,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3579,7 +3579,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3588,7 +3588,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3597,7 +3597,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3606,7 +3606,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -3623,7 +3623,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "919a42f6-7244-4192-a515-ca7c551efbd6",
+              "id": "317e2bee-c5b3-4b54-b6aa-30ca13057204",
               "name": "Not Found: product not found, or not in the requested `productClusterId`.",
               "originalRequest": {
                 "url": {
@@ -3695,7 +3695,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3713,7 +3713,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "false"
+                      "value": "true"
                     },
                     {
                       "disabled": true,
@@ -3722,7 +3722,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3758,7 +3758,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3785,7 +3785,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3794,7 +3794,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3803,7 +3803,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3812,7 +3812,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3821,7 +3821,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -3838,7 +3838,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "653760c6-149a-4e44-b1d2-eb993c75ad91",
+              "id": "d1f9d68f-3dc3-44e4-8492-b161a1b0a02a",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -3910,7 +3910,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3928,7 +3928,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "false"
+                      "value": "true"
                     },
                     {
                       "disabled": true,
@@ -3937,7 +3937,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -3973,7 +3973,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -4000,7 +4000,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -4009,7 +4009,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -4018,7 +4018,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -4027,7 +4027,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     },
                     {
                       "disabled": true,
@@ -4036,7 +4036,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -4054,7 +4054,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4af7d034-9506-4186-bf06-933ba1ff2302",
+                "id": "a81156b2-9980-4ae2-b7e0-eb3ec52b3d17",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4073,7 +4073,7 @@
       "event": []
     },
     {
-      "id": "2881effd-b00b-4629-a898-a28fcf3a4aa0",
+      "id": "56fe1a2f-c04b-49dd-90c2-910a7d1a57d7",
       "name": "Delivery Promise",
       "description": {
         "content": "",
@@ -4081,7 +4081,7 @@
       },
       "item": [
         {
-          "id": "1403cdda-76d6-4588-979e-2340468e4de2",
+          "id": "82b2354e-044d-487f-84ee-9f153aed0d98",
           "name": "Get pickup point availability for Delivery Promise",
           "request": {
             "name": "Get pickup point availability for Delivery Promise",
@@ -4168,7 +4168,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "variable": [
@@ -4198,7 +4198,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ef9e8d57-31b0-4e37-b1ce-cb0427b94f5b",
+              "id": "780cbc4f-6d4a-47a4-8b89-00b2a255fc5a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4280,7 +4280,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -4308,7 +4308,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "Dui"
+                  "value": "Ut exerci"
                 }
               ],
               "body": "{\n  \"pickupPointDistances\": [\n    {\n      \"pickupId\": \"fulfillmentqa_vtexsp\",\n      \"distance\": 4.99,\n      \"pickupName\": \"VTEX SP\",\n      \"isActive\": true,\n      \"address\": {\n        \"city\": \"New York\",\n        \"neighborhood\": \"Manhattan\",\n        \"number\": \"350\",\n        \"postalCode\": \"10001\",\n        \"street\": \"5th Avenue\",\n        \"state\": \"NY\"\n      },\n      \"businessHours\": [\n        {\n          \"dayOfWeek\": 1,\n          \"openingTime\": \"09:00:00\",\n          \"closingTime\": \"18:00:00\"\n        }\n      ]\n    }\n  ]\n}",
@@ -4318,7 +4318,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e0b83249-780e-472e-a452-5bd25383945c",
+              "id": "7dee7e69-4fb4-4702-9e7a-b037a8b671b6",
               "name": "Bad Request: delivery context could not be resolved (neither hashes nor country + ZIP code were usable), or invalid parameters.",
               "originalRequest": {
                 "url": {
@@ -4400,7 +4400,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -4417,7 +4417,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "018fa46f-4798-427e-ae3f-274579545831",
+              "id": "cbf07cf1-bc31-4387-b771-78fd2a2c951f",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -4499,7 +4499,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "Dui"
+                      "value": "Ut exerci"
                     }
                   ],
                   "variable": []
@@ -4517,7 +4517,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5888fad8-3992-46e9-ab03-6fd36063e7ec",
+                "id": "3ced2333-3a6c-48ef-b1c2-1bcbceb6425c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/pickup-point-availability/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4555,7 +4555,7 @@
     }
   ],
   "info": {
-    "_postman_id": "66e3e07f-04b8-4e77-b9c6-64b63d57f07e",
+    "_postman_id": "531b7ca3-e830-4db5-a46c-c8efdca43a09",
     "name": "Intelligent Search API v1",
     "version": {
       "raw": "0.1.0",

--- a/PostmanCollections/VTEX - Intelligent Search API - v1.json
+++ b/PostmanCollections/VTEX - Intelligent Search API - v1.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "8ddb0cdf-9036-4ff3-aeb2-aaebff729306"
+    "postman_id": "7d2b3a1d-55ac-4a0a-bc6e-327abcf9da78"
   },
   "item": [
     {
-      "id": "902d90d0-a825-4e44-93ca-79ab510d5760",
+      "id": "208b1496-a624-4998-885d-742b884688fc",
       "name": "Autocomplete",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "15940525-863b-47b0-bf67-6cba51a3e2f4",
+          "id": "bf49bd02-94ca-467c-bc4e-e05e42598af2",
           "name": "Get list of the 10 most searched terms",
           "request": {
             "name": "Get list of the 10 most searched terms",
@@ -54,7 +54,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1b27cb50-5528-4e80-905a-9a44f8508fbe",
+              "id": "9ac85fe6-2ca0-41bb-9b36-69720c042d91",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -100,7 +100,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"home\",\n      \"count\": 14\n    },\n    {\n      \"term\": \"shirt\",\n      \"count\": 10\n    },\n    {\n      \"term\": \"top\",\n      \"count\": 9\n    },\n    {\n      \"term\": \"tops\",\n      \"count\": 6\n    },\n    {\n      \"term\": \"camera\",\n      \"count\": 5\n    },\n    {\n      \"term\": \"kit\",\n      \"count\": 5\n    },\n    {\n      \"term\": \"work shirt\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"shirts\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"clothing\",\n      \"count\": 2\n    },\n    {\n      \"term\": \"classic shoes\",\n      \"count\": 1\n    }\n  ]\n}",
@@ -110,7 +110,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "158ea5ba-ab1d-44b3-90c8-7554cd23e339",
+              "id": "5e6b69b0-b8b5-4576-8449-bfdfa6dbc1e8",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -145,7 +145,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c74b30a9-ba87-4140-a48f-2cb7ba7f9267",
+              "id": "dfdc4d59-9946-4bbb-a6b5-891965086684",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -181,7 +181,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a32d06e9-c4ad-495e-83e9-9dc7a21615a3",
+                "id": "efe3d2b4-f403-4b09-86e8-29020a940eb4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/top-searches - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -197,7 +197,7 @@
           }
         },
         {
-          "id": "234f9f36-e4fc-41de-9544-6ff47f4d03fe",
+          "id": "af3054d1-dd74-4613-91b7-4c560588c4fd",
           "name": "Get list of suggested terms and attributes similar to the search term",
           "request": {
             "name": "Get list of suggested terms and attributes similar to the search term",
@@ -248,7 +248,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6eb2dae7-4fe5-466d-a800-c7d984924626",
+              "id": "5d82e6ba-d4b6-4bf8-b70f-770b3b270ccc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -303,7 +303,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"tv\",\n      \"count\": 28861,\n      \"attributes\": [\n        {\n          \"key\": \"department\",\n          \"value\": \"tvs-and-video\",\n          \"labelKey\": \"Department\",\n          \"labelValue\": \"TVs and Video\"\n        }\n      ]\n    },\n    {\n      \"term\": \"smarth tv\",\n      \"count\": 2308\n    },\n    {\n      \"term\": \"rack tv\",\n      \"count\": 589\n    }\n  ]\n}",
@@ -313,7 +313,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b6b61678-b630-42a1-805a-58a80c7516c1",
+              "id": "ada43eaf-0f63-434d-9b99-88e9b7e22c9d",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -357,7 +357,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7d0ca1e3-92f6-4a06-addb-79aebc62d907",
+              "id": "a24651d3-a64a-4475-80f3-9ca2438fc7f4",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -402,7 +402,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c2db69cb-b616-4146-850b-be424c3e1412",
+                "id": "cb6e12fd-a2e1-4836-9f33-34b5fddf10ac",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/autocomplete-suggestions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -418,7 +418,7 @@
           }
         },
         {
-          "id": "07c5bdde-1661-4766-806d-ab979d571a31",
+          "id": "cb49f955-eb23-41ef-8edd-08585116f2db",
           "name": "Get list of suggested terms similar to the search term",
           "request": {
             "name": "Get list of suggested terms similar to the search term",
@@ -469,7 +469,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f2d9d3b6-4199-4cc0-afbb-aeffd5cfc623",
+              "id": "f6b4e5c1-4a75-4dea-a2df-d7a41c44afb1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -524,7 +524,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"searches\": [\n    {\n      \"term\": \"mountain bike\",\n      \"count\": 66\n    },\n    {\n      \"term\": \"bike helmet\",\n      \"count\": 121\n    },\n    {\n      \"term\": \"electric bike\",\n      \"count\": 78\n    }\n  ]\n}",
@@ -534,7 +534,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f1df802b-3618-4912-9ed7-8bf24d5186c7",
+              "id": "1c0389b5-3eb1-44db-b01a-6cdb6db4276e",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -578,7 +578,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7b83a46d-48d7-44cd-93d6-dac85ee53615",
+              "id": "362b8be0-353c-4081-97ce-37f2b18a341c",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -623,7 +623,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b0ae7997-48f8-42a8-865b-c90b6b9d3699",
+                "id": "c6eb881c-4d84-46e9-a26a-8312886e26cb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/search-suggestions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -642,7 +642,7 @@
       "event": []
     },
     {
-      "id": "e31b6fa5-7237-4dbe-a871-1bdb890f6d00",
+      "id": "fa33af86-1c87-4a5b-8ec5-d31852227385",
       "name": "Product list page",
       "description": {
         "content": "",
@@ -650,7 +650,7 @@
       },
       "item": [
         {
-          "id": "23604e8f-ff33-4cb7-9662-ad5e5d2df946",
+          "id": "c774c439-a58b-4027-b790-d516e82cb2eb",
           "name": "Get attempt of correction of a misspelled term",
           "request": {
             "name": "Get attempt of correction of a misspelled term",
@@ -701,7 +701,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b748bfbc-02ed-4834-9eb8-52485e3eafcc",
+              "id": "fef0adfe-d38c-48cd-8a4b-9f4a9db536e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -756,7 +756,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"correction\": {\n    \"correction\": true,\n    \"misspelled\": true,\n    \"text\": \"mountain bike\",\n    \"highlighted\": \"mountain <em>bike</em>\"\n  }\n}",
@@ -766,7 +766,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "00e9ab85-0e11-43fc-8cdb-87753f47fc76",
+              "id": "6432ead5-f8c0-4450-b157-223a1a215559",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -810,7 +810,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c9508f69-9b3c-4f47-8804-336cdb5c924e",
+              "id": "af5910c3-e660-4244-b15f-677e7478b3e1",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -855,7 +855,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d9e1c9ec-421d-4628-a3b5-5e6339bcd68f",
+                "id": "baf229b2-93e3-48df-86ac-24e5ea0439a1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/correction-search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -871,7 +871,7 @@
           }
         },
         {
-          "id": "ec9a7fe7-2540-44e6-9715-0b3b2c0a6e0c",
+          "id": "a9f609b9-787b-4133-9ffb-bfece6dfdd33",
           "name": "Get list of banners registered for query",
           "request": {
             "name": "Get list of banners registered for query",
@@ -934,7 +934,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b7ffce10-d4ff-4126-94cd-509dd306f92f",
+              "id": "20ee47c6-8616-4e82-bc09-1e4501426de6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -990,7 +990,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"banners\": [\n    {\n      \"id\": \"summersale\",\n      \"name\": \"Summer Sale\",\n      \"area\": \"1\",\n      \"html\": \"<h1>This is a test</h1>\"\n    }\n  ]\n}",
@@ -1000,7 +1000,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9265bd15-9d13-4e3f-b0af-445a060011a9",
+              "id": "7b66a8df-7187-4c03-a5ed-a9493bc4c921",
               "name": "Bad request. Invalid parameters or missing account context.",
               "originalRequest": {
                 "url": {
@@ -1045,7 +1045,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "433849e4-6bb2-4b37-a295-b986d4990607",
+              "id": "fdb03fa2-8372-4b2f-84b8-4777e5db4067",
               "name": "Internal server error or upstream failure.",
               "originalRequest": {
                 "url": {
@@ -1091,7 +1091,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4890721d-2ba1-4df4-9da9-79eb23d934bf",
+                "id": "1249d9e3-970b-4c71-9d02-6f46c1a54504",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/banners/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1107,7 +1107,7 @@
           }
         },
         {
-          "id": "7c03170f-ecea-445b-aea1-99f7b8d3aa39",
+          "id": "4590c707-cb89-4546-bdfc-e74ac7ba6a7e",
           "name": "Search products",
           "request": {
             "name": "Search products",
@@ -1203,7 +1203,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -1239,7 +1239,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -1262,11 +1262,20 @@
                 {
                   "disabled": true,
                   "description": {
+                    "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                    "type": "text/plain"
+                  },
+                  "key": "dpPreview",
+                  "value": "true"
+                },
+                {
+                  "disabled": true,
+                  "description": {
                     "content": "UTM source value, forwarded to the pricing and availability simulation. Intelligent Search API (Legacy) previously read this from `segment.utm_source`. In v1, pass the value directly as a query parameter.",
                     "type": "text/plain"
                   },
                   "key": "utmSource",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -1275,7 +1284,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmCampaign",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -1284,7 +1293,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmiCampaign",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -1293,7 +1302,7 @@
                     "type": "text/plain"
                   },
                   "key": "campaigns",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -1302,7 +1311,7 @@
                     "type": "text/plain"
                   },
                   "key": "priceTables",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -1368,7 +1377,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3269737c-7967-422f-bcc2-f444ee117665",
+              "id": "2197a784-c484-4c20-9515-815b65ef4207",
               "name": "OK\r\n\r\nList of products for the given query.",
               "originalRequest": {
                 "url": {
@@ -1459,7 +1468,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1495,7 +1504,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1518,11 +1527,20 @@
                     {
                       "disabled": true,
                       "description": {
+                        "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                        "type": "text/plain"
+                      },
+                      "key": "dpPreview",
+                      "value": "true"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
                         "content": "UTM source value, forwarded to the pricing and availability simulation. Intelligent Search API (Legacy) previously read this from `segment.utm_source`. In v1, pass the value directly as a query parameter.",
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1531,7 +1549,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1540,7 +1558,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1549,7 +1567,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1558,7 +1576,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1622,7 +1640,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"products\": [\n    {\n      \"cacheId\": \"sp-2000003\",\n      \"productId\": \"2000003\",\n      \"description\": \"Introducing our exquisite Top Wood Clock.\",\n      \"productName\": \"Top Wood Clock\",\n      \"productReference\": \"clock120\",\n      \"linkText\": \"wood-clock\",\n      \"brand\": \"Sony\",\n      \"brandId\": 2000005,\n      \"link\": \"/wood-clock/p\",\n      \"categories\": [\n        \"/Home & Decor/\"\n      ],\n      \"categoryId\": \"40\",\n      \"categoriesIds\": [\n        \"/40/\"\n      ],\n      \"priceRange\": {\n        \"sellingPrice\": {\n          \"highPrice\": 197.99,\n          \"lowPrice\": 197.99\n        },\n        \"listPrice\": {\n          \"highPrice\": 197.99,\n          \"lowPrice\": 197.99\n        }\n      },\n      \"specificationGroups\": [],\n      \"skuSpecifications\": [],\n      \"productClusters\": [],\n      \"clusterHighlights\": [],\n      \"properties\": [],\n      \"items\": [\n        {\n          \"sellers\": [\n            {\n              \"sellerId\": \"1\",\n              \"sellerName\": \"VTEX\",\n              \"addToCartLink\": \"\",\n              \"sellerDefault\": true,\n              \"commertialOffer\": {\n                \"AvailableQuantity\": 10000,\n                \"Price\": 197.99,\n                \"ListPrice\": 197.99,\n                \"spotPrice\": 197.99,\n                \"Tax\": 0,\n                \"PriceValidUntil\": \"2025-04-01T13:13:20Z\"\n              }\n            }\n          ],\n          \"images\": [],\n          \"itemId\": \"2000534\",\n          \"name\": \"1\",\n          \"nameComplete\": \"Top Wood Clock 1\",\n          \"measurementUnit\": \"un\",\n          \"unitMultiplier\": 1,\n          \"variations\": [],\n          \"ean\": \"16001\",\n          \"modalType\": \"\",\n          \"videos\": [],\n          \"attachments\": [],\n          \"isKit\": false\n        }\n      ],\n      \"origin\": \"intelligent-search\"\n    }\n  ],\n  \"recordsFiltered\": 5,\n  \"correction\": {\n    \"misspelled\": false\n  },\n  \"fuzzy\": \"0\",\n  \"operator\": \"and\",\n  \"translated\": false,\n  \"pagination\": {\n    \"count\": 1,\n    \"current\": {\n      \"index\": 1\n    },\n    \"before\": [],\n    \"after\": [],\n    \"perPage\": 24,\n    \"next\": {\n      \"index\": 2\n    },\n    \"previous\": {\n      \"index\": 0\n    },\n    \"first\": {\n      \"index\": 1\n    },\n    \"last\": {\n      \"index\": 1\n    }\n  },\n  \"options\": {\n    \"sorts\": [],\n    \"counts\": [],\n    \"deliveryPromisesEnabled\": false\n  },\n  \"searchId\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"\n}",
@@ -1632,7 +1650,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d1f82827-f3e4-4a94-ab2f-cc6de3a8d93c",
+              "id": "13787911-0ee8-479d-862f-2dcea961fdb2",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -1723,7 +1741,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1759,7 +1777,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1782,11 +1800,20 @@
                     {
                       "disabled": true,
                       "description": {
+                        "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                        "type": "text/plain"
+                      },
+                      "key": "dpPreview",
+                      "value": "true"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
                         "content": "UTM source value, forwarded to the pricing and availability simulation. Intelligent Search API (Legacy) previously read this from `segment.utm_source`. In v1, pass the value directly as a query parameter.",
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1795,7 +1822,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1804,7 +1831,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1813,7 +1840,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1822,7 +1849,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -1887,7 +1914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5a5d8cc1-1c8d-4faf-98f6-4e6c516c8d47",
+              "id": "b29083e2-d1ea-429d-baa0-7cf420ed021e",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -1978,7 +2005,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2014,7 +2041,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2037,11 +2064,20 @@
                     {
                       "disabled": true,
                       "description": {
+                        "content": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                        "type": "text/plain"
+                      },
+                      "key": "dpPreview",
+                      "value": "true"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
                         "content": "UTM source value, forwarded to the pricing and availability simulation. Intelligent Search API (Legacy) previously read this from `segment.utm_source`. In v1, pass the value directly as a query parameter.",
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2050,7 +2086,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2059,7 +2095,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2068,7 +2104,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2077,7 +2113,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2131,7 +2167,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "31f6b73d-7a2d-41ae-abf8-14debb1589f7",
+                "id": "0db9389f-fce7-46ed-9f47-347db6a960fb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/product-search/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2147,7 +2183,7 @@
           }
         },
         {
-          "id": "6edde85a-7f5f-458e-a405-1b65179034e8",
+          "id": "8fd40b82-4918-49dc-96d7-726aea2265a2",
           "name": "List filters for a search",
           "request": {
             "name": "List filters for a search",
@@ -2198,7 +2234,7 @@
                     "type": "text/plain"
                   },
                   "key": "removeHiddenFacets",
-                  "value": "true"
+                  "value": "false"
                 },
                 {
                   "disabled": true,
@@ -2216,7 +2252,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2252,7 +2288,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2300,7 +2336,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "331a225c-fbe7-47b6-8278-8402f49a0ae3",
+              "id": "db2ef0e8-79c8-478c-af1d-68dd550491c4",
               "name": "OK\r\n\r\nList of facets for the given query.",
               "originalRequest": {
                 "url": {
@@ -2346,7 +2382,7 @@
                         "type": "text/plain"
                       },
                       "key": "removeHiddenFacets",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -2364,7 +2400,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2400,7 +2436,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2446,7 +2482,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"facets\": [\n    {\n      \"values\": [\n        {\n          \"id\": \"47\",\n          \"quantity\": 1,\n          \"name\": \"Clothing\",\n          \"key\": \"category-2\",\n          \"value\": \"clothing\",\n          \"selected\": false,\n          \"href\": \"shirt/blue/clothing?map=ft,color,category\"\n        }\n      ],\n      \"type\": \"TEXT\",\n      \"name\": \"Category\",\n      \"hidden\": false,\n      \"key\": \"category-2\",\n      \"quantity\": 1\n    },\n    {\n      \"values\": [\n        {\n          \"quantity\": 1,\n          \"name\": \"\",\n          \"key\": \"price\",\n          \"selected\": false,\n          \"range\": {\n            \"from\": 45,\n            \"to\": 50\n          }\n        }\n      ],\n      \"type\": \"PRICERANGE\",\n      \"name\": \"Price\",\n      \"hidden\": false,\n      \"key\": \"price\",\n      \"quantity\": 1\n    }\n  ],\n  \"sampling\": false,\n  \"breadcrumb\": [\n    {\n      \"name\": \"shirt\",\n      \"href\": \"/shirt?map=ft\"\n    }\n  ],\n  \"queryArgs\": {\n    \"query\": \"shirt\",\n    \"selectedFacets\": [\n      {\n        \"key\": \"ft\",\n        \"value\": \"shirt\"\n      }\n    ]\n  },\n  \"translated\": false\n}",
@@ -2457,7 +2493,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "94f26cc9-18bf-4e34-a09e-22d15649e44b",
+                "id": "a6bc59ad-dd63-41e2-b852-68c23d76457a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/facets/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2476,7 +2512,7 @@
       "event": []
     },
     {
-      "id": "7da57cc2-0169-4f0d-9188-4bd7c15df665",
+      "id": "7782c9c0-fa40-49ff-9218-681006e200eb",
       "name": "Product details page (PDP)",
       "description": {
         "content": "",
@@ -2484,7 +2520,7 @@
       },
       "item": [
         {
-          "id": "bed12f0f-2309-4532-8c96-641a90d20a9c",
+          "id": "14ecab64-46d8-4c51-8879-21054675f245",
           "name": "Get product",
           "request": {
             "name": "Get product",
@@ -2561,7 +2597,7 @@
                     "type": "text/plain"
                   },
                   "key": "productClusterId",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2570,7 +2606,7 @@
                     "type": "text/plain"
                   },
                   "key": "productOriginVtex",
-                  "value": "true"
+                  "value": "false"
                 },
                 {
                   "disabled": true,
@@ -2579,7 +2615,7 @@
                     "type": "text/plain"
                   },
                   "key": "show-invisible-items",
-                  "value": "true"
+                  "value": "false"
                 },
                 {
                   "disabled": true,
@@ -2588,7 +2624,7 @@
                     "type": "text/plain"
                   },
                   "key": "regionId",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2624,7 +2660,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2651,7 +2687,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmSource",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2660,7 +2696,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmCampaign",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2669,7 +2705,7 @@
                     "type": "text/plain"
                   },
                   "key": "utmiCampaign",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2678,7 +2714,7 @@
                     "type": "text/plain"
                   },
                   "key": "campaigns",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 },
                 {
                   "disabled": true,
@@ -2687,7 +2723,7 @@
                     "type": "text/plain"
                   },
                   "key": "priceTables",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "variable": []
@@ -2706,7 +2742,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f5f8d056-eac4-44a5-b000-c1c8d945589c",
+              "id": "8d985999-6359-403b-83f1-412afb176ad7",
               "name": "OK\r\n\r\nSingle product object. The response is the product itself; there is no `recordsFiltered`, `pagination`, or `searchId` wrapper.",
               "originalRequest": {
                 "url": {
@@ -2778,7 +2814,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2787,7 +2823,7 @@
                         "type": "text/plain"
                       },
                       "key": "productOriginVtex",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -2796,7 +2832,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -2805,7 +2841,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2841,7 +2877,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2868,7 +2904,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2877,7 +2913,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2886,7 +2922,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2895,7 +2931,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -2904,7 +2940,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -2932,7 +2968,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"productId\": \"123456\",\n  \"productName\": \"Smartphone XYZ\",\n  \"brand\": \"TechBrand\",\n  \"brandId\": 9001,\n  \"linkText\": \"smartphone-xyz\",\n  \"link\": \"/smartphone-xyz/p\",\n  \"categories\": [\n    \"/Electronics/\"\n  ],\n  \"categoryId\": \"10\",\n  \"categoriesIds\": [\n    \"/10/\"\n  ],\n  \"priceRange\": {\n    \"sellingPrice\": {\n      \"highPrice\": 999.99,\n      \"lowPrice\": 999.99\n    },\n    \"listPrice\": {\n      \"highPrice\": 1299.99,\n      \"lowPrice\": 1299.99\n    }\n  },\n  \"specificationGroups\": [],\n  \"skuSpecifications\": [],\n  \"productClusters\": [],\n  \"clusterHighlights\": [],\n  \"properties\": [],\n  \"items\": [\n    {\n      \"sellers\": [\n        {\n          \"sellerId\": \"1\",\n          \"sellerDefault\": true,\n          \"commertialOffer\": {\n            \"Price\": 999.99,\n            \"ListPrice\": 1299.99,\n            \"AvailableQuantity\": 50\n          }\n        }\n      ],\n      \"images\": [],\n      \"itemId\": \"789\",\n      \"name\": \"Smartphone XYZ - 128GB - Black\",\n      \"nameComplete\": \"Smartphone XYZ - 128GB - Black\",\n      \"measurementUnit\": \"un\",\n      \"unitMultiplier\": 1,\n      \"variations\": [],\n      \"ean\": \"7891234567890\",\n      \"modalType\": \"\",\n      \"videos\": [],\n      \"attachments\": [],\n      \"isKit\": false\n    }\n  ],\n  \"origin\": \"intelligent-search\"\n}",
@@ -2942,7 +2978,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "04d959b5-fac2-4077-a4f9-ee288a0111ad",
+              "id": "e292e125-29d5-49bb-8333-2e0513c242a8",
               "name": "Bad Request: missing or invalid parameters (for example, missing `sc` or `value`).",
               "originalRequest": {
                 "url": {
@@ -3014,7 +3050,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3023,7 +3059,7 @@
                         "type": "text/plain"
                       },
                       "key": "productOriginVtex",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3032,7 +3068,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3041,7 +3077,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3077,7 +3113,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3104,7 +3140,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3113,7 +3149,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3122,7 +3158,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3131,7 +3167,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3140,7 +3176,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -3157,7 +3193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b0d76165-ca60-4cba-a46e-a3a9bebd662a",
+              "id": "977a99ba-3bcb-4af5-9dbe-72a00199a52d",
               "name": "Unauthorized: private sales channel requires valid authentication.",
               "originalRequest": {
                 "url": {
@@ -3229,7 +3265,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3238,7 +3274,7 @@
                         "type": "text/plain"
                       },
                       "key": "productOriginVtex",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3247,7 +3283,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3256,7 +3292,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3292,7 +3328,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3319,7 +3355,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3328,7 +3364,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3337,7 +3373,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3346,7 +3382,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3355,7 +3391,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -3372,7 +3408,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "eb7316f8-4f2d-4896-87bf-4ade6f453236",
+              "id": "460fa002-64e5-41ee-b78a-121823ea704b",
               "name": "Forbidden: user is not allowed to access this resource.",
               "originalRequest": {
                 "url": {
@@ -3444,7 +3480,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3453,7 +3489,7 @@
                         "type": "text/plain"
                       },
                       "key": "productOriginVtex",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3462,7 +3498,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3471,7 +3507,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3507,7 +3543,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3534,7 +3570,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3543,7 +3579,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3552,7 +3588,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3561,7 +3597,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3570,7 +3606,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -3587,7 +3623,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2648ca25-459e-48bb-b9c0-82c841c54bad",
+              "id": "1d8ad9ff-ab7b-416d-93ba-e6641b98d81a",
               "name": "Not Found: product not found, or not in the requested `productClusterId`.",
               "originalRequest": {
                 "url": {
@@ -3659,7 +3695,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3668,7 +3704,7 @@
                         "type": "text/plain"
                       },
                       "key": "productOriginVtex",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3677,7 +3713,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3686,7 +3722,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3722,7 +3758,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3749,7 +3785,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3758,7 +3794,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3767,7 +3803,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3776,7 +3812,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3785,7 +3821,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -3802,7 +3838,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2f30c806-873b-40bc-ba71-ca88382ec86b",
+              "id": "a2e68ede-4747-4d3d-9c63-390794601734",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -3874,7 +3910,7 @@
                         "type": "text/plain"
                       },
                       "key": "productClusterId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3883,7 +3919,7 @@
                         "type": "text/plain"
                       },
                       "key": "productOriginVtex",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3892,7 +3928,7 @@
                         "type": "text/plain"
                       },
                       "key": "show-invisible-items",
-                      "value": "true"
+                      "value": "false"
                     },
                     {
                       "disabled": true,
@@ -3901,7 +3937,7 @@
                         "type": "text/plain"
                       },
                       "key": "regionId",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3937,7 +3973,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3964,7 +4000,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmSource",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3973,7 +4009,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3982,7 +4018,7 @@
                         "type": "text/plain"
                       },
                       "key": "utmiCampaign",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -3991,7 +4027,7 @@
                         "type": "text/plain"
                       },
                       "key": "campaigns",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     },
                     {
                       "disabled": true,
@@ -4000,7 +4036,7 @@
                         "type": "text/plain"
                       },
                       "key": "priceTables",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -4018,7 +4054,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "382b09f4-aa72-40af-b6a2-3adea27c04e4",
+                "id": "e5b1c382-ac6c-440b-8d58-391767add467",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4037,7 +4073,7 @@
       "event": []
     },
     {
-      "id": "4161fbd6-7767-49e3-a07d-7031c21c3339",
+      "id": "b4dcc012-14d7-49f8-99f6-ebd5d5bf44bb",
       "name": "Delivery Promise",
       "description": {
         "content": "",
@@ -4045,7 +4081,7 @@
       },
       "item": [
         {
-          "id": "bb87466a-545c-46c4-ade6-28e937ace9ba",
+          "id": "6d69dcd3-87ad-46e3-9568-69287d157d39",
           "name": "Get pickup point availability for Delivery Promise",
           "request": {
             "name": "Get pickup point availability for Delivery Promise",
@@ -4132,7 +4168,7 @@
                     "type": "text/plain"
                   },
                   "key": "pickupPoint",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "variable": [
@@ -4162,7 +4198,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "966357be-782e-4d52-be7d-99fb289171c7",
+              "id": "c0d41c64-1310-4e6a-b597-a72d311f6dd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4244,7 +4280,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -4272,7 +4308,7 @@
                     "type": "text/plain"
                   },
                   "key": "Cache-Control",
-                  "value": "est et Ut"
+                  "value": "id officia"
                 }
               ],
               "body": "{\n  \"pickupPointDistances\": [\n    {\n      \"pickupId\": \"fulfillmentqa_vtexsp\",\n      \"distance\": 4.99,\n      \"pickupName\": \"VTEX SP\",\n      \"isActive\": true,\n      \"address\": {\n        \"city\": \"New York\",\n        \"neighborhood\": \"Manhattan\",\n        \"number\": \"350\",\n        \"postalCode\": \"10001\",\n        \"street\": \"5th Avenue\",\n        \"state\": \"NY\"\n      },\n      \"businessHours\": [\n        {\n          \"dayOfWeek\": 1,\n          \"openingTime\": \"09:00:00\",\n          \"closingTime\": \"18:00:00\"\n        }\n      ]\n    }\n  ]\n}",
@@ -4282,7 +4318,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2c809ac7-d477-4c99-aa54-12e056226fc6",
+              "id": "4390b388-acf7-4213-ac6e-541f9178481a",
               "name": "Bad Request: delivery context could not be resolved (neither hashes nor country + ZIP code were usable), or invalid parameters.",
               "originalRequest": {
                 "url": {
@@ -4364,7 +4400,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -4381,7 +4417,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "96812401-449a-4cf5-9fae-1ea256a53ec2",
+              "id": "af66d5d1-11d3-438e-bb7a-35206cdedc0a",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -4463,7 +4499,7 @@
                         "type": "text/plain"
                       },
                       "key": "pickupPoint",
-                      "value": "est et Ut"
+                      "value": "id officia"
                     }
                   ],
                   "variable": []
@@ -4481,7 +4517,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a8249426-ed23-42db-ba03-b5649604dfe8",
+                "id": "500602b8-d58f-4ea0-a2c5-054b418bc37f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/pickup-point-availability/:facets - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4519,7 +4555,7 @@
     }
   ],
   "info": {
-    "_postman_id": "8ddb0cdf-9036-4ff3-aeb2-aaebff729306",
+    "_postman_id": "7d2b3a1d-55ac-4a0a-bc6e-327abcf9da78",
     "name": "Intelligent Search API v1",
     "version": {
       "raw": "0.1.0",

--- a/VTEX - Intelligent Search API - v1.json
+++ b/VTEX - Intelligent Search API - v1.json
@@ -1314,7 +1314,7 @@
             "dpPreview": {
                 "in": "query",
                 "name": "dpPreview",
-                "description": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
+                "description": "Previews [Delivery Promise](https://developers.vtex.com/docs/guides/delivery-promise) behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
                 "schema": {
                     "type": "boolean",
                     "example": true

--- a/VTEX - Intelligent Search API - v1.json
+++ b/VTEX - Intelligent Search API - v1.json
@@ -1314,7 +1314,7 @@
             "dpPreview": {
                 "in": "query",
                 "name": "dpPreview",
-                "description": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production Search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter — Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`. This parameter is only available in Intelligent Search API v1; it isn't supported by Intelligent Search API (Legacy).",
+                "description": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter, since Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`.",
                 "schema": {
                     "type": "boolean",
                     "example": true

--- a/VTEX - Intelligent Search API - v1.json
+++ b/VTEX - Intelligent Search API - v1.json
@@ -433,6 +433,9 @@
                         "$ref": "#/components/parameters/pickupPointsHash"
                     },
                     {
+                        "$ref": "#/components/parameters/dpPreview"
+                    },
+                    {
                         "$ref": "#/components/parameters/utmSource"
                     },
                     {
@@ -1306,6 +1309,15 @@
                 "schema": {
                     "type": "string",
                     "example": "d41d8cd98f00b204e9800998ecf8427e"
+                }
+            },
+            "dpPreview": {
+                "in": "query",
+                "name": "dpPreview",
+                "description": "Previews Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production Search requests. When set to `true`, the response returns `deliveryPromiseEnabled: false`. Once the account is promoted to `DpLive`, remove this parameter — Delivery Promise is applied in production and the response returns `deliveryPromiseEnabled: true`. This parameter is only available in Intelligent Search API v1; it isn't supported by Intelligent Search API (Legacy).",
+                "schema": {
+                    "type": "boolean",
+                    "example": true
                 }
             },
             "utmSource": {


### PR DESCRIPTION
Adds the `dpPreview` query parameter to the `GET /product-search/{facets}` endpoint in Intelligent Search API v1, per [EDU-19122](https://vtex-dev.atlassian.net/browse/EDU-19122). This parameter lets developers preview Delivery Promise behavior on accounts still in the `DpReady` activation state, without affecting production search requests.

Scoped to Intelligent Search API v1 only (`VTEX - Intelligent Search API - v1.json`) — the legacy spec (`VTEX - Intelligent Search API.json`) is untouched, since `dpPreview` is not supported there.

Companion guide update in `dev-portal-content`: https://github.com/vtexdocs/dev-portal-content/pull/2902

#### Types of changes
- [x] New content (endpoints, descriptions or fields from scratch)

### Changelog
- [ ] Yes, I already created a release note about this change.
- [ ] Not yet, but I'm going to.
- [x] No, it's just a fix.

[EDU-19122]: https://vtex-dev.atlassian.net/browse/EDU-19122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ