### PR TITLE
EDU-19136: Document Reports API rate limits in VTEX Ads API

### DIFF
--- a/PostmanCollections/VTEX - Ads API.json
+++ b/PostmanCollections/VTEX - Ads API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "d28f70c2-2e9e-47a9-aab2-3dafc4fc08f3"
+    "postman_id": "bfba6930-d630-4b44-a146-2607a2ac5c92"
   },
   "item": [
     {
-      "id": "375df2fb-82bb-4e85-bf5a-3d863a0a93a8",
+      "id": "3fe81f0d-05e6-4631-849e-7cce82ea9bf4",
       "name": "Catalog synchronization",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "f8ce9897-45ba-428d-8fb4-85ed999a238a",
+          "id": "ab9f326a-cc3c-43dc-a875-8066176957cd",
           "name": "Synchronize product information",
           "request": {
             "name": "Synchronize product information",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5bdbe44b-f4d8-4a68-9be7-04775c316f01",
+              "id": "3e647ce5-b6df-49a5-bb36-4b05e4fac1ca",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -155,7 +155,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7a7ddfc9-c022-46ec-863b-3d3df223a7fe",
+              "id": "613dd229-dd10-4cca-9b6d-5de4c25d9443",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -224,7 +224,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9ad25b1f-4204-43d5-839a-9deee9ecfbd2",
+                "id": "4d98e8d4-d922-4135-b190-f47fd13deb53",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -240,7 +240,7 @@
           }
         },
         {
-          "id": "cd835e47-e71c-4b00-861a-a57389ed5b20",
+          "id": "96fe091f-9b87-40c6-8f12-bb62be375f75",
           "name": "Synchronize inventory information",
           "request": {
             "name": "Synchronize inventory information",
@@ -305,7 +305,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "28b56a77-3680-4659-a9d1-6abaecb09289",
+              "id": "5fb55189-852c-4409-a016-43bdf762733c",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -383,7 +383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "af007a07-25d1-4aa9-8828-5e6aed1d8dd8",
+              "id": "d1dde0d5-2e32-4dfa-9e04-085b732a888b",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -452,7 +452,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b7f198d2-bb6b-49b1-a830-9825d40ea782",
+                "id": "6233869b-be65-41d1-b8bb-f0da5746bdcd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/inventories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -471,7 +471,7 @@
       "event": []
     },
     {
-      "id": "a23fce9c-31d4-4767-9568-d658cca73951",
+      "id": "cdda3949-c774-4ec8-809b-8183d83554ef",
       "name": "Audiences",
       "description": {
         "content": "",
@@ -479,7 +479,7 @@
       },
       "item": [
         {
-          "id": "9124f4ef-3d8d-4bb7-98bb-1c214446fa73",
+          "id": "169a26b2-8161-4f09-a5d5-fe694aa0cd16",
           "name": "Generate audience upload URL",
           "request": {
             "name": "Generate audience upload URL",
@@ -521,7 +521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a4e766e1-a28f-4e55-aab2-53f86dc71c81",
+              "id": "aca4f1d1-8373-489f-9438-3ee09b5377ec",
               "name": "OK\n\nPresigned upload URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -576,7 +576,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "10c12572-84af-4125-9e90-a22ff07e64d8",
+              "id": "eb695d54-af80-40d0-b053-eaa74ad8bd4b",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f6c7ac4b-d380-427e-a958-f482b06df618",
+                "id": "fb0879b5-90ce-4a20-a464-d0aede3d7bb1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/audience/upload-url - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -641,7 +641,7 @@
       "event": []
     },
     {
-      "id": "224f3740-ba0c-41ff-9321-598d1be97cac",
+      "id": "9e75d21a-741c-4433-91d7-ab96848b1e1b",
       "name": "Ads events notification",
       "description": {
         "content": "",
@@ -649,7 +649,7 @@
       },
       "item": [
         {
-          "id": "8d908b37-e74a-4320-be08-260e402a24d3",
+          "id": "649670b8-c7b9-4fbf-8935-6d9f428a27ad",
           "name": "Track ad impressions",
           "request": {
             "name": "Track ad impressions",
@@ -736,7 +736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a1a140b5-835e-4def-8ad1-7638c5506e78",
+              "id": "312d7d6d-c6bd-44fc-859e-05079b703dac",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -825,7 +825,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "834d4c27-2705-42c1-8153-e376174b3695",
+              "id": "a178ef38-adf1-4bb0-a99c-029625969a3b",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -914,7 +914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3c4c8114-1752-4b7c-8a6c-56805985ffeb",
+              "id": "26bbb991-346d-489f-842d-9abff4417cd4",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -994,7 +994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "08042682-c1dd-4d4c-8fff-97a2cc6f567d",
+                "id": "976e5672-8a64-44e2-8df7-7e908b71b52f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/impression/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1010,7 +1010,7 @@
           }
         },
         {
-          "id": "c4e5e69b-d31d-4ced-84bf-eb0fdb1bd001",
+          "id": "2f407712-7590-45c1-8515-bd3c92f5adc8",
           "name": "Track ad clicks",
           "request": {
             "name": "Track ad clicks",
@@ -1097,7 +1097,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7367c1c8-65ed-419b-9516-3f9f545f82ef",
+              "id": "c6f2782d-47c5-4661-ba43-efa764259151",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1186,7 +1186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fdcd4a0e-6d08-4159-b272-b5948d83fdd6",
+              "id": "752d28c0-7ec7-44ff-be8b-9658c9b3e643",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1275,7 +1275,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0dd0a914-dc4c-495c-a8ae-729a9d86dfc7",
+              "id": "f0c31b88-b33e-4d44-947c-8a00dca0cb41",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1355,7 +1355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c658d65f-6f93-4a17-9246-77405a83e7d6",
+                "id": "4424b178-8fe8-4a5d-934b-20aaf5913d7d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/click/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1371,7 +1371,7 @@
           }
         },
         {
-          "id": "9c40b7b9-6951-4ad3-aa77-827cc5188a06",
+          "id": "77881084-8ef3-49e9-a92a-c0949b561322",
           "name": "Track ad views",
           "request": {
             "name": "Track ad views",
@@ -1458,7 +1458,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e0d9b3b8-182f-4d3c-9a5e-4157f7150cfa",
+              "id": "723f4a26-f29c-4301-a03c-9e217225e2c9",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1547,7 +1547,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d015f761-891a-4278-8bec-30b6dd6b0b78",
+              "id": "c8a34d8d-6713-4dbd-8b75-3371a1383b7c",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1636,7 +1636,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a288fb58-f2cf-457b-aaba-713a75f65f79",
+              "id": "1cf2b58a-f55e-4abd-a87b-a0c5092db0a6",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1716,7 +1716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4bd2e6ae-cf97-499a-a99c-c35dbd41319e",
+                "id": "54fe053b-d723-4b86-8c64-eaba9fd28fed",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/view/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1732,7 +1732,7 @@
           }
         },
         {
-          "id": "a4cab8e5-ca4a-4579-9a02-c5702ecdc39d",
+          "id": "225d050f-6bdf-4bb7-bbec-65e5f77cd608",
           "name": "Track conversions",
           "request": {
             "name": "Track conversions",
@@ -1797,7 +1797,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "62417366-81a8-42d5-858c-279d17231582",
+              "id": "70482dfb-b78c-4f9e-aae5-f3bba1edc176",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -1875,7 +1875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "be0bf013-eec7-4a2c-a3e9-a5e1c11f78cc",
+              "id": "e05e7e06-79bc-435c-91b4-69e65aa9587b",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1944,7 +1944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "024afa73-0ec6-4b0f-ab77-f2592fa9f750",
+                "id": "a5d8eaed-afc2-4f88-9339-33bd9d94002f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/conversion - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1963,7 +1963,7 @@
       "event": []
     },
     {
-      "id": "d6afdf10-cfb2-43fe-a395-ef2127d9dbdb",
+      "id": "ecff5c48-2e56-4170-b048-38b173db30dc",
       "name": "Ads",
       "description": {
         "content": "",
@@ -1971,7 +1971,7 @@
       },
       "item": [
         {
-          "id": "ff3701db-dc5c-4725-931d-014b01cdc9c9",
+          "id": "1145e43b-b343-4f7b-b933-fcf36e3a0c76",
           "name": "Get ads",
           "request": {
             "name": "Get ads",
@@ -2047,7 +2047,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "608d8a3a-13e9-4980-ab3b-630e99cdde59",
+              "id": "b9cadb08-6859-4b6b-a99d-ff1a55b32214",
               "name": "OK\n\nQuery processed successfully.",
               "originalRequest": {
                 "url": {
@@ -2125,7 +2125,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e5cc23c5-6e8c-4559-b7e3-e8352ed3afba",
+              "id": "3f2167fd-56d7-4fc6-8020-b4c2155c7bd4",
               "name": "Bad Request\n\nInvalid request.",
               "originalRequest": {
                 "url": {
@@ -2193,7 +2193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "112e7e60-7531-4a2d-8138-bded240a0c99",
+              "id": "63d4a102-ea78-4fc3-89da-e483b270dcf6",
               "name": "Not Found\n\nResource not found.",
               "originalRequest": {
                 "url": {
@@ -2261,7 +2261,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2a3e6504-7442-48c7-bfbd-5e63b4c2adcb",
+              "id": "48b609bb-f9a0-4ad5-9911-d0742fb9b4f8",
               "name": "Unprocessable Entity\n\nField validation error.",
               "originalRequest": {
                 "url": {
@@ -2329,7 +2329,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "73a84ccd-e5d9-40c2-a556-ac681cf63fff",
+              "id": "189436f3-90b2-4f55-b39b-b06df68d6e4e",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -2398,7 +2398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c8401318-ff12-4bbe-9950-c3f2584ac161",
+                "id": "17a020b0-ce50-4aa5-a8ea-1e9c56f944fd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/rma/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2417,7 +2417,7 @@
       "event": []
     },
     {
-      "id": "268b86ec-af67-4635-b906-4b1bfa8b0872",
+      "id": "f35ffdda-6753-43f9-96e1-36356701d505",
       "name": "Reports",
       "description": {
         "content": "",
@@ -2425,7 +2425,7 @@
       },
       "item": [
         {
-          "id": "91653d13-015b-4e63-a276-6957b8ef2d9c",
+          "id": "a0f75131-ab3f-44d2-95c2-7c7dc93084a0",
           "name": "Get advertisers report",
           "request": {
             "name": "Get advertisers report",
@@ -2541,7 +2541,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a3584e4d-ab62-44da-9a23-899664620a63",
+              "id": "83c56f16-f7e6-4665-b47f-7d4842c44e3c",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -2670,7 +2670,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "014fef82-26f3-454a-a844-0c0d823d0e52",
+              "id": "0b312c4b-57fe-4ed9-b41e-c351bbd5a844",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2789,7 +2789,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e06a417d-61cb-4faa-afd5-6147b62c5c9f",
+              "id": "5131719d-e773-42de-956f-c4937d93a780",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -2919,7 +2919,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a2639bed-cfc5-4fee-97c6-27fe84db9f62",
+                "id": "724fd442-7d62-42c0-b565-aeadd3e6ac08",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/advertisers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2935,7 +2935,7 @@
           }
         },
         {
-          "id": "99ed5cfa-d395-4f78-b92b-c3d0b4ad4de2",
+          "id": "ee8a0719-ac0f-4a86-a9d0-eafe4b33eda9",
           "name": "Get publishers report",
           "request": {
             "name": "Get publishers report",
@@ -3078,7 +3078,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f606da32-f7f5-4ae2-a016-86a4d59296b0",
+              "id": "71ef56fb-5a32-47fa-8dae-31351b2a8b7a",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3234,7 +3234,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7f9b5c48-ad81-49e3-aa4f-09a447eaeeab",
+              "id": "399322da-54ed-4bd1-9289-fb5c551be8f8",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3380,7 +3380,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c8948386-8fa5-48dc-9359-368ad45f1d3c",
+              "id": "46457a4e-f802-4759-8447-5f803f051725",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7a0a1b8b-cdaa-475d-81c9-5aa49204aae7",
+                "id": "9af7c193-fc30-4d66-86d2-337583950d7d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3553,7 +3553,7 @@
           }
         },
         {
-          "id": "03072499-c5df-4e09-aa73-a66a4e1e8523",
+          "id": "8999c093-1375-4883-8ff7-0bab9a9eec18",
           "name": "Get network publishers report",
           "request": {
             "name": "Get network publishers report",
@@ -3696,7 +3696,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ba26ec53-5ff5-4d3b-a072-162260d7c571",
+              "id": "ebfc905a-b7e8-4a5e-9ca2-24c39b832701",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3852,7 +3852,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e4185439-706b-4bc8-99d4-3d8faa47425a",
+              "id": "6f5128da-66f2-4acd-b924-c682a7b9c9f2",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3998,7 +3998,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3458d28c-31e4-4b6c-96db-737ffd4a3c7f",
+              "id": "0feb8f59-1ba9-4b18-a0cd-958f436b7383",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4155,7 +4155,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3bc415a1-d4e8-474f-8026-9b42059abdcd",
+                "id": "c84dd2c1-d9d1-4cf3-b3ba-7c3ba529c995",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/network/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4171,7 +4171,7 @@
           }
         },
         {
-          "id": "5d09385e-3c38-4d8b-b29c-2f4b60e55222",
+          "id": "cbb1018b-d9c5-48ee-80db-58ef50d4a43c",
           "name": "List campaigns",
           "request": {
             "name": "List campaigns",
@@ -4340,7 +4340,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4b1a808f-f2f7-4df3-92df-72a53943cfa0",
+              "id": "b53afb28-7743-46c4-ac12-dee1a6e5fb9b",
               "name": "OK\n\nCampaigns returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4522,7 +4522,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7fcdde00-e8bd-45a9-bfdb-ceec866c732a",
+              "id": "edee31dc-160e-4a84-9338-ed0730b5bc32",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4694,7 +4694,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1410c0ce-83fa-4ca5-bb5e-46088231a68d",
+              "id": "e3d90ec2-908f-48fa-b99d-a29a68376928",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4877,7 +4877,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8deab6fd-8cd7-4443-b8f5-5456ae008e61",
+                "id": "afb23631-585b-479d-9a38-3246532db546",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4893,7 +4893,7 @@
           }
         },
         {
-          "id": "be57a705-8b30-4c2c-bca9-7153ec997fad",
+          "id": "d33e0ef0-0499-4249-8568-97e38c288836",
           "name": "Get campaign details",
           "request": {
             "name": "Get campaign details",
@@ -4974,7 +4974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "819e672d-5615-41a8-93e0-46e9ea73a271",
+              "id": "5fe8009f-e73b-4602-be68-b92f0b20f498",
               "name": "OK\n\nCampaign returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5057,7 +5057,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c0d7bca1-30c4-4a50-bfef-ada3cdd3cd37",
+              "id": "d405e003-9a93-4f37-b9b8-06dda8294238",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5130,7 +5130,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2c1346d3-18f7-43ec-b960-6f00f9230379",
+              "id": "ca58b589-7585-42d3-b796-37d73915d13a",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
@@ -5203,7 +5203,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fac078be-7c86-4423-8582-d071de90fb85",
+              "id": "6b842e80-418f-44bd-a956-0c28c2cfe87c",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -5287,7 +5287,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4a1303c6-6ebd-4cf5-a0e4-e3974f0acd58",
+                "id": "9d5faf7a-a995-427b-958f-bb76ac2b1487",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5303,7 +5303,7 @@
           }
         },
         {
-          "id": "66613c20-1ec7-47c1-931f-07fe61abea1d",
+          "id": "f2e1858a-dbfa-4eae-badc-65e14b764f4e",
           "name": "Get advertiser campaigns detailed report",
           "request": {
             "name": "Get advertiser campaigns detailed report",
@@ -5527,7 +5527,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4d23846e-5718-4793-a1b0-41c8ae9a81fc",
+              "id": "3a1f8b5e-293d-4b05-96e9-11e33469c1fb",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5764,7 +5764,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "93b924dd-739c-4b2d-b182-376b442a6ed5",
+              "id": "04c34978-c68a-425c-97cc-3ae7319ea377",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5991,7 +5991,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f694da12-687e-48ff-92c1-5498eb6e0d70",
+              "id": "0aceafde-d2a8-4211-a5d8-bc5cbfcb846c",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -6229,7 +6229,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "51b79cf5-b4f3-4f3e-8f62-41fb9fefd639",
+                "id": "a31e44e2-9b4e-4b7f-8707-30f6ac644e23",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6245,7 +6245,7 @@
           }
         },
         {
-          "id": "83082f34-4d08-4f1a-9f93-623a6956af80",
+          "id": "1e19da78-914a-4c94-9411-cc68e3202602",
           "name": "Get advertiser ads detailed report",
           "request": {
             "name": "Get advertiser ads detailed report",
@@ -6487,7 +6487,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6e36886e-23be-4ad1-8b4f-7a625469bd09",
+              "id": "dcc678bc-67de-4158-a5ac-114333a2777d",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -6742,7 +6742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "85a681bf-fe95-4195-b11f-1511df84078c",
+              "id": "e20da574-0eb0-4ad7-a188-586661d36f8c",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6987,7 +6987,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ef19b829-b51d-4f59-9cd0-ac86f5188f41",
+              "id": "02762f63-8927-486c-8607-2cf5228e531e",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -7243,7 +7243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2745f403-5650-4bf6-aacc-0e20a0065370",
+                "id": "da767b90-3a43-48b1-931c-baad56fc7f3d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/ads-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7259,7 +7259,7 @@
           }
         },
         {
-          "id": "4194bf0a-3763-4725-a2da-346309f359a7",
+          "id": "8baf3d86-09d0-4291-8c05-3cb660b02d85",
           "name": "Get ads performance report",
           "request": {
             "name": "Get ads performance report",
@@ -7465,7 +7465,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ab96d6ec-ce3c-4dbc-9eb4-ef60ba14b144",
+              "id": "13c48414-5d9f-47c1-9cff-b4c390852adb",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -7684,7 +7684,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6b2c35e7-a454-4be4-aaea-3b0c00c16d0f",
+              "id": "b9465609-cf04-4a15-8458-865b8d6836cc",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "506363bf-287e-40bd-bf6d-6a3c23e3d92b",
+              "id": "e85a0d67-d935-4ac6-8a14-d98039bc0b0d",
               "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -8113,7 +8113,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e267e8fe-0fc3-4805-ada1-92d3dc912ba1",
+                "id": "18f16126-357d-40df-98da-c2729d1d8cad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/ad/results/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8132,7 +8132,7 @@
       "event": []
     },
     {
-      "id": "a22c3088-a212-4587-bea6-a354edc767f5",
+      "id": "b46c9be1-7bb4-4ddb-a6b1-fb19270410ba",
       "name": "Credit transfer",
       "description": {
         "content": "",
@@ -8140,7 +8140,7 @@
       },
       "item": [
         {
-          "id": "9c05b688-f90a-450f-95e5-c147bddb64dd",
+          "id": "9e5d0852-2aa7-42ea-8b5f-2fab1ae9dc5e",
           "name": "Notify credit transfer status",
           "request": {
             "name": "Notify credit transfer status",
@@ -8233,7 +8233,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b93af77e-8b91-498e-861a-ab0064df6768",
+              "id": "79a3586f-8cd7-46d1-bf8d-b28a33ecd4f7",
               "name": "No Content\n\nNotification accepted.",
               "originalRequest": {
                 "url": {
@@ -8302,7 +8302,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "33793f3b-371e-48da-8780-95648a8e4d38",
+              "id": "49e640ba-33f9-4e59-a884-9a6bf7973b06",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -8372,7 +8372,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "13d67458-fcef-470d-8f83-fd89c822678c",
+                "id": "7dc2b6c0-3699-407b-b3fd-fe3eb76f1366",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/webhook/marketplace/transfers/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8389,7 +8389,7 @@
       "event": []
     },
     {
-      "id": "88dd4120-d3c0-4557-806b-690f4aac412f",
+      "id": "6386a920-ec5c-4908-a2df-2489fa20a666",
       "name": "Single sign-on",
       "description": {
         "content": "",
@@ -8397,7 +8397,7 @@
       },
       "item": [
         {
-          "id": "7cb36245-270a-49da-8537-ae125eabc49d",
+          "id": "2185b194-affe-480c-85a2-d828c29409df",
           "name": "Generate seller single sign-on URL",
           "request": {
             "name": "Generate seller single sign-on URL",
@@ -8461,7 +8461,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "aad92753-0ce4-4974-b882-ded48f47f507",
+              "id": "07e3b118-0ae0-4a93-a45d-39abc2e511b1",
               "name": "OK\n\nRedirect URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -8538,7 +8538,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b0ccbad9-1685-4d82-bd7e-46c032ff4113",
+              "id": "f6193d52-f5d2-41ef-a800-7a439b590ff2",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -8606,7 +8606,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "69b603bd-cbca-4651-bd07-ed2573ed28de",
+                "id": "f03c1310-f6b9-4760-91de-d9d58794b21a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/sso/marketplace - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8654,7 +8654,7 @@
     }
   ],
   "info": {
-    "_postman_id": "d28f70c2-2e9e-47a9-aab2-3dafc4fc08f3",
+    "_postman_id": "bfba6930-d630-4b44-a146-2607a2ac5c92",
     "name": "VTEX Ads API",
     "version": {
       "raw": "1.0.0",

--- a/PostmanCollections/VTEX - Ads API.json
+++ b/PostmanCollections/VTEX - Ads API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "0eb8b10b-41b2-48cc-9715-67164d40d51b"
+    "postman_id": "d28f70c2-2e9e-47a9-aab2-3dafc4fc08f3"
   },
   "item": [
     {
-      "id": "850a5691-cd31-4fa3-8341-a23d16770e91",
+      "id": "375df2fb-82bb-4e85-bf5a-3d863a0a93a8",
       "name": "Catalog synchronization",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "6df1f5a8-36df-4ed1-aced-d689456a0c3d",
+          "id": "f8ce9897-45ba-428d-8fb4-85ed999a238a",
           "name": "Synchronize product information",
           "request": {
             "name": "Synchronize product information",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "71b2857b-1de0-408b-9475-205c3199d829",
+              "id": "5bdbe44b-f4d8-4a68-9be7-04775c316f01",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -155,7 +155,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0d78e751-ea9f-4879-9b23-4bbdbb0e8832",
+              "id": "7a7ddfc9-c022-46ec-863b-3d3df223a7fe",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -224,7 +224,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9622ad85-52b0-448d-bc4d-3508c9a8876a",
+                "id": "9ad25b1f-4204-43d5-839a-9deee9ecfbd2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -240,7 +240,7 @@
           }
         },
         {
-          "id": "bf65ccbd-dead-459b-9570-224c74aa6096",
+          "id": "cd835e47-e71c-4b00-861a-a57389ed5b20",
           "name": "Synchronize inventory information",
           "request": {
             "name": "Synchronize inventory information",
@@ -305,7 +305,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fd39b0c6-4a2c-4240-895f-6eadadcdbd81",
+              "id": "28b56a77-3680-4659-a9d1-6abaecb09289",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -383,7 +383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d7950a13-4b7f-401b-9fb9-252978621c5b",
+              "id": "af007a07-25d1-4aa9-8828-5e6aed1d8dd8",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -452,7 +452,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "991176f1-7be2-4740-82a9-68a1c137c214",
+                "id": "b7f198d2-bb6b-49b1-a830-9825d40ea782",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/inventories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -471,7 +471,7 @@
       "event": []
     },
     {
-      "id": "15a62392-121f-4c55-bd61-b280cbc02cba",
+      "id": "a23fce9c-31d4-4767-9568-d658cca73951",
       "name": "Audiences",
       "description": {
         "content": "",
@@ -479,7 +479,7 @@
       },
       "item": [
         {
-          "id": "3e03debf-9471-47b0-8226-fae10b17a6da",
+          "id": "9124f4ef-3d8d-4bb7-98bb-1c214446fa73",
           "name": "Generate audience upload URL",
           "request": {
             "name": "Generate audience upload URL",
@@ -521,7 +521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0ad070df-b21c-477b-96d2-e183d0403e63",
+              "id": "a4e766e1-a28f-4e55-aab2-53f86dc71c81",
               "name": "OK\n\nPresigned upload URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -576,7 +576,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d5f05874-015b-4cbf-b492-b935824b59b5",
+              "id": "10c12572-84af-4125-9e90-a22ff07e64d8",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8eaa3dea-bf96-4d8d-b085-9bde4c7dbc26",
+                "id": "f6c7ac4b-d380-427e-a958-f482b06df618",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/audience/upload-url - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -641,7 +641,7 @@
       "event": []
     },
     {
-      "id": "af60217f-e18e-40fb-a750-f27f4cdd3895",
+      "id": "224f3740-ba0c-41ff-9321-598d1be97cac",
       "name": "Ads events notification",
       "description": {
         "content": "",
@@ -649,7 +649,7 @@
       },
       "item": [
         {
-          "id": "eabde541-2d97-4777-b5e0-0b2571679da6",
+          "id": "8d908b37-e74a-4320-be08-260e402a24d3",
           "name": "Track ad impressions",
           "request": {
             "name": "Track ad impressions",
@@ -736,7 +736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4ca488ce-5099-419c-a779-2e7de932637a",
+              "id": "a1a140b5-835e-4def-8ad1-7638c5506e78",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -825,7 +825,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4d928809-eea0-4d35-a441-aa2e99317bf9",
+              "id": "834d4c27-2705-42c1-8153-e376174b3695",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -914,7 +914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e14eb125-141d-46ff-a680-2a5f181729c3",
+              "id": "3c4c8114-1752-4b7c-8a6c-56805985ffeb",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -994,7 +994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f3ea2f50-376a-4857-9fec-ffad09cbf08c",
+                "id": "08042682-c1dd-4d4c-8fff-97a2cc6f567d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/impression/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1010,7 +1010,7 @@
           }
         },
         {
-          "id": "65a83f67-e62c-4e6a-a820-45916c3abd8a",
+          "id": "c4e5e69b-d31d-4ced-84bf-eb0fdb1bd001",
           "name": "Track ad clicks",
           "request": {
             "name": "Track ad clicks",
@@ -1097,7 +1097,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "63faa53d-4821-46a8-bfba-e0128418c02a",
+              "id": "7367c1c8-65ed-419b-9516-3f9f545f82ef",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1186,7 +1186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "70279679-8434-41e4-b3c8-1069eea43276",
+              "id": "fdcd4a0e-6d08-4159-b272-b5948d83fdd6",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1275,7 +1275,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "77830ac0-1e65-419e-868c-d4a7407897b1",
+              "id": "0dd0a914-dc4c-495c-a8ae-729a9d86dfc7",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1355,7 +1355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b29cb526-6f84-4e70-beb4-9ed013d64ece",
+                "id": "c658d65f-6f93-4a17-9246-77405a83e7d6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/click/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1371,7 +1371,7 @@
           }
         },
         {
-          "id": "6f9a9546-c5dd-4de0-86ed-604543535a86",
+          "id": "9c40b7b9-6951-4ad3-aa77-827cc5188a06",
           "name": "Track ad views",
           "request": {
             "name": "Track ad views",
@@ -1458,7 +1458,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "754c5876-c5b7-4d2a-9e0f-b5cffdd8adc4",
+              "id": "e0d9b3b8-182f-4d3c-9a5e-4157f7150cfa",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1547,7 +1547,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bc6fed89-bd0a-4c91-98d2-cbbaff119c27",
+              "id": "d015f761-891a-4278-8bec-30b6dd6b0b78",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1636,7 +1636,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b1cf6ceb-5072-44e7-bb75-ceaf8f2ceb5e",
+              "id": "a288fb58-f2cf-457b-aaba-713a75f65f79",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1716,7 +1716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eca5c911-15ed-4609-8b6a-e116669a3d33",
+                "id": "4bd2e6ae-cf97-499a-a99c-c35dbd41319e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/view/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1732,7 +1732,7 @@
           }
         },
         {
-          "id": "81185f7c-a72e-40f1-bf4a-cb42c353c836",
+          "id": "a4cab8e5-ca4a-4579-9a02-c5702ecdc39d",
           "name": "Track conversions",
           "request": {
             "name": "Track conversions",
@@ -1797,7 +1797,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7f087ee4-3d3d-41fa-a68d-90079ccc4342",
+              "id": "62417366-81a8-42d5-858c-279d17231582",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -1875,7 +1875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "deafb23d-8f26-49b0-94aa-ee9ad796ca33",
+              "id": "be0bf013-eec7-4a2c-a3e9-a5e1c11f78cc",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1944,7 +1944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a36aa507-18ca-414f-9a07-04e0e33585d1",
+                "id": "024afa73-0ec6-4b0f-ab77-f2592fa9f750",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/conversion - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1963,7 +1963,7 @@
       "event": []
     },
     {
-      "id": "b3aa8c56-e139-4624-94d3-1b66cac2c9ff",
+      "id": "d6afdf10-cfb2-43fe-a395-ef2127d9dbdb",
       "name": "Ads",
       "description": {
         "content": "",
@@ -1971,7 +1971,7 @@
       },
       "item": [
         {
-          "id": "5121dcf8-9d26-4ae6-896f-22a31ea8a072",
+          "id": "ff3701db-dc5c-4725-931d-014b01cdc9c9",
           "name": "Get ads",
           "request": {
             "name": "Get ads",
@@ -2047,7 +2047,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "01f7cbde-6749-46dc-a66f-873a60050037",
+              "id": "608d8a3a-13e9-4980-ab3b-630e99cdde59",
               "name": "OK\n\nQuery processed successfully.",
               "originalRequest": {
                 "url": {
@@ -2125,7 +2125,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7e61449c-e0bc-4b65-9c82-cf10c2ce4f4e",
+              "id": "e5cc23c5-6e8c-4559-b7e3-e8352ed3afba",
               "name": "Bad Request\n\nInvalid request.",
               "originalRequest": {
                 "url": {
@@ -2193,7 +2193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "157b11c4-9f6f-45d0-b7e5-1c9bf745ec03",
+              "id": "112e7e60-7531-4a2d-8138-bded240a0c99",
               "name": "Not Found\n\nResource not found.",
               "originalRequest": {
                 "url": {
@@ -2261,7 +2261,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "46ded926-7c7c-4bc0-8c02-4bc70c02d220",
+              "id": "2a3e6504-7442-48c7-bfbd-5e63b4c2adcb",
               "name": "Unprocessable Entity\n\nField validation error.",
               "originalRequest": {
                 "url": {
@@ -2329,7 +2329,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "59e51929-00e1-4de2-9acc-e1ca813cc140",
+              "id": "73a84ccd-e5d9-40c2-a556-ac681cf63fff",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -2398,7 +2398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4ff4fd85-35db-4bf3-92c8-b336907c4221",
+                "id": "c8401318-ff12-4bbe-9950-c3f2584ac161",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/rma/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2417,7 +2417,7 @@
       "event": []
     },
     {
-      "id": "cbb75152-a39f-414b-adf0-5b2bba5a4093",
+      "id": "268b86ec-af67-4635-b906-4b1bfa8b0872",
       "name": "Reports",
       "description": {
         "content": "",
@@ -2425,12 +2425,12 @@
       },
       "item": [
         {
-          "id": "e3fc6b26-e2b0-4cff-abda-d99632474df2",
+          "id": "91653d13-015b-4e63-a276-6957b8ef2d9c",
           "name": "Get advertisers report",
           "request": {
             "name": "Get advertisers report",
             "description": {
-              "content": "Retrieves information from all advertisers associated with a publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the publisher view (publisher account).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Retrieves information from all advertisers associated with a publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the publisher view (publisher account).\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -2541,7 +2541,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "07de2471-6acb-4e89-8bb6-01576c255573",
+              "id": "a3584e4d-ab62-44da-9a23-899664620a63",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -2670,7 +2670,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d5590b82-c9d9-4226-8ca9-dad824f2dd0b",
+              "id": "014fef82-26f3-454a-a844-0c0d823d0e52",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2784,13 +2784,142 @@
               "code": 401,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "e06a417d-61cb-4faa-afd5-6147b62c5c9f",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "report",
+                    "v2",
+                    "advertisers"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, includes detailed account information in the result.",
+                        "type": "text/plain"
+                      },
+                      "key": "account_info",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page. When `download=true`, the BFF requests up to `20000` rows for XLSX generation.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns the total number of available records.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns an XLSX file buffer for download instead of JSON.",
+                        "type": "text/plain"
+                      },
+                      "key": "download",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "c14fd91d-7f46-41e7-96e9-91b240858b1e",
+                "id": "a2639bed-cfc5-4fee-97c6-27fe84db9f62",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/advertisers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2806,12 +2935,12 @@
           }
         },
         {
-          "id": "1a247af2-1b67-461f-b31b-30f6423d1466",
+          "id": "99ed5cfa-d395-4f78-b92b-c3d0b4ad4de2",
           "name": "Get publishers report",
           "request": {
             "name": "Get publishers report",
             "description": {
-              "content": "Retrieves information about the publishers associated with an advertiser account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the advertiser view (advertiser account).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Retrieves information about the publishers associated with an advertiser account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the advertiser view (advertiser account).\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -2949,7 +3078,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e374a64c-b7f9-4fcf-aa0c-9e23cd2134df",
+              "id": "f606da32-f7f5-4ae2-a016-86a4d59296b0",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3105,7 +3234,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c8a977dd-ba03-4a2d-bc5d-082aec89f5c4",
+              "id": "7f9b5c48-ad81-49e3-aa4f-09a447eaeeab",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3246,13 +3375,169 @@
               "code": 401,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "c8948386-8fa5-48dc-9359-368ad45f1d3c",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "report",
+                    "v2",
+                    "publishers"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters results by publisher name.",
+                        "type": "text/plain"
+                      },
+                      "key": "publisher_name",
+                      "value": "MyStore"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, includes detailed account information in the result.",
+                        "type": "text/plain"
+                      },
+                      "key": "account_info",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page. When `download=true`, the BFF requests up to `20000` rows for XLSX generation.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns the total number of available records.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "income"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "desc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns an XLSX file buffer for download instead of JSON.",
+                        "type": "text/plain"
+                      },
+                      "key": "download",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "a31935a7-f20f-40a3-9925-285ac950afeb",
+                "id": "7a0a1b8b-cdaa-475d-81c9-5aa49204aae7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3268,12 +3553,12 @@
           }
         },
         {
-          "id": "bbb2ea85-a89e-41d5-92f1-3f653bb1c2ff",
+          "id": "03072499-c5df-4e09-aa73-a66a4e1e8523",
           "name": "Get network publishers report",
           "request": {
             "name": "Get network publishers report",
             "description": {
-              "content": "Retrieves information about publishers associated with a Network Publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only publishers operating in the Network format are allowed to access this report.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Retrieves information about publishers associated with a Network Publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only publishers operating in the Network format are allowed to access this report.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -3411,7 +3696,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fe629d88-d2cb-4dde-9713-f5e379d446a3",
+              "id": "ba26ec53-5ff5-4d3b-a072-162260d7c571",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3567,7 +3852,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6c7ad326-4f04-47ac-8e3b-54db3fc84076",
+              "id": "e4185439-706b-4bc8-99d4-3d8faa47425a",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3708,13 +3993,169 @@
               "code": 401,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "3458d28c-31e4-4b6c-96db-737ffd4a3c7f",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "report",
+                    "network",
+                    "publishers"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters results by publisher name.",
+                        "type": "text/plain"
+                      },
+                      "key": "publisher_name",
+                      "value": "MyStore"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, includes detailed account information in the result.",
+                        "type": "text/plain"
+                      },
+                      "key": "account_info",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page. When `download=true`, the BFF requests up to `20000` rows for XLSX generation.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns the total number of available records.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "impressions"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "desc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns an XLSX file buffer for download instead of JSON.",
+                        "type": "text/plain"
+                      },
+                      "key": "download",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "d80441f4-814b-4732-8d14-1c7b4372cbbb",
+                "id": "3bc415a1-d4e8-474f-8026-9b42059abdcd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/network/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3730,12 +4171,12 @@
           }
         },
         {
-          "id": "2ba9b91a-74b3-43aa-8dd3-85a17017b848",
+          "id": "5d09385e-3c38-4d8b-b29c-2f4b60e55222",
           "name": "List campaigns",
           "request": {
             "name": "List campaigns",
             "description": {
-              "content": "Fetches all available campaigns, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Fetches all available campaigns, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -3899,7 +4340,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "be8bccf3-71c0-42b2-9284-bf9b1dd10fce",
+              "id": "4b1a808f-f2f7-4df3-92df-72a53943cfa0",
               "name": "OK\n\nCampaigns returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4081,7 +4522,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8442424a-482f-4a20-92da-5ab7716c069b",
+              "id": "7fcdde00-e8bd-45a9-bfdb-ceec866c732a",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4248,13 +4689,195 @@
               "code": 401,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "1410c0ce-83fa-4ca5-bb5e-46088231a68d",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "campaign",
+                    "v2"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by campaign status.",
+                        "type": "text/plain"
+                      },
+                      "key": "status",
+                      "value": "running"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters campaigns by advertiser ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "advertiser_id",
+                      "value": "advertiser-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by ad type.",
+                        "type": "text/plain"
+                      },
+                      "key": "ad_type",
+                      "value": "product"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Searches campaigns by name.",
+                        "type": "text/plain"
+                      },
+                      "key": "name",
+                      "value": "Holiday Sale"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, includes detailed account information in the result.",
+                        "type": "text/plain"
+                      },
+                      "key": "account_info",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page. When `download=true`, the BFF requests up to `20000` rows for XLSX generation.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns the total number of available records.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "created_at"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "desc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns an XLSX file buffer for download instead of JSON.",
+                        "type": "text/plain"
+                      },
+                      "key": "download",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "e3a7b2b4-86b4-4287-a21a-4ff620da53d5",
+                "id": "8deab6fd-8cd7-4443-b8f5-5456ae008e61",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4270,12 +4893,12 @@
           }
         },
         {
-          "id": "5464550e-02b3-42a0-91d6-5600cb01f219",
+          "id": "be57a705-8b30-4c2c-bca9-7153ec997fad",
           "name": "Get campaign details",
           "request": {
             "name": "Get campaign details",
             "description": {
-              "content": "Retrieves detailed information about a campaign, such as the products associated with the campaign, status history, ads, and metrics. The data is returned only in JSON format.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Retrieves detailed information about a campaign, such as the products associated with the campaign, status history, ads, and metrics. The data is returned only in JSON format.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -4351,7 +4974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9fa44671-5c41-4f04-a723-f7591fea4072",
+              "id": "819e672d-5615-41a8-93e0-46e9ea73a271",
               "name": "OK\n\nCampaign returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4434,7 +5057,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8836d42d-6380-4f06-8dc2-38b5df2926e7",
+              "id": "c0d7bca1-30c4-4a50-bfef-ada3cdd3cd37",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4507,7 +5130,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "515109fc-faba-4c05-93ba-651ffcbf25e8",
+              "id": "2c1346d3-18f7-43ec-b960-6f00f9230379",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
@@ -4575,13 +5198,96 @@
               "code": 404,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "fac078be-7c86-4423-8582-d071de90fb85",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "campaign",
+                    ":campaign_id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "13c30550-ee34-489a-a486-5b4cffeaa959",
+                "id": "4a1303c6-6ebd-4cf5-a0e4-e3974f0acd58",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4597,12 +5303,12 @@
           }
         },
         {
-          "id": "e6c539f0-0628-44c9-9f56-932c43b3c53c",
+          "id": "66613c20-1ec7-47c1-931f-07fe61abea1d",
           "name": "Get advertiser campaigns detailed report",
           "request": {
             "name": "Get advertiser campaigns detailed report",
             "description": {
-              "content": "Exports a mixed campaign report for advertiser accounts, including both regular campaigns and subpublisher information for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Exports a mixed campaign report for advertiser accounts, including both regular campaigns and subpublisher information for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -4821,7 +5527,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2d55871f-f011-4387-83a6-1ac448b7a333",
+              "id": "4d23846e-5718-4793-a1b0-41c8ae9a81fc",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5058,7 +5764,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "31d3d4b2-dfed-4724-8a84-2ea839fda6b0",
+              "id": "93b924dd-739c-4b2d-b182-376b442a6ed5",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5280,13 +5986,250 @@
               "code": 401,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "f694da12-687e-48ff-92c1-5498eb6e0d70",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "report",
+                    "advertisers",
+                    "campaigns-detailed"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by campaign ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "campaign-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by campaign status.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_status",
+                      "value": "running"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by publisher ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "publisher_id",
+                      "value": "publisher-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by publisher name.",
+                        "type": "text/plain"
+                      },
+                      "key": "publisher_name",
+                      "value": "MyStore"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by ad type.",
+                        "type": "text/plain"
+                      },
+                      "key": "ad_type",
+                      "value": "product"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by ad status.",
+                        "type": "text/plain"
+                      },
+                      "key": "ad_status",
+                      "value": "enabled"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by seller ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "seller_id",
+                      "value": "seller-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by advertiser tag ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "tag_id",
+                      "value": "tag-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by targeting type.",
+                        "type": "text/plain"
+                      },
+                      "key": "targeting_type",
+                      "value": "category"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters network rows by subpublisher ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "sub_publisher_id",
+                      "value": "subpublisher-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters network rows by subpublisher name.",
+                        "type": "text/plain"
+                      },
+                      "key": "sub_publisher_name",
+                      "value": "Subpublisher Name"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page. When `download=true`, the BFF requests up to `20000` rows for XLSX generation.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns pagination metadata.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "true"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "income"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "desc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns an XLSX file buffer for download instead of JSON.",
+                        "type": "text/plain"
+                      },
+                      "key": "download",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "f94cdf8c-fc11-40d1-8127-abaa91dd41f3",
+                "id": "51b79cf5-b4f3-4f3e-8f62-41fb9fefd639",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5302,12 +6245,12 @@
           }
         },
         {
-          "id": "94d08a70-381e-406e-91ff-f3f04de80880",
+          "id": "83082f34-4d08-4f1a-9f93-623a6956af80",
           "name": "Get advertiser ads detailed report",
           "request": {
             "name": "Get advertiser ads detailed report",
             "description": {
-              "content": "Exports a detailed ad report for advertiser accounts, including subpublisher breakdown for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. Non-network campaigns return one row per ad, while network campaigns return one row per `ad + subpublisher`. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Exports a detailed ad report for advertiser accounts, including subpublisher breakdown for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. Non-network campaigns return one row per ad, while network campaigns return one row per `ad + subpublisher`. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -5544,7 +6487,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dcc7a4c8-944f-44de-93db-8a4108f9a640",
+              "id": "6e36886e-23be-4ad1-8b4f-7a625469bd09",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5799,7 +6742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f91b46ee-8adb-40da-b6af-669c7de5119e",
+              "id": "85a681bf-fe95-4195-b11f-1511df84078c",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6039,13 +6982,268 @@
               "code": 401,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "ef19b829-b51d-4f59-9cd0-ac86f5188f41",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "report",
+                    "advertisers",
+                    "ads-detailed"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by campaign name.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_name",
+                      "value": "Holiday Sale"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by campaign ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "campaign-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by publisher ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "publisher_id",
+                      "value": "publisher-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by advertiser ID. In the BFF flow, this value is derived from the authenticated advertiser context.",
+                        "type": "text/plain"
+                      },
+                      "key": "advertiser_id",
+                      "value": "advertiser-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by product SKU.",
+                        "type": "text/plain"
+                      },
+                      "key": "product_sku",
+                      "value": "SKU-123"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by status.",
+                        "type": "text/plain"
+                      },
+                      "key": "ad_status",
+                      "value": "enabled"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by ad type.",
+                        "type": "text/plain"
+                      },
+                      "key": "ad_type",
+                      "value": "product"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by targeting type.",
+                        "type": "text/plain"
+                      },
+                      "key": "targeting_type",
+                      "value": "category"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by advertiser tag ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "tag_id",
+                      "value": "tag-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters network rows by subpublisher ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "sub_publisher_id",
+                      "value": "subpublisher-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters network rows by subpublisher name.",
+                        "type": "text/plain"
+                      },
+                      "key": "sub_publisher_name",
+                      "value": "Subpublisher Name"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, includes paused ads.",
+                        "type": "text/plain"
+                      },
+                      "key": "show_inactive",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, excludes `pending_review` and `rejected` rows when `ad_status` is not provided.",
+                        "type": "text/plain"
+                      },
+                      "key": "hide_pending_rejected",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page. When `download=true`, the BFF requests up to `20000` rows for XLSX generation.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns pagination metadata.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "true"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "income"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "desc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns an XLSX file buffer for download instead of JSON.",
+                        "type": "text/plain"
+                      },
+                      "key": "download",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "51a3f363-7e84-44c7-8e2e-3113017af66a",
+                "id": "2745f403-5650-4bf6-aacc-0e20a0065370",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/ads-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6061,12 +7259,12 @@
           }
         },
         {
-          "id": "4ada8b9a-6842-4092-ad21-701cfaabf2bb",
+          "id": "4194bf0a-3763-4725-a2da-346309f359a7",
           "name": "Get ads performance report",
           "request": {
             "name": "Get ads performance report",
             "description": {
-              "content": "Fetches all available ads, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Paused ads are excluded from the default response. To include paused ads, set `show_inactive=true`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Fetches all available ads, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Paused ads are excluded from the default response. To include paused ads, set `show_inactive=true`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -6267,7 +7465,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e1b51e5a-6eda-4ce6-bed2-ee22c0a59ad9",
+              "id": "ab96d6ec-ce3c-4dbc-9eb4-ef60ba14b144",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -6486,7 +7684,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "98368038-53b5-4336-9b47-daf673c72afe",
+              "id": "6b2c35e7-a454-4be4-aaea-3b0c00c16d0f",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6690,13 +7888,232 @@
               "code": 401,
               "header": [],
               "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "506363bf-287e-40bd-bf6d-6a3c23e3d92b",
+              "name": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "ad",
+                    "results",
+                    "v2"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Start date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) End date for metrics in `YYYY-MM-DD` format.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by campaign name.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_name",
+                      "value": "Holiday Sale"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by campaign ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "campaign-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by advertiser ID.",
+                        "type": "text/plain"
+                      },
+                      "key": "advertiser_id",
+                      "value": "advertiser-id"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by product SKU.",
+                        "type": "text/plain"
+                      },
+                      "key": "product_sku",
+                      "value": "SKU-123"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters ads by status.",
+                        "type": "text/plain"
+                      },
+                      "key": "ad_status",
+                      "value": "enabled"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by ad type.",
+                        "type": "text/plain"
+                      },
+                      "key": "ad_type",
+                      "value": "banner"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Filters by targeting type.",
+                        "type": "text/plain"
+                      },
+                      "key": "targeting_type",
+                      "value": "category"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, includes paused ads.",
+                        "type": "text/plain"
+                      },
+                      "key": "show_inactive",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, includes detailed account information in the result.",
+                        "type": "text/plain"
+                      },
+                      "key": "account_info",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page. When `download=true`, the BFF requests up to `20000` rows for XLSX generation.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns the total number of available records.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "income"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "desc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, returns an XLSX file buffer for download instead of JSON.",
+                        "type": "text/plain"
+                      },
+                      "key": "download",
+                      "value": "false"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
             }
           ],
           "event": [
             {
               "listen": "test",
               "script": {
-                "id": "b97d193a-4569-4d11-b0f1-321386c25176",
+                "id": "e267e8fe-0fc3-4805-ada1-92d3dc912ba1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/ad/results/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6715,7 +8132,7 @@
       "event": []
     },
     {
-      "id": "0d4ca497-5752-4aa9-9fe3-6869b30475c1",
+      "id": "a22c3088-a212-4587-bea6-a354edc767f5",
       "name": "Credit transfer",
       "description": {
         "content": "",
@@ -6723,7 +8140,7 @@
       },
       "item": [
         {
-          "id": "9865cd77-9ac2-4cb9-aae0-22aefcfd0270",
+          "id": "9c05b688-f90a-450f-95e5-c147bddb64dd",
           "name": "Notify credit transfer status",
           "request": {
             "name": "Notify credit transfer status",
@@ -6816,7 +8233,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1bb17990-20c2-4499-9b29-6db66f07d768",
+              "id": "b93af77e-8b91-498e-861a-ab0064df6768",
               "name": "No Content\n\nNotification accepted.",
               "originalRequest": {
                 "url": {
@@ -6885,7 +8302,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d48b5539-d88c-4f55-8bb3-45167de6c805",
+              "id": "33793f3b-371e-48da-8780-95648a8e4d38",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6955,7 +8372,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2b193b76-ec00-497e-9e5c-9cb5b804bbec",
+                "id": "13d67458-fcef-470d-8f83-fd89c822678c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/webhook/marketplace/transfers/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6972,7 +8389,7 @@
       "event": []
     },
     {
-      "id": "14973168-37ad-45ab-bbca-81467cfd5f46",
+      "id": "88dd4120-d3c0-4557-806b-690f4aac412f",
       "name": "Single sign-on",
       "description": {
         "content": "",
@@ -6980,7 +8397,7 @@
       },
       "item": [
         {
-          "id": "c756bab2-e562-4bbb-92cf-9932326b6d92",
+          "id": "7cb36245-270a-49da-8537-ae125eabc49d",
           "name": "Generate seller single sign-on URL",
           "request": {
             "name": "Generate seller single sign-on URL",
@@ -7044,7 +8461,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "278ba1a9-ac8f-48de-a2a3-ffcf7ddbe66b",
+              "id": "aad92753-0ce4-4974-b882-ded48f47f507",
               "name": "OK\n\nRedirect URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -7121,7 +8538,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "44014e1c-7b2d-4b5f-b453-5f6186c6a330",
+              "id": "b0ccbad9-1685-4d82-bd7e-46c032ff4113",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -7189,7 +8606,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "84ddc5ec-8ca7-4df2-a1d6-86f15adeeed7",
+                "id": "69b603bd-cbca-4651-bd07-ed2573ed28de",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/sso/marketplace - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7237,7 +8654,7 @@
     }
   ],
   "info": {
-    "_postman_id": "0eb8b10b-41b2-48cc-9715-67164d40d51b",
+    "_postman_id": "d28f70c2-2e9e-47a9-aab2-3dafc4fc08f3",
     "name": "VTEX Ads API",
     "version": {
       "raw": "1.0.0",
@@ -7250,7 +8667,7 @@
     },
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {
-      "content": "VTEX Ads API enables merchants and marketplace operators to synchronize product catalogs, display ads in the storefront, record ad interactions, among other operations within the VTEX Ads platform.\n\nThis API is primarily used by:\n- Store developers\n- Marketplace operators\n- Integration partners\n- Advertising platform providers\n\nWith this API you can:\n- Synchronize product catalog information for advertising\n- Track ad impressions, clicks, and views\n- Monitor conversion events and campaign performance\n- Manage ad inventory and placements\n\n>ℹ️ Learn more about [VTEX Ads](https://help.vtex.com/en/docs/tracks/retail-media).\n\n## Architecture\n\nVTEX Ads is **cookie-less**. Identification and targeting rely on first-party identifiers — `user_id` and `session_id` — rather than third-party cookies, ensuring compliance with modern privacy regulations.\n\n- **`session_id`:** Persistent visitor identifier, required in every ad query and event. It must remain stable for at least 14 days (the default conversion window). For mobile applications, send the device ID as the `session_id` (GAID on Android, IDFA on iOS) so that the session is maintained indefinitely.\n- **`user_id`:** Unique customer identifier on the publisher's platform. It must be consistent across web, mobile app, and physical store. Required in conversion events; recommended for impressions, clicks, and views.\n\n## Before you begin\n\n- **Base URLs.** The API is served from three hosts depending on the operation:\n    - `https://api-retail-media.newtail.com.br` — Catalog synchronization, Reports, Credit transfer webhook, and SSO.\n    - `https://newtail-media.newtail.com.br` — Ad query.\n    - `https://events.newtail-media.newtail.com.br` — Ads events notification (impression, click, view, conversion).\n- **Authentication.** Catalog synchronization, Reports, and SSO endpoints require the `X-App-Id` and `X-Api-Key` headers. Ad query and ads event notifications are public and do not require authentication. The Credit transfer webhook uses a different scheme: `X-Api-Key` and `X-Secret-Key` (it does not use `X-App-Id`). Contact [our support](https://help.vtex.com/en/tutorial/how-does-vtex-support-work--2eAT5EyOvaLoHdIWDVaxC3) to obtain credentials.\n- **Bulk operations.** A maximum of 500 objects per request and 3 simultaneous requests are allowed for catalog and inventory updates.\n- **Event URLs.** The event URLs for tracking impressions, clicks, and views must not be constructed manually — always use the URLs returned by `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\n- **Browser-side events.** Use `navigator.sendBeacon()` to fire impression, view, click, and conversion events from the browser. It ensures asynchronous delivery even when the user navigates away or closes the page.\n- **PII hashing.** All personally identifiable fields (`email_hashed`, `phone_hashed`, `social_id_hashed`, `first_name_hashed`, `last_name_hashed`) must be hashed with SHA-256 before being sent. Normalize values first (lowercase and trim; phone numbers in E.164 format).\n- **Reports export.** Reports return JSON by default. Set `download=true` to receive an XLSX file (capped at 20,000 rows per export).\n- **Ad query performance.** Apply a 500-600 ms timeout to ad query calls and prefer persistent HTTP connections (`Connection: keep-alive`).\n\n## Attribution and deduplication\n\n- **Default conversion window:** 14 days from the user's interaction (click for product campaigns; view for banner, video, and sponsored brand campaigns).\n- **Conversion idempotency:** Re-sending the same `order_id` within 30 days is ignored.\n- **Event deduplication:** For the same user and ad, impressions are deduplicated for 1 minute and clicks for 1 hour.\n- **Data latency:** Conversions appear in reports approximately 30 minutes (API integrations) or up to 2 hours (VTEX platform) after the order is placed.\n\n| Parameter name | Description | Type |\n| - | - | - |\n| `X-App-Id` | Publisher App ID for authorization | Authentication header |\n| `X-Api-Key` | API Key for authentication | Authentication header |\n| `X-Secret-Key` | Secret key paired with `X-Api-Key` for the credit transfer webhook | Authentication header |\n| `Content-Type` | Type of the content being sent | Request header |\n| `Accept` | HTTP Client Negotiation Accept Header | Request header |",
+      "content": "VTEX Ads API enables merchants and marketplace operators to synchronize product catalogs, display ads in the storefront, record ad interactions, among other operations within the VTEX Ads platform.\n\nThis API is primarily used by:\n- Store developers\n- Marketplace operators\n- Integration partners\n- Advertising platform providers\n\nWith this API you can:\n- Synchronize product catalog information for advertising\n- Track ad impressions, clicks, and views\n- Monitor conversion events and campaign performance\n- Manage ad inventory and placements\n\n>ℹ️ Learn more about [VTEX Ads](https://help.vtex.com/en/docs/tracks/retail-media).\n\n## Architecture\n\nVTEX Ads is **cookie-less**. Identification and targeting rely on first-party identifiers — `user_id` and `session_id` — rather than third-party cookies, ensuring compliance with modern privacy regulations.\n\n- **`session_id`:** Persistent visitor identifier, required in every ad query and event. It must remain stable for at least 14 days (the default conversion window). For mobile applications, send the device ID as the `session_id` (GAID on Android, IDFA on iOS) so that the session is maintained indefinitely.\n- **`user_id`:** Unique customer identifier on the publisher's platform. It must be consistent across web, mobile app, and physical store. Required in conversion events; recommended for impressions, clicks, and views.\n\n## Before you begin\n\n- **Base URLs.** The API is served from three hosts depending on the operation:\n    - `https://api-retail-media.newtail.com.br` — Catalog synchronization, Reports, Credit transfer webhook, and SSO.\n    - `https://newtail-media.newtail.com.br` — Ad query.\n    - `https://events.newtail-media.newtail.com.br` — Ads events notification (impression, click, view, conversion).\n- **Authentication.** Catalog synchronization, Reports, and SSO endpoints require the `X-App-Id` and `X-Api-Key` headers. Ad query and ads event notifications are public and do not require authentication. The Credit transfer webhook uses a different scheme: `X-Api-Key` and `X-Secret-Key` (it does not use `X-App-Id`). Contact [our support](https://help.vtex.com/en/tutorial/how-does-vtex-support-work--2eAT5EyOvaLoHdIWDVaxC3) to obtain credentials.\n- **Bulk operations.** A maximum of 500 objects per request and 3 simultaneous requests are allowed for catalog and inventory updates.\n- **Event URLs.** The event URLs for tracking impressions, clicks, and views must not be constructed manually — always use the URLs returned by `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\n- **Browser-side events.** Use `navigator.sendBeacon()` to fire impression, view, click, and conversion events from the browser. It ensures asynchronous delivery even when the user navigates away or closes the page.\n- **PII hashing.** All personally identifiable fields (`email_hashed`, `phone_hashed`, `social_id_hashed`, `first_name_hashed`, `last_name_hashed`) must be hashed with SHA-256 before being sent. Normalize values first (lowercase and trim; phone numbers in E.164 format).\n- **Reports export.** Reports return JSON by default. Set `download=true` to receive an XLSX file (capped at 20,000 rows per export).\n- **Rate limits.** Reports endpoints are limited to 100 requests per minute per account. This limit applies only to API Key-authenticated calls and does not affect normal platform use through the UI. Requests that exceed the limit receive `429 Too Many Requests` with \"Rate limit exceeded for this account\". Wait for the next window before retrying, and spread large export workloads over time. Contact [our support](https://help.vtex.com/en/tutorial/how-does-vtex-support-work--2eAT5EyOvaLoHdIWDVaxC3) if your integration needs a higher volume.\n- **Ad query performance.** Apply a 500-600 ms timeout to ad query calls and prefer persistent HTTP connections (`Connection: keep-alive`).\n\n## Attribution and deduplication\n\n- **Default conversion window:** 14 days from the user's interaction (click for product campaigns; view for banner, video, and sponsored brand campaigns).\n- **Conversion idempotency:** Re-sending the same `order_id` within 30 days is ignored.\n- **Event deduplication:** For the same user and ad, impressions are deduplicated for 1 minute and clicks for 1 hour.\n- **Data latency:** Conversions appear in reports approximately 30 minutes (API integrations) or up to 2 hours (VTEX platform) after the order is placed.\n\n| Parameter name | Description | Type |\n| - | - | - |\n| `X-App-Id` | Publisher App ID for authorization | Authentication header |\n| `X-Api-Key` | API Key for authentication | Authentication header |\n| `X-Secret-Key` | Secret key paired with `X-Api-Key` for the credit transfer webhook | Authentication header |\n| `Content-Type` | Type of the content being sent | Request header |\n| `Accept` | HTTP Client Negotiation Accept Header | Request header |",
       "type": "text/plain"
     }
   }

--- a/VTEX - Ads API.json
+++ b/VTEX - Ads API.json
@@ -3,7 +3,7 @@
     "info": {
         "version": "1.0.0",
         "title": "VTEX Ads API",
-        "description": "VTEX Ads API enables merchants and marketplace operators to synchronize product catalogs, display ads in the storefront, record ad interactions, among other operations within the VTEX Ads platform.\n\nThis API is primarily used by:\n- Store developers\n- Marketplace operators\n- Integration partners\n- Advertising platform providers\n\nWith this API you can:\n- Synchronize product catalog information for advertising\n- Track ad impressions, clicks, and views\n- Monitor conversion events and campaign performance\n- Manage ad inventory and placements\n\n>ℹ️ Learn more about [VTEX Ads](https://help.vtex.com/en/docs/tracks/retail-media).\n\n## Architecture\n\nVTEX Ads is **cookie-less**. Identification and targeting rely on first-party identifiers — `user_id` and `session_id` — rather than third-party cookies, ensuring compliance with modern privacy regulations.\n\n- **`session_id`:** Persistent visitor identifier, required in every ad query and event. It must remain stable for at least 14 days (the default conversion window). For mobile applications, send the device ID as the `session_id` (GAID on Android, IDFA on iOS) so that the session is maintained indefinitely.\n- **`user_id`:** Unique customer identifier on the publisher's platform. It must be consistent across web, mobile app, and physical store. Required in conversion events; recommended for impressions, clicks, and views.\n\n## Before you begin\n\n- **Base URLs.** The API is served from three hosts depending on the operation:\n    - `https://api-retail-media.newtail.com.br` — Catalog synchronization, Reports, Credit transfer webhook, and SSO.\n    - `https://newtail-media.newtail.com.br` — Ad query.\n    - `https://events.newtail-media.newtail.com.br` — Ads events notification (impression, click, view, conversion).\n- **Authentication.** Catalog synchronization, Reports, and SSO endpoints require the `X-App-Id` and `X-Api-Key` headers. Ad query and ads event notifications are public and do not require authentication. The Credit transfer webhook uses a different scheme: `X-Api-Key` and `X-Secret-Key` (it does not use `X-App-Id`). Contact [our support](https://help.vtex.com/en/tutorial/how-does-vtex-support-work--2eAT5EyOvaLoHdIWDVaxC3) to obtain credentials.\n- **Bulk operations.** A maximum of 500 objects per request and 3 simultaneous requests are allowed for catalog and inventory updates.\n- **Event URLs.** The event URLs for tracking impressions, clicks, and views must not be constructed manually — always use the URLs returned by `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\n- **Browser-side events.** Use `navigator.sendBeacon()` to fire impression, view, click, and conversion events from the browser. It ensures asynchronous delivery even when the user navigates away or closes the page.\n- **PII hashing.** All personally identifiable fields (`email_hashed`, `phone_hashed`, `social_id_hashed`, `first_name_hashed`, `last_name_hashed`) must be hashed with SHA-256 before being sent. Normalize values first (lowercase and trim; phone numbers in E.164 format).\n- **Reports export.** Reports return JSON by default. Set `download=true` to receive an XLSX file (capped at 20,000 rows per export).\n- **Ad query performance.** Apply a 500-600 ms timeout to ad query calls and prefer persistent HTTP connections (`Connection: keep-alive`).\n\n## Attribution and deduplication\n\n- **Default conversion window:** 14 days from the user's interaction (click for product campaigns; view for banner, video, and sponsored brand campaigns).\n- **Conversion idempotency:** Re-sending the same `order_id` within 30 days is ignored.\n- **Event deduplication:** For the same user and ad, impressions are deduplicated for 1 minute and clicks for 1 hour.\n- **Data latency:** Conversions appear in reports approximately 30 minutes (API integrations) or up to 2 hours (VTEX platform) after the order is placed.\n\n| Parameter name | Description | Type |\n| - | - | - |\n| `X-App-Id` | Publisher App ID for authorization | Authentication header |\n| `X-Api-Key` | API Key for authentication | Authentication header |\n| `X-Secret-Key` | Secret key paired with `X-Api-Key` for the credit transfer webhook | Authentication header |\n| `Content-Type` | Type of the content being sent | Request header |\n| `Accept` | HTTP Client Negotiation Accept Header | Request header |"
+        "description": "VTEX Ads API enables merchants and marketplace operators to synchronize product catalogs, display ads in the storefront, record ad interactions, among other operations within the VTEX Ads platform.\n\nThis API is primarily used by:\n- Store developers\n- Marketplace operators\n- Integration partners\n- Advertising platform providers\n\nWith this API you can:\n- Synchronize product catalog information for advertising\n- Track ad impressions, clicks, and views\n- Monitor conversion events and campaign performance\n- Manage ad inventory and placements\n\n>ℹ️ Learn more about [VTEX Ads](https://help.vtex.com/en/docs/tracks/retail-media).\n\n## Architecture\n\nVTEX Ads is **cookie-less**. Identification and targeting rely on first-party identifiers — `user_id` and `session_id` — rather than third-party cookies, ensuring compliance with modern privacy regulations.\n\n- **`session_id`:** Persistent visitor identifier, required in every ad query and event. It must remain stable for at least 14 days (the default conversion window). For mobile applications, send the device ID as the `session_id` (GAID on Android, IDFA on iOS) so that the session is maintained indefinitely.\n- **`user_id`:** Unique customer identifier on the publisher's platform. It must be consistent across web, mobile app, and physical store. Required in conversion events; recommended for impressions, clicks, and views.\n\n## Before you begin\n\n- **Base URLs.** The API is served from three hosts depending on the operation:\n    - `https://api-retail-media.newtail.com.br` — Catalog synchronization, Reports, Credit transfer webhook, and SSO.\n    - `https://newtail-media.newtail.com.br` — Ad query.\n    - `https://events.newtail-media.newtail.com.br` — Ads events notification (impression, click, view, conversion).\n- **Authentication.** Catalog synchronization, Reports, and SSO endpoints require the `X-App-Id` and `X-Api-Key` headers. Ad query and ads event notifications are public and do not require authentication. The Credit transfer webhook uses a different scheme: `X-Api-Key` and `X-Secret-Key` (it does not use `X-App-Id`). Contact [our support](https://help.vtex.com/en/tutorial/how-does-vtex-support-work--2eAT5EyOvaLoHdIWDVaxC3) to obtain credentials.\n- **Bulk operations.** A maximum of 500 objects per request and 3 simultaneous requests are allowed for catalog and inventory updates.\n- **Event URLs.** The event URLs for tracking impressions, clicks, and views must not be constructed manually — always use the URLs returned by `POST` [Get ads](https://developers.vtex.com/docs/api-reference/vtex-ads-api#post-/v1/rma/-publisher_id-).\n- **Browser-side events.** Use `navigator.sendBeacon()` to fire impression, view, click, and conversion events from the browser. It ensures asynchronous delivery even when the user navigates away or closes the page.\n- **PII hashing.** All personally identifiable fields (`email_hashed`, `phone_hashed`, `social_id_hashed`, `first_name_hashed`, `last_name_hashed`) must be hashed with SHA-256 before being sent. Normalize values first (lowercase and trim; phone numbers in E.164 format).\n- **Reports export.** Reports return JSON by default. Set `download=true` to receive an XLSX file (capped at 20,000 rows per export).\n- **Rate limits.** Reports endpoints are limited to 100 requests per minute per account. This limit applies only to API Key-authenticated calls and does not affect normal platform use through the UI. Requests that exceed the limit receive `429 Too Many Requests` with \"Rate limit exceeded for this account\". Wait for the next window before retrying, and spread large export workloads over time. Contact [our support](https://help.vtex.com/en/tutorial/how-does-vtex-support-work--2eAT5EyOvaLoHdIWDVaxC3) if your integration needs a higher volume.\n- **Ad query performance.** Apply a 500-600 ms timeout to ad query calls and prefer persistent HTTP connections (`Connection: keep-alive`).\n\n## Attribution and deduplication\n\n- **Default conversion window:** 14 days from the user's interaction (click for product campaigns; view for banner, video, and sponsored brand campaigns).\n- **Conversion idempotency:** Re-sending the same `order_id` within 30 days is ignored.\n- **Event deduplication:** For the same user and ad, impressions are deduplicated for 1 minute and clicks for 1 hour.\n- **Data latency:** Conversions appear in reports approximately 30 minutes (API integrations) or up to 2 hours (VTEX platform) after the order is placed.\n\n| Parameter name | Description | Type |\n| - | - | - |\n| `X-App-Id` | Publisher App ID for authorization | Authentication header |\n| `X-Api-Key` | API Key for authentication | Authentication header |\n| `X-Secret-Key` | Secret key paired with `X-Api-Key` for the credit transfer webhook | Authentication header |\n| `Content-Type` | Type of the content being sent | Request header |\n| `Accept` | HTTP Client Negotiation Accept Header | Request header |"
     },
     "servers": [
         {
@@ -1376,7 +1376,7 @@
                     "Reports"
                 ],
                 "summary": "Get advertisers report",
-                "description": "Retrieves information from all advertisers associated with a publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the publisher view (publisher account).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Retrieves information from all advertisers associated with a publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the publisher view (publisher account).\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -1634,6 +1634,16 @@
                     },
                     "401": {
                         "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1650,7 +1660,7 @@
                     "Reports"
                 ],
                 "summary": "Get publishers report",
-                "description": "Retrieves information about the publishers associated with an advertiser account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the advertiser view (advertiser account).\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Retrieves information about the publishers associated with an advertiser account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only available in the advertiser view (advertiser account).\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -1924,6 +1934,16 @@
                     },
                     "401": {
                         "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1940,7 +1960,7 @@
                     "Reports"
                 ],
                 "summary": "Get network publishers report",
-                "description": "Retrieves information about publishers associated with a Network Publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only publishers operating in the Network format are allowed to access this report.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Retrieves information about publishers associated with a Network Publisher account. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Only publishers operating in the Network format are allowed to access this report.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -2196,6 +2216,16 @@
                     },
                     "401": {
                         "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2212,7 +2242,7 @@
                     "Reports"
                 ],
                 "summary": "List campaigns",
-                "description": "Fetches all available campaigns, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Fetches all available campaigns, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -2715,6 +2745,16 @@
                     },
                     "401": {
                         "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2731,7 +2771,7 @@
                     "Reports"
                 ],
                 "summary": "Get campaign details",
-                "description": "Retrieves detailed information about a campaign, such as the products associated with the campaign, status history, ads, and metrics. The data is returned only in JSON format.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Retrieves detailed information about a campaign, such as the products associated with the campaign, status history, ads, and metrics. The data is returned only in JSON format.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -3323,6 +3363,16 @@
                     },
                     "404": {
                         "description": "Not Found\n\nCampaign not found."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3339,7 +3389,7 @@
                     "Reports"
                 ],
                 "summary": "Get advertiser campaigns detailed report",
-                "description": "Exports a mixed campaign report for advertiser accounts, including both regular campaigns and subpublisher information for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Exports a mixed campaign report for advertiser accounts, including both regular campaigns and subpublisher information for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -3803,6 +3853,16 @@
                     },
                     "401": {
                         "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3819,7 +3879,7 @@
                     "Reports"
                 ],
                 "summary": "Get advertiser ads detailed report",
-                "description": "Exports a detailed ad report for advertiser accounts, including subpublisher breakdown for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. Non-network campaigns return one row per ad, while network campaigns return one row per `ad + subpublisher`. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Exports a detailed ad report for advertiser accounts, including subpublisher breakdown for network campaigns. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ This route is intended for advertiser accounts. Non-network campaigns return one row per ad, while network campaigns return one row per `ad + subpublisher`. For non white-label accounts, only non-private publisher rows are returned.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -4254,6 +4314,16 @@
                     },
                     "401": {
                         "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -4270,7 +4340,7 @@
                     "Reports"
                 ],
                 "summary": "Get ads performance report",
-                "description": "Fetches all available ads, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Paused ads are excluded from the default response. To include paused ads, set `show_inactive=true`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Fetches all available ads, applying filters as needed. The data is returned in JSON format by default, but can be exported as an XLSX file by setting `download=true`.\r\n\r\n>ℹ️ Paused ads are excluded from the default response. To include paused ads, set `show_inactive=true`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Content-Type"
@@ -4859,6 +4929,16 @@
                     },
                     "401": {
                         "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nRate limit exceeded. Reports endpoints are limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Documents the 100 requests per minute per account rate limit for VTEX Ads Reports endpoints in the OpenAPI schema.

## Changes

- Add a **Rate limits** section to the API overview describing the limit, scope (API Key-authenticated calls only), and retry guidance
- Add rate limit callout warnings to all Reports endpoint descriptions
- Add `429 Too Many Requests` response schemas with example error payload to all Reports endpoints

## Related Task

[EDU-19136](https://vtex-dev.atlassian.net/browse/EDU-19136)


[EDU-19136]: https://vtex-dev.atlassian.net/browse/EDU-19136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ