### PR TITLE
Remove Description from specification translation

### DIFF
--- a/PostmanCollections/VTEX - Catalog API.json
+++ b/PostmanCollections/VTEX - Catalog API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "6a4d6e50-11af-4db4-b939-ac4ad681926d"
+    "postman_id": "82e5b7cf-e13e-4881-8ff3-a854ee80fa7b"
   },
   "item": [
     {
-      "id": "972bdbef-e20f-47d9-866e-f02febb65eb3",
+      "id": "e1008a21-bc04-4927-8bd1-61963f191109",
       "name": "SKU service",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "15ada9c2-86cc-488e-9c43-68ce234037f4",
+          "id": "34c48b28-f1c2-4fce-9ee8-3bc5e2bb70ae",
           "name": "Get SKU service",
           "request": {
             "name": "Get SKU service",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "00270efc-9835-4960-bb53-c7324bd37d5b",
+              "id": "40a0ee86-8fac-495b-a09a-9f4869a6bd26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -145,7 +145,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3e785840-c9a9-4f24-bd79-5c7aa1875ab2",
+                "id": "699c3cb5-abbf-4b00-9ac7-812d0246ea19",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -161,7 +161,7 @@
           }
         },
         {
-          "id": "d7ed45ab-78c7-4e16-838a-9cbfd17cd71f",
+          "id": "ea5c5a88-d07b-4d2a-ab30-04d4f5a9c64b",
           "name": "Update SKU service",
           "request": {
             "name": "Update SKU service",
@@ -239,7 +239,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d1d172dc-13c6-46b7-955c-fb9d48cead37",
+              "id": "bb27a46f-16e0-4de0-82cb-567790aa6cbc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -320,7 +320,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0ff6ff18-e2b5-4270-bf7e-5ad266c75701",
+                "id": "d60801b4-53ef-4625-8fd2-9dee72f7b69b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -336,7 +336,7 @@
           }
         },
         {
-          "id": "1826b775-b92f-4ef1-aa2a-8fb13c2c57cd",
+          "id": "ccd106d7-749e-476f-ba3c-777304f83080",
           "name": "Dissociate SKU service",
           "request": {
             "name": "Dissociate SKU service",
@@ -397,7 +397,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7aa9ad97-304a-451d-bf74-fadb1ee4e565",
+              "id": "ea25c3d5-9bf2-4244-879d-537d73e958ff",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -455,7 +455,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5f5c564c-29d3-44de-a11a-c7ff8fd1672f",
+                "id": "f9224928-3aa8-4863-829a-b5c05b2bdc14",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -468,7 +468,7 @@
           }
         },
         {
-          "id": "3dddd4c0-5d51-45cd-b522-17561e89022c",
+          "id": "a12c80db-76af-41d1-8ac8-bf760692e88a",
           "name": "Associate SKU service",
           "request": {
             "name": "Associate SKU service",
@@ -534,7 +534,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "05f51648-843c-4118-a4f6-e7010fb2a555",
+              "id": "08bda5d8-07ff-4fca-b44c-d3ae95dfa6d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -614,7 +614,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5bec9ed9-1ab1-4c48-8c04-6d1486578a5e",
+                "id": "ee853710-c33d-4aee-9b7e-820f63174cc1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservice - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -633,7 +633,7 @@
       "event": []
     },
     {
-      "id": "da9ddcbb-dbd1-4db9-937d-aa160dc91258",
+      "id": "f591b1a8-839f-4440-97b5-573fd63724c5",
       "name": "SKU service attachment",
       "description": {
         "content": "",
@@ -641,7 +641,7 @@
       },
       "item": [
         {
-          "id": "d7d3ef28-6723-4cc1-bcf3-06c9e1daa782",
+          "id": "e4a9a6f0-560c-4dec-a76c-9ceac0b24f14",
           "name": "Associate SKU service attachment",
           "request": {
             "name": "Associate SKU service attachment",
@@ -707,7 +707,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7117b87e-0dea-4e06-aefb-3cffc7667c4b",
+              "id": "340f8906-3fa6-4c59-aff3-fbcebd787164",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -787,7 +787,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1e1a7223-dc91-46aa-ad59-354799bcf9b5",
+                "id": "7a150656-707b-4c65-9b42-5fdc7435bc79",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicetypeattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -803,7 +803,7 @@
           }
         },
         {
-          "id": "32f42b3f-fa32-4ad2-b4ed-a4ada3a0abd5",
+          "id": "b9292fc5-9af6-47f7-a0f3-b8d408038023",
           "name": "Dissociate attachment by attachment ID or SKU service type ID",
           "request": {
             "name": "Dissociate attachment by attachment ID or SKU service type ID",
@@ -871,7 +871,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8f44febc-d419-4bb3-b26e-b2e30cb8a41b",
+              "id": "b28d2ec5-d6ff-49fe-85ab-4a4786fe2f73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -947,7 +947,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3d5d3dd0-9921-41c8-b319-cbee45e27dab",
+                "id": "2860fa95-a5a4-4829-9f2c-daf8159bff19",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetypeattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -960,7 +960,7 @@
           }
         },
         {
-          "id": "b74f4d29-b640-495b-9e2e-79153da92ab1",
+          "id": "1d4ffab1-cd2a-4303-b985-e4d916e27592",
           "name": "Dissociate attachment from SKU service type",
           "request": {
             "name": "Dissociate attachment from SKU service type",
@@ -1021,7 +1021,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "76e38706-25e6-4320-8009-911343e3433e",
+              "id": "7a3e4c6e-ecb5-4f05-b0c3-4443bffe469b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1079,7 +1079,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eb3a9441-d6d4-4118-868f-7dadc37e04a4",
+                "id": "9e1d26ed-c2d2-49cd-82b2-de64865b0462",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetypeattachment/:skuServiceTypeAttachmentId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1095,7 +1095,7 @@
       "event": []
     },
     {
-      "id": "695821da-f48b-4ffc-b3b4-b0c6c844cf75",
+      "id": "d386a583-75aa-4327-a58a-251a3f47fa4d",
       "name": "SKU service value",
       "description": {
         "content": "",
@@ -1103,7 +1103,7 @@
       },
       "item": [
         {
-          "id": "274e319f-bd99-4256-8416-649c282e7273",
+          "id": "7e5b97b7-00e8-4e41-8b89-27746e5fc456",
           "name": "Create SKU service value",
           "request": {
             "name": "Create SKU service value",
@@ -1169,7 +1169,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f9259caa-2d8a-491f-9cf1-e27d6d292c24",
+              "id": "49aa0fff-f3fd-4d07-bd5e-927b8835e2a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1249,7 +1249,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6b0a3296-24a4-47f2-8b55-32031b959077",
+                "id": "0ae28f28-2fa0-4ff1-97b4-2d517a343cf4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicevalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1265,7 +1265,7 @@
           }
         },
         {
-          "id": "2f9e6610-fd25-449d-aef6-455d20448f90",
+          "id": "1dcccdfe-25de-4995-8e7b-12b638ccad4f",
           "name": "Get SKU service value",
           "request": {
             "name": "Get SKU service value",
@@ -1330,7 +1330,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9f70f2ee-d152-4660-818f-6fec7679cf66",
+              "id": "1f34bf69-65c0-4767-8c36-eb7ea5fb8095",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1398,7 +1398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1c8e4f47-5361-4cd1-838c-f88785dee193",
+                "id": "8e11955c-3d55-4d6f-aa1b-857263c5989d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1414,7 +1414,7 @@
           }
         },
         {
-          "id": "7e248e4f-0c74-4ed9-b826-0a1663ad8125",
+          "id": "a0e8893a-69a9-4b30-9b4b-bb55768d84d5",
           "name": "Update SKU service value",
           "request": {
             "name": "Update SKU service value",
@@ -1492,7 +1492,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bf28dee9-0fd4-4622-9350-94c90a2f1a8b",
+              "id": "ed514723-d9ef-46eb-a7dd-e003618331ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1573,7 +1573,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d5050534-e2ce-4460-949d-ee8afdf01e19",
+                "id": "accd0467-20e9-4790-94a6-d5aa1dfa2561",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1589,7 +1589,7 @@
           }
         },
         {
-          "id": "acc115ea-1e2c-42f1-8e5d-c7de3a48ad1f",
+          "id": "6411c135-1bb5-4d7a-b22e-09208a5e127f",
           "name": "Delete SKU service value",
           "request": {
             "name": "Delete SKU service value",
@@ -1650,7 +1650,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ac828036-86d0-4c1b-a749-d4b13d1dc718",
+              "id": "4c833a57-44ad-4b23-828f-5167910dc8f8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1708,7 +1708,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d0fbc391-71b0-4ca8-b1c4-6170c81a3797",
+                "id": "ed0c9c7d-c214-4df0-afca-c92833bb5e64",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1724,7 +1724,7 @@
       "event": []
     },
     {
-      "id": "86c7e9cd-badc-4466-aa69-f793c7cd4cd5",
+      "id": "e3a51c8e-6d8f-424e-b08b-8183147af5ac",
       "name": "SKU service type",
       "description": {
         "content": "",
@@ -1732,7 +1732,7 @@
       },
       "item": [
         {
-          "id": "159df798-4904-4732-991d-a23d7ac07546",
+          "id": "5bcb1c01-db11-475a-b29a-e4a95bb97496",
           "name": "Create SKU service type",
           "request": {
             "name": "Create SKU service type",
@@ -1798,7 +1798,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "289c8652-964e-4da3-8c87-fa510034858b",
+              "id": "c65e2722-c6bc-4151-a706-8db9c5207b77",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1878,7 +1878,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4f4d2fec-4c2d-4a29-8b39-e75ff6518d42",
+                "id": "2591b159-02ca-476b-a0c0-96b4fc2b326a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicetype - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1894,7 +1894,7 @@
           }
         },
         {
-          "id": "80451c22-7324-45cb-8087-9bb1df4dda9e",
+          "id": "6eec43ff-7622-48fa-80fb-7c8bfaf13b05",
           "name": "Get SKU service type",
           "request": {
             "name": "Get SKU service type",
@@ -1959,7 +1959,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2c876f7e-7c45-4486-bcb9-7d937e6c1224",
+              "id": "903baf3c-e0bb-4d86-b194-08b138e247db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2027,7 +2027,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7ba5bb0b-1569-45ef-a84e-42c4ea901aac",
+                "id": "13abe5f5-4f17-44ab-9557-e79c98f54887",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2043,7 +2043,7 @@
           }
         },
         {
-          "id": "f06748a8-85f5-4e72-aa22-94cb21f3d037",
+          "id": "00bc0edc-241e-4aba-a251-3a2f53af07ba",
           "name": "Update SKU service type",
           "request": {
             "name": "Update SKU service type",
@@ -2121,7 +2121,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5b29ffe7-ad6b-42c6-a708-739779097ea6",
+              "id": "3f039737-2f83-4e28-9e05-75ac1b25ec0d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2202,7 +2202,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0476cb22-e227-4701-a3db-87807b58954a",
+                "id": "95ae3272-5b18-4b4f-9972-dbf6ff8bbb67",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2218,7 +2218,7 @@
           }
         },
         {
-          "id": "d489e835-1b01-425f-b73c-2b3b5822d39f",
+          "id": "6504ef02-c818-4e6b-a3b7-2e57e7d5dea8",
           "name": "Delete SKU service type",
           "request": {
             "name": "Delete SKU service type",
@@ -2279,7 +2279,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "138aefc9-995c-46a5-abcd-09686f68bee5",
+              "id": "c3b50a24-c37a-48eb-9366-2853c2860643",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2337,7 +2337,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "87e73617-0bf1-4396-b456-8d52df5a048d",
+                "id": "c527cd2c-fcdf-4bbd-b807-644a92bd8d11",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2353,7 +2353,7 @@
       "event": []
     },
     {
-      "id": "f47ca651-a45b-4777-b0cf-2547442d7ebc",
+      "id": "fb54e575-bc02-44d1-8477-8e8c3ce56f01",
       "name": "Category",
       "description": {
         "content": "",
@@ -2361,7 +2361,7 @@
       },
       "item": [
         {
-          "id": "81b92c66-08b9-4d51-8804-cd26a91efb2b",
+          "id": "075a0745-f035-4859-b3e7-4509d52ab010",
           "name": "Get category tree",
           "request": {
             "name": "Get category tree",
@@ -2427,7 +2427,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "42134506-9e9c-4e96-a2c9-a14fbafb82d7",
+              "id": "29238de3-41e2-4a22-ac52-94cac05a3850",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2496,7 +2496,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "71a19237-fe56-454f-ba9f-633151dd408c",
+                "id": "52e3aef7-10fd-497d-b87f-45abce206dbf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/category/tree/:categoryLevels - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2512,7 +2512,7 @@
           }
         },
         {
-          "id": "7df87abe-04e8-4f82-ad02-2a89fcef4f84",
+          "id": "3dddf2d1-79db-495f-9247-7a90466c788c",
           "name": "Get category by ID",
           "request": {
             "name": "Get category by ID",
@@ -2587,7 +2587,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4401f074-efd3-4333-9725-bdef6c45cbb0",
+              "id": "f80428f8-b845-4f56-84a0-15812f1ef9e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2665,7 +2665,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4857c261-bdc4-4cf2-805b-20472fb256bd",
+                "id": "05884947-4f0d-4c8f-8280-40c778a2e459",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2681,7 +2681,7 @@
           }
         },
         {
-          "id": "aabafa59-df9d-4ccd-93c7-7ae1f625cffa",
+          "id": "bd83b1cd-dcbd-4f5c-bfa1-abbe477103d2",
           "name": "Update category",
           "request": {
             "name": "Update category",
@@ -2759,7 +2759,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7b64cc0a-9fe6-44ef-a420-f73f203bb44f",
+              "id": "ad3affab-71b9-4f17-95c6-48117ec337c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2840,7 +2840,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2fdc8d2c-bb85-4b9c-b681-9b74b95cf1af",
+                "id": "0b7d0b67-9b16-4458-b74f-2b17f694dfca",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2856,7 +2856,7 @@
           }
         },
         {
-          "id": "88bcec68-ad5b-472c-bad1-1b7eaef92f4b",
+          "id": "4a3ae9a5-8684-4df5-8f78-1d79818e9971",
           "name": "Create category",
           "request": {
             "name": "Create category",
@@ -2922,7 +2922,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "be4413b1-3782-4ac8-b454-0c087689141c",
+              "id": "8eef1840-8d2a-4ba4-8758-9550fe6883fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3002,7 +3002,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1949a818-6bd4-46bd-89f8-b1b947062c71",
+                "id": "861d5c73-799a-47c3-9307-ca6808f42ac8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/category - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3021,7 +3021,7 @@
       "event": []
     },
     {
-      "id": "d375c6d9-4e61-4092-852c-f13094c191ca",
+      "id": "c4b1e249-b3cf-48df-af22-30b6a14797e6",
       "name": "Brand",
       "description": {
         "content": "",
@@ -3029,7 +3029,7 @@
       },
       "item": [
         {
-          "id": "bf576e8f-ad7d-4129-9bd7-c8a12f0ee956",
+          "id": "03f3cfa1-b887-437f-b4c8-a42f910fa7ba",
           "name": "Get brand list",
           "request": {
             "name": "Get brand list",
@@ -3083,7 +3083,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a04a8c30-c9f0-4b9a-acfd-165513f83d73",
+              "id": "25a145d5-7e9c-4b40-9994-8cb9b30b2b43",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "244a2d41-89c5-4b60-ad1c-0359e80237a0",
+                "id": "39473602-bd6b-47e9-bed3-f5ebeeb75bb8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3167,7 +3167,7 @@
           }
         },
         {
-          "id": "ae560a93-5ae5-406e-9501-be30ea8c3d0c",
+          "id": "6db88c5b-78bc-4373-a0b1-80eb9b7b8af8",
           "name": "Get paginated brand list",
           "request": {
             "name": "Get paginated brand list",
@@ -3240,7 +3240,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "05c85812-fc4c-49be-98af-eea69ae5e623",
+              "id": "34c16dbe-b7b0-4fb3-93b9-55c7de66b3e8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3327,7 +3327,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "50c13f3f-def2-4749-b101-f0ef605fee1f",
+                "id": "3cfe9769-893a-4348-9693-b2e267d72d1f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/pagedlist - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3343,7 +3343,7 @@
           }
         },
         {
-          "id": "36ab7487-e2f4-44ce-953f-ca97f3156135",
+          "id": "828d6dfd-2119-4fbd-8a86-2cca463f5fd5",
           "name": "Get brand by ID",
           "request": {
             "name": "Get brand by ID",
@@ -3408,7 +3408,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "85a1bf2a-6466-4720-9bdf-3487ec67728b",
+              "id": "64ea31e1-35e5-496c-9c63-7fcc6c860ad6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3476,7 +3476,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "369c3715-4dd2-4323-a3e0-bc087a26d1e7",
+                "id": "8807225b-e151-48cf-a50c-98d8c649d64b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3492,7 +3492,7 @@
           }
         },
         {
-          "id": "d84ecc34-a675-4332-a53b-e166fc845ef2",
+          "id": "be267fb9-2c74-4015-8bc5-92c84660901b",
           "name": "Create brand",
           "request": {
             "name": "Create brand",
@@ -3558,7 +3558,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "43e2dadd-c506-454c-a1df-6dc73c99ac59",
+              "id": "8c6e1755-7bb3-465c-865a-0da81bf50539",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3638,7 +3638,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0b84bc7e-8394-4fe0-8a18-929ff255bb44",
+                "id": "84243fb5-d6bb-4e87-a1de-bbc08dac6313",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/brand - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3654,7 +3654,7 @@
           }
         },
         {
-          "id": "22c69621-df47-456c-94b1-a3f51450f3d1",
+          "id": "d3aa4c46-3c3c-4cae-9aa0-71b1a078ca89",
           "name": "Get brand and context",
           "request": {
             "name": "Get brand and context",
@@ -3719,7 +3719,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "61124873-85e3-4ac5-9663-a8afd6db211a",
+              "id": "b21a7852-a1ef-4b66-a5e4-0e7d70aafeb9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3787,7 +3787,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "50baf75e-1635-4065-836f-025ddcefb191",
+                "id": "de2d2d7d-aa5a-459e-9e37-582461d379db",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3803,7 +3803,7 @@
           }
         },
         {
-          "id": "1d65efca-82a9-495f-85cf-03bb8460bc55",
+          "id": "beaa8826-0e3a-42da-b47d-18fce5a6eb2c",
           "name": "Update brand",
           "request": {
             "name": "Update brand",
@@ -3881,7 +3881,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6c765ac4-db48-4c59-9454-51f484317563",
+              "id": "ace2982c-fa4d-4a27-b508-74bf82a9b2e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3962,7 +3962,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e8ff28dd-9d78-4953-b4f8-8653c5d9b981",
+                "id": "154f43c7-2a37-4505-9388-1660b2fc23fc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3978,7 +3978,7 @@
           }
         },
         {
-          "id": "ff19e59f-771c-457a-8dcc-63e5bbd177b4",
+          "id": "109c5382-bb7b-4da6-bd10-508af8ef12ae",
           "name": "Delete brand",
           "request": {
             "name": "Delete brand",
@@ -4039,7 +4039,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "98ece09b-1a30-4ac3-949c-0ec16d698619",
+              "id": "78b726a5-1f5a-48fa-aca8-40b0e83e59a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4097,7 +4097,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ffef5d60-cf12-42c9-9a6f-1147555c1468",
+                "id": "756ae5dc-a2b5-410f-b407-f1b6a503e555",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4113,7 +4113,7 @@
       "event": []
     },
     {
-      "id": "3f78446c-6ba4-4c64-8800-2a05cc9935c7",
+      "id": "0bf6a118-0d83-47d4-8dee-1fae35d9dd02",
       "name": "Attachment",
       "description": {
         "content": "",
@@ -4121,7 +4121,7 @@
       },
       "item": [
         {
-          "id": "7914120f-cc0d-4e2a-b246-7f2a8e15951c",
+          "id": "320c1be0-aa13-4eb6-8a93-f12eef4d7294",
           "name": "Get attachment by ID",
           "request": {
             "name": "Get attachment by ID",
@@ -4186,7 +4186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3c752ee2-a47e-462d-851b-48eda7f81ce3",
+              "id": "bf0ffc1b-3b1a-4f34-888f-c39bf44523a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4254,7 +4254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e74b46ce-a45a-4bc3-8062-63d1120fef29",
+                "id": "6f138a49-6b4d-4457-892b-82acb81b53e2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4270,7 +4270,7 @@
           }
         },
         {
-          "id": "aeb58952-9b18-4c13-a545-f6ddd4bc1b61",
+          "id": "ac1587df-1cd9-4a1b-93de-49f40488f535",
           "name": "Update attachment",
           "request": {
             "name": "Update attachment",
@@ -4348,7 +4348,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5d08cc4a-cb77-4974-a5ed-892709851f46",
+              "id": "95f005e0-ae9b-455d-82d2-18f69e68391d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4429,7 +4429,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "74a410ef-a152-417a-bc2f-4d890def156c",
+                "id": "83778db2-5563-4ba8-9535-5b79852feab1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4445,7 +4445,7 @@
           }
         },
         {
-          "id": "7c8007ce-6ea0-4bf1-a711-b630b5466492",
+          "id": "7856cc4b-0a4b-43f7-bdb3-099a9c32626d",
           "name": "Delete attachment",
           "request": {
             "name": "Delete attachment",
@@ -4506,7 +4506,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7dcf9a7a-1ca6-465d-aa15-af6f8ecf06e4",
+              "id": "4b89a93a-4a0f-4066-a82e-74fb654f3b75",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4564,7 +4564,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bc68df28-d6ce-40c5-a64d-39da8dbc3554",
+                "id": "f8ad2ea5-8b8a-441f-8a8c-c099d4b5ff1f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4577,7 +4577,7 @@
           }
         },
         {
-          "id": "54101c7d-c5ac-4013-b491-3f25a89f87c8",
+          "id": "e20a6c82-5d47-4ba6-9521-ebc0718cfcc1",
           "name": "Create attachment",
           "request": {
             "name": "Create attachment",
@@ -4643,7 +4643,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5c2842ee-eff7-4e34-856d-3ef7c818c596",
+              "id": "c9af5e62-cf97-467f-9ec5-c83390b9b2c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4723,7 +4723,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5415cdd5-5341-4157-a01a-9c8b8b53c7e9",
+                "id": "76c39380-f729-4823-8909-ff65fd7be4bf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/attachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "59a96906-a313-4b5e-b505-91be1146a704",
+          "id": "9b5dab68-fa85-44b2-ae17-f288167870af",
           "name": "Get all attachments",
           "request": {
             "name": "Get all attachments",
@@ -4792,7 +4792,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e5a6c947-5585-4b99-898b-0538313fbf33",
+              "id": "3404fe12-d634-4e50-a307-53e32ad94444",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4859,7 +4859,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9ba44a5e-7081-4586-9848-987f0c573918",
+                "id": "3060882c-449c-4de5-add0-7a8371e7530e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachments - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4878,7 +4878,7 @@
       "event": []
     },
     {
-      "id": "43c56663-a85e-4561-944d-e6d9fa2b515d",
+      "id": "ddf6a414-6f4b-4255-b544-afca907e14f0",
       "name": "Product",
       "description": {
         "content": "",
@@ -4886,7 +4886,7 @@
       },
       "item": [
         {
-          "id": "12199b3c-768a-4cb8-ad44-49e0a35d9c35",
+          "id": "de6efe3a-31b0-4df5-b187-311c35259c30",
           "name": "Get product and SKU IDs",
           "request": {
             "name": "Get product and SKU IDs",
@@ -4968,7 +4968,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7024ae0e-687e-43eb-a3d5-ad44f2ef474e",
+              "id": "d8004402-16b8-4ad3-a8b8-655c563c8fae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5064,7 +5064,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "124e4b79-4fd3-4cec-8838-7e72129f2b75",
+                "id": "ddfaab69-dfad-4573-a9bc-f21d3add8257",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/GetProductAndSkuIds - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5080,7 +5080,7 @@
           }
         },
         {
-          "id": "ce9f6d8d-365a-45db-9751-00ddb24ccb08",
+          "id": "7875bb8b-c0a4-48ea-9b46-5a3dc4982db6",
           "name": "Get product by ID",
           "request": {
             "name": "Get product by ID",
@@ -5145,7 +5145,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f3194abe-276b-4e32-be3c-794d843afd02",
+              "id": "a11007d0-a7b8-4c14-8e15-8722fe89bbc6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5213,7 +5213,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cecdfccb-dae9-4e19-9ee5-f5e0b51bab74",
+                "id": "94c7a985-817d-4e53-91cf-d4cb79517920",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5229,7 +5229,7 @@
           }
         },
         {
-          "id": "0bf4efac-8886-46ba-a407-0bf14e6a4dad",
+          "id": "5c6be730-52fb-4c61-8a2c-69b106bcbee8",
           "name": "Update product",
           "request": {
             "name": "Update product",
@@ -5307,7 +5307,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d1f83641-cad4-4e53-8dea-0299c9a738e1",
+              "id": "8665c0e9-ffa5-4a86-90c0-707359091585",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5388,7 +5388,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b1417c6b-757a-4553-9719-5283c0f56094",
+                "id": "5f341192-8808-4879-a3c2-1623921c8b5c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5404,7 +5404,7 @@
           }
         },
         {
-          "id": "439d0c21-c371-41c7-b86c-f68ad9fced23",
+          "id": "b97ac861-1557-4382-937e-62708ced85e3",
           "name": "Get product and its general context",
           "request": {
             "name": "Get product and its general context",
@@ -5470,7 +5470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d98a2bc5-0216-41e6-8a29-a0845b1639fa",
+              "id": "d8a62fc9-4646-4dda-b0bd-76be9105a1a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5539,7 +5539,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4ee717c9-dadb-4e97-88a5-23feba229ea2",
+                "id": "e6c34b44-2063-49b6-b3c3-7f7983c34695",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/productget/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5555,7 +5555,7 @@
           }
         },
         {
-          "id": "febaed50-f9b7-4c81-9822-6aea2ed4c80d",
+          "id": "302b30e8-5fbd-4f01-af19-72505aa1af3e",
           "name": "Get product by reference ID",
           "request": {
             "name": "Get product by reference ID",
@@ -5621,7 +5621,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e2db7662-406e-4eec-b570-bee655cbd796",
+              "id": "f4b57a64-c0d6-465a-8421-6dc1a6abe7f4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5690,7 +5690,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "646f8efa-ef7c-47d7-9da3-663d65ba1e1e",
+                "id": "718cca1f-50bf-4734-9c4e-5cceacfe4ffa",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/productgetbyrefid/:refId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5706,7 +5706,7 @@
           }
         },
         {
-          "id": "5d58a063-8d18-44ef-97f8-d146f420a3e0",
+          "id": "1a333c6c-0589-4cfd-8703-82601ff440aa",
           "name": "Get product's SKUs by product ID",
           "request": {
             "name": "Get product's SKUs by product ID",
@@ -5772,7 +5772,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b8768477-cb82-49aa-9eb2-751515b08640",
+              "id": "667ac87c-5cde-4452-bd05-517a3f196161",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b5b7926d-255e-464b-b24d-6a0c71b1885f",
+                "id": "90ef69b5-277b-4ecb-85d3-e3ebd86e5660",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/products/variations/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5857,7 +5857,7 @@
           }
         },
         {
-          "id": "614c61df-4bbb-43b7-b3ea-1a0d8f2bad7f",
+          "id": "67ae2d41-2aa6-481b-9a63-9298692ea397",
           "name": "Get product review rate by product ID",
           "request": {
             "name": "Get product review rate by product ID",
@@ -5923,7 +5923,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "14244cdf-6889-4aa9-b4de-c5a10d921a14",
+              "id": "89e41ad3-887a-4318-982d-d438f223e775",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5992,7 +5992,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "598da966-ef57-4ab7-a1ce-b31ab0e3176d",
+                "id": "e1db01a8-99df-42e2-b0b3-6722377947d9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/addon/pvt/review/GetProductRate/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6008,7 +6008,7 @@
           }
         },
         {
-          "id": "c31eb4a0-e7f6-4cfd-a536-fcc1d8fb8014",
+          "id": "5557b5eb-0213-4041-9a66-d69bc26f0ef7",
           "name": "Create product with category and brand",
           "request": {
             "name": "Create product with category and brand",
@@ -6074,7 +6074,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "770b143e-3ec7-4260-b26c-92b438a1d7d0",
+              "id": "4eecafcc-6117-456d-b0e8-9fd6d7fedb7e",
               "name": "New category and brand",
               "originalRequest": {
                 "url": {
@@ -6153,7 +6153,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "cf359626-254e-470d-8105-9409f4b03de3",
+              "id": "f71e13c7-715b-4841-b163-310931878221",
               "name": "Associating it to an existing category and brand",
               "originalRequest": {
                 "url": {
@@ -6233,7 +6233,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6d9beeb6-a2d0-411b-8d80-619bffec8a9e",
+                "id": "03872bdb-5629-485d-b4bb-ccc835d21aae",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6252,7 +6252,7 @@
       "event": []
     },
     {
-      "id": "9517f497-082b-4a62-888a-4f06c91aeb76",
+      "id": "91223772-4f10-4003-82aa-a462fd472288",
       "name": "Product specification",
       "description": {
         "content": "",
@@ -6260,7 +6260,7 @@
       },
       "item": [
         {
-          "id": "81ab212b-b675-41ac-aeb6-9f200a22b6ba",
+          "id": "0428a40f-f3ef-48f4-948e-2e669fb9d55e",
           "name": "Get product specifications by product ID",
           "request": {
             "name": "Get product specifications by product ID",
@@ -6326,7 +6326,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "77929d5b-d8a2-4a69-a75f-7026d8dd11a7",
+              "id": "4e062ce3-42ce-4572-8019-9957b1702b05",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6395,7 +6395,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d67cb487-9527-4294-8c16-6ccd6ffdc627",
+                "id": "5e892261-8eae-4955-b16c-208836c2391f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6411,7 +6411,7 @@
           }
         },
         {
-          "id": "7383c50f-2b2c-4b07-8922-a944db36cf36",
+          "id": "bef38734-6740-44b9-8c16-f246c2629e59",
           "name": "Update product specification by product ID",
           "request": {
             "name": "Update product specification by product ID",
@@ -6486,7 +6486,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f8143f7e-0f63-40f0-87bc-2a66778938fc",
+              "id": "9e0158a9-ed2b-47e3-b044-ddd96d77f8ae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6558,7 +6558,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1bc7f09b-72ba-47b9-906a-796422375691",
+                "id": "df8c6954-ff1d-4c88-822d-fb4dfac9c2da",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/products/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -6571,7 +6571,7 @@
           }
         },
         {
-          "id": "98899b49-99aa-448c-ab60-d861901793f7",
+          "id": "2e798d08-68d3-46cb-a8c8-e1d3cd437bc4",
           "name": "Get product specifications and their information by product ID",
           "request": {
             "name": "Get product specifications and their information by product ID",
@@ -6637,7 +6637,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b0e0f506-14a5-4393-855a-a0b9949b2f63",
+              "id": "506d9524-f498-49e1-b05c-2d3c1a6cd226",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6706,7 +6706,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "08bfc778-e19d-40cf-bfc9-b1c41d5118d1",
+                "id": "7fa4f4ee-9441-4255-b56d-9cbf34be8747",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6722,7 +6722,7 @@
           }
         },
         {
-          "id": "8a81e632-535a-44f1-82d2-28a3f728f272",
+          "id": "a3ec4f3e-66fb-4452-9df1-25241bc0d512",
           "name": "Associate product specification",
           "request": {
             "name": "Associate product specification",
@@ -6801,7 +6801,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "05580eb2-ca2f-4439-a794-2dde24370994",
+              "id": "52425594-7725-4678-8b25-edbf41ac9644",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6883,7 +6883,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6532e213-b6e7-4640-98d3-4dbb1be4de00",
+                "id": "62ab3cc0-6e04-4cdc-a91a-ed26f1eccd21",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6899,7 +6899,7 @@
           }
         },
         {
-          "id": "7f85708b-aef5-4a1b-972b-790db7dbb0d6",
+          "id": "dcfd2828-f470-4cd3-b8c2-a9f0c16a7643",
           "name": "Delete all product specifications by product ID",
           "request": {
             "name": "Delete all product specifications by product ID",
@@ -6961,7 +6961,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5fca5d9c-d7af-4736-8b8a-25c65d0aade5",
+              "id": "ec503271-f777-4116-bd93-f897c1741530",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7020,7 +7020,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "123b84b6-1fd3-45ca-82c8-9b02750c73fa",
+                "id": "4b8908ce-45d7-41bb-b92e-7e3be7a642db",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7033,7 +7033,7 @@
           }
         },
         {
-          "id": "e0650cc4-fdc2-4bfa-a810-b1ae4ceac0e4",
+          "id": "b14fd579-d2e4-407f-8909-08f13c31beeb",
           "name": "Delete a product specification",
           "request": {
             "name": "Delete a product specification",
@@ -7110,7 +7110,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c4c2da43-42db-4c98-8ced-6f94c2a2ef97",
+              "id": "c14574bb-94fc-469f-99a2-68eeeed1b351",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7169,7 +7169,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ec474e18-548a-479c-a4af-197ade1e1e42",
+              "id": "49b4b1de-f9e2-4009-9f48-9bc4fcdc58e2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -7239,7 +7239,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9dcd2701-63d7-4179-9c69-407ad06b9a55",
+                "id": "921f6f1c-3b40-4cac-a87c-6fb0cc43aa7a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7252,7 +7252,7 @@
           }
         },
         {
-          "id": "7c0242c8-e8eb-4a5e-bd39-ef4ea358766c",
+          "id": "78506448-08c6-417a-84e7-e56332037949",
           "name": "Associate product specification using specification name and group name",
           "request": {
             "name": "Associate product specification using specification name and group name",
@@ -7331,7 +7331,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d2545680-73e8-4945-a045-50211fe32dee",
+              "id": "016e1a41-2549-41f8-9b95-dea95f523104",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7413,7 +7413,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f4a49c6d-5193-4921-b23c-280833f7b9f1",
+                "id": "692f3980-46a3-4157-80e5-47484ef1bdd1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7432,7 +7432,7 @@
       "event": []
     },
     {
-      "id": "8ea06a57-ed5a-4630-b450-6c3e102019e9",
+      "id": "e84579ef-785e-46dc-aea6-7389468370be",
       "name": "Similar category",
       "description": {
         "content": "",
@@ -7440,7 +7440,7 @@
       },
       "item": [
         {
-          "id": "8bb210ae-7eaa-4e7a-ae1f-6f79f75fe07b",
+          "id": "c818f7ba-a603-4dc6-8a1e-09afc080790d",
           "name": "Get similar categories",
           "request": {
             "name": "Get similar categories",
@@ -7506,7 +7506,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fecfe480-15e4-4ff3-a4f4-a062532f9873",
+              "id": "9c32643c-8e24-4de8-bf00-0e4682e864aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7575,7 +7575,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6a73e7cf-e836-4eee-b993-1717a7dff6ec",
+                "id": "0941595a-e41c-4d21-be74-6e0feb4c3892",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/similarcategory - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7591,7 +7591,7 @@
           }
         },
         {
-          "id": "0cdf1f40-e573-465e-8aea-298fec11be00",
+          "id": "094a100e-3773-4e3f-9a9c-7b63b5a9d1ab",
           "name": "Add similar category",
           "request": {
             "name": "Add similar category",
@@ -7668,7 +7668,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "febd87dc-2e46-4952-b76b-312b084f7661",
+              "id": "893cf51e-d9df-4e39-bffb-be9a669d2d06",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7738,7 +7738,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4469d46e-5e9d-4ba8-8aa5-3b8459a0ac61",
+                "id": "de4194cf-e454-499c-a599-49b67b7dc65b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/similarcategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7754,7 +7754,7 @@
           }
         },
         {
-          "id": "1f86ac7e-f21a-45ae-8e16-25f313e646ad",
+          "id": "a96bb4ef-76b6-4129-b704-b2cfdba47c8d",
           "name": "Delete similar category",
           "request": {
             "name": "Delete similar category",
@@ -7827,7 +7827,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "90587a2a-513c-4ebb-a300-a3585dbcd47d",
+              "id": "2d91c747-7dc5-4644-8082-fdf54e09013d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7887,7 +7887,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0e26f261-906e-4ed3-9a33-eb489ad24e02",
+                "id": "8d03866e-e7d7-4aec-9c93-2b970c71ef57",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/similarcategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7903,7 +7903,7 @@
       "event": []
     },
     {
-      "id": "147f5fd8-03de-4554-bac3-aaa39f43e461",
+      "id": "a591877f-89d2-4268-99ec-9aef39b280ed",
       "name": "SKU",
       "description": {
         "content": "",
@@ -7911,7 +7911,7 @@
       },
       "item": [
         {
-          "id": "54a78cc0-fde6-4c3c-b925-a9d0900b61a4",
+          "id": "200ec43d-3be8-48fb-8047-e47efacc5ae9",
           "name": "List all SKU IDs",
           "request": {
             "name": "List all SKU IDs",
@@ -7984,7 +7984,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "89e2eb05-2371-4efa-ab0c-9ea7e833a9b8",
+              "id": "9ce11613-0ece-4840-b133-1ea6dcd540cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8071,7 +8071,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a6738371-a209-4332-87da-e2fb6b74ddbc",
+                "id": "3fe1a5c6-40ff-4d42-bb9c-ef7f22af1695",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitids - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8087,7 +8087,7 @@
           }
         },
         {
-          "id": "e136a140-db24-4ad3-ac85-7e8972910c39",
+          "id": "66833670-fbb8-44a1-9234-235f6a7176c4",
           "name": "Get SKU and context",
           "request": {
             "name": "Get SKU and context",
@@ -8163,7 +8163,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f3fd2130-ebe6-4fc4-b02a-7c22d3ac858f",
+              "id": "0331ac4d-e333-4b6e-a1d6-d6429d25d84c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8242,7 +8242,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0144f066-3c68-4d7e-8c73-2afe1677ce47",
+                "id": "cb0b57ea-99af-4603-88ed-5cae3f91c720",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyid/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8258,7 +8258,7 @@
           }
         },
         {
-          "id": "964391f6-bb2c-4494-aa7d-ab8b360b7462",
+          "id": "23a5416d-abc0-488b-9b0c-5167a63e397c",
           "name": "Get SKU by reference ID",
           "request": {
             "name": "Get SKU by reference ID",
@@ -8321,7 +8321,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "90f8727c-a4b8-4b8d-9094-34f5cb9ade9c",
+              "id": "f4e48e4f-2add-4f9f-8e49-cfd3c65f5ca1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8398,7 +8398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5b18125c-d78e-4e74-9d74-f64735b1b876",
+                "id": "bf470a21-3e95-44e4-a498-20458838dbd6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8414,7 +8414,7 @@
           }
         },
         {
-          "id": "66d9665e-4949-48b5-80dc-17b51f9ba742",
+          "id": "c8732ffe-72e3-47e5-b7a9-4edd3307e494",
           "name": "Create SKU",
           "request": {
             "name": "Create SKU",
@@ -8480,7 +8480,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "08c675c1-48c6-4a00-b62f-530fa12744d8",
+              "id": "025ec6d3-5250-4ea3-9491-431fd92b7ca4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8560,7 +8560,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ee537a3e-6725-45c6-a888-9e6a6cfddb30",
+                "id": "f03cb0fb-ba66-4007-bb2a-1298de14921e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8576,7 +8576,7 @@
           }
         },
         {
-          "id": "cb126f2e-f7a6-4441-8ae0-8b82667052ab",
+          "id": "701eca28-bdf8-43b9-a5b5-bca4b43376cc",
           "name": "Get SKU ID by reference ID",
           "request": {
             "name": "Get SKU ID by reference ID",
@@ -8642,7 +8642,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a4cc8f62-c918-45c9-89c5-60a68463182c",
+              "id": "5e7d8b8e-c439-4af0-acad-0a0ad82d8e93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8711,7 +8711,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e5db9af7-3819-4b50-95e5-aa8afaa74297",
+                "id": "b623e46f-562f-4769-84b8-e9a44dc1f902",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitidbyrefid/:refId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8727,7 +8727,7 @@
           }
         },
         {
-          "id": "f9aecf0c-5ea1-4993-b1e3-5f324e026913",
+          "id": "e8981ccf-39a6-4cc6-8dff-7c1169e8268f",
           "name": "Get SKU by alternate ID",
           "request": {
             "name": "Get SKU by alternate ID",
@@ -8793,7 +8793,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "94318e29-8bba-45b1-a021-f652487e94fc",
+              "id": "afc611a2-4a54-4716-a0f2-7057872e87d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8862,7 +8862,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "36fc8420-2639-4f5d-a8a9-82fac001c065",
+                "id": "3b63815b-eab1-49ae-a87f-7737cea0e689",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyalternateId/:alternateId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8878,7 +8878,7 @@
           }
         },
         {
-          "id": "85f53da0-ae16-43ee-a137-b3d95478c971",
+          "id": "1a876dbe-483a-47dc-9c5e-465a7f98a481",
           "name": "Get SKU list by product ID",
           "request": {
             "name": "Get SKU list by product ID",
@@ -8944,7 +8944,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7b7dd3d3-59f1-403c-ae78-504c068b9908",
+              "id": "e375ce69-170d-47af-bb3f-fa3a912d003b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9013,7 +9013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0a7c75ca-dc76-419d-92bb-05db8d2e64ca",
+                "id": "760b2c0e-1054-4d89-9752-855bc1092f44",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitByProductId/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9029,7 +9029,7 @@
           }
         },
         {
-          "id": "37b2c0e4-1ace-4d7c-a2d4-654cd337d2ce",
+          "id": "f9fae899-00fe-4be1-9f4e-1b3aab59f0c3",
           "name": "Retrieve SKU ID list by reference ID list",
           "request": {
             "name": "Retrieve SKU ID list by reference ID list",
@@ -9096,7 +9096,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "adebd45e-afb4-4bd3-80eb-301391ba34d6",
+              "id": "44647e22-531d-47db-b5f5-12d028cb9622",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9176,7 +9176,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c7a53af9-5f33-446c-82d7-a6b4aae5f712",
+              "id": "1ccd8104-52f9-4947-92b7-23447632bf2f",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -9247,7 +9247,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "db3875be-0f65-4013-a4b5-0d1fa420b352",
+                "id": "96c6dfa2-2c48-437e-9419-61555e74e120",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pub/sku/stockkeepingunitidsbyrefids - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9263,7 +9263,7 @@
           }
         },
         {
-          "id": "bae9d953-728a-4ffa-93cf-99ae9f93e4b3",
+          "id": "29b69c50-4ca8-4a61-b123-fe04e62712f9",
           "name": "Get SKU",
           "request": {
             "name": "Get SKU",
@@ -9328,7 +9328,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "75e7deb7-a929-4d05-b65a-d8688c7d7d0a",
+              "id": "fa3dc61d-fdfd-4ad8-8029-daa0bfffdc1a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9396,7 +9396,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b6a6511a-9533-489f-ba6c-686426b84e78",
+                "id": "7cea6679-6e39-4ec7-a8c2-8c31c019bb58",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9412,7 +9412,7 @@
           }
         },
         {
-          "id": "c3b08d9e-182a-4cce-adb7-317da57f9dfe",
+          "id": "ea4cc1c3-2b90-4825-ba7f-816ab4b07ea3",
           "name": "Update SKU",
           "request": {
             "name": "Update SKU",
@@ -9490,7 +9490,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "53bc3686-c01e-4998-9482-33cda3ccca66",
+              "id": "fa1c327c-d8fc-48e7-9be8-d3a499234d2d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9571,7 +9571,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e92c678a-d57c-4bbd-b747-b62cd74dc809",
+                "id": "004e98da-203a-41cc-ad27-42763095f6e6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9590,7 +9590,7 @@
       "event": []
     },
     {
-      "id": "c62aa47d-0fcd-4367-80a0-c1ca988f5ad0",
+      "id": "cefe6541-1395-408e-a8e8-637dcd647bfd",
       "name": "SKU EAN",
       "description": {
         "content": "",
@@ -9598,7 +9598,7 @@
       },
       "item": [
         {
-          "id": "70ff7784-cd1e-4310-96bf-b6dfa5fa619d",
+          "id": "13483310-9282-4f8e-bb7a-f22509f86d91",
           "name": "Get SKU by EAN",
           "request": {
             "name": "Get SKU by EAN",
@@ -9664,7 +9664,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "59138e11-3674-4f72-8420-8716647a66ef",
+              "id": "4854d900-da00-4332-bcec-95e902cde886",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9733,7 +9733,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dd906a60-e3bc-4d27-82a3-1126d3ff42f5",
+                "id": "6c7d143d-0ffc-4f86-88fb-4565f8b75749",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9749,7 +9749,7 @@
           }
         },
         {
-          "id": "37ff0cd1-5550-4fe6-9917-63e33020de87",
+          "id": "a9be9bda-effe-42ba-a342-550be77de9d6",
           "name": "Get EAN by SKU ID",
           "request": {
             "name": "Get EAN by SKU ID",
@@ -9815,7 +9815,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "77f049da-eafa-4ec6-b8f3-76ed2607cc30",
+              "id": "8f82bb55-4dff-4de0-8639-d2fd5d71b566",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9884,7 +9884,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c8af4bac-70ac-4dd1-8885-155391e22f39",
+                "id": "4ad9bf93-b9a1-4cb3-be65-c58e84125c74",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9900,7 +9900,7 @@
           }
         },
         {
-          "id": "210cb0fb-d898-45f8-a8ce-944787a6a923",
+          "id": "f03b9638-7b29-44b4-9646-13962437501d",
           "name": "Delete all SKU EAN values",
           "request": {
             "name": "Delete all SKU EAN values",
@@ -9962,7 +9962,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ad0eee47-c30c-42e9-af77-004a24bf79b0",
+              "id": "ca59a3ae-08f2-400e-958e-dd9625990577",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cb0e907c-53bc-40e6-bb4a-842ea943787f",
+                "id": "0afafd2b-649a-40c5-a86e-6f8fd18e1a53",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10034,7 +10034,7 @@
           }
         },
         {
-          "id": "677128fc-23a6-4a52-a064-06b8237a85d2",
+          "id": "d4efbec5-5bc1-4e44-8e1c-e2f31a7d629a",
           "name": "Create SKU EAN",
           "request": {
             "name": "Create SKU EAN",
@@ -10107,7 +10107,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "900333c7-2192-4928-ac95-e9c438abd5b1",
+              "id": "4509118e-a6ab-4a71-8bfb-b0f890f50b1a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10167,7 +10167,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1f2b80d1-9c3f-47c4-ac21-9c05ed15662a",
+                "id": "1a09f000-8913-4cf0-bc33-10d2c7ce7e8c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/ean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10180,7 +10180,7 @@
           }
         },
         {
-          "id": "98012f62-563b-4d94-b948-528ba859e521",
+          "id": "4cc30db3-b910-4bfd-9e64-fab076dc4694",
           "name": "Delete SKU EAN",
           "request": {
             "name": "Delete SKU EAN",
@@ -10253,7 +10253,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "92a096e7-62a8-445e-b976-b8473480dd8b",
+              "id": "71a39ab4-e44b-4a9e-8e83-66bad7526675",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10313,7 +10313,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "583575a8-78d1-4882-8d23-f9ff1f380ff0",
+                "id": "aa198b83-2d88-43a8-8af8-bf9ebb49ddd9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/ean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10329,7 +10329,7 @@
       "event": []
     },
     {
-      "id": "c67e7886-078c-4a37-9497-0ee894f40571",
+      "id": "9f238b11-e32c-4ccc-9258-fc94d1936277",
       "name": "SKU file",
       "description": {
         "content": "",
@@ -10337,7 +10337,7 @@
       },
       "item": [
         {
-          "id": "5bf89f64-57e6-47a7-a287-ca113d3cc50f",
+          "id": "1793ae64-c93d-4895-a757-1796a1f1cc50",
           "name": "Get SKU files",
           "request": {
             "name": "Get SKU files",
@@ -10403,7 +10403,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "36905c1c-0779-4ce6-bfd6-be0ce45ea948",
+              "id": "72ab5e31-a765-4d73-8615-55cd8f9da66f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10472,7 +10472,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7cc27cff-4907-4169-9db3-af6b23fa7ea9",
+                "id": "9bdce717-280b-48de-883c-8a28a913f217",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10488,7 +10488,7 @@
           }
         },
         {
-          "id": "0fc6e377-786f-43b1-a747-c4bcbea8614a",
+          "id": "28f8beb5-c6fd-47b8-8795-859d39bf4eb2",
           "name": "Create SKU file",
           "request": {
             "name": "Create SKU file",
@@ -10567,7 +10567,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8bb6160b-3a66-4a30-ba3d-69634ffd54c6",
+              "id": "abcc9771-7036-4caa-993d-57a02a205187",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10649,7 +10649,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eaa97613-9ce5-412d-ac5d-42fd61bb51d3",
+                "id": "b40d8db7-3478-4b9f-9479-e8b4cde7d671",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10665,7 +10665,7 @@
           }
         },
         {
-          "id": "dbab20a8-b68c-4a54-be1e-2ecab6346069",
+          "id": "f59be1f5-4e19-4c23-91f8-35812ea26be8",
           "name": "Delete all SKU files",
           "request": {
             "name": "Delete all SKU files",
@@ -10727,7 +10727,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b469d9c7-11bc-4e2f-be20-58b97ca6704b",
+              "id": "aac7cfe1-20eb-4e55-b96a-0c691bf96923",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10786,7 +10786,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "355afb62-320c-4d7d-a304-b3bfbd18194f",
+                "id": "4da3b50a-21f0-4a2c-af34-0d4532b1171b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10799,7 +10799,7 @@
           }
         },
         {
-          "id": "7f9aa914-618c-4f2f-a7db-479cb30af42c",
+          "id": "6463a188-21df-4f91-a4ee-d1c92af6727e",
           "name": "Update SKU file",
           "request": {
             "name": "Update SKU file",
@@ -10889,7 +10889,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bfd30df3-0924-4754-bd76-a4b8823f5b94",
+              "id": "2a1d5554-df56-4cdd-b2f7-5f75837e25cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10972,7 +10972,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "873de2d9-ce53-4da9-9a2d-9f51724604db",
+                "id": "d2a4da23-58da-469b-960b-cbaadcc14f80",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10988,7 +10988,7 @@
           }
         },
         {
-          "id": "38c9c6a7-292d-4fd0-8f09-dc43e4a77e5b",
+          "id": "9fd9484d-ccd8-41a2-8153-ae624c0c7a17",
           "name": "Delete SKU image file",
           "request": {
             "name": "Delete SKU image file",
@@ -11061,7 +11061,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c08eb20f-a084-432f-8c5a-7871730d16e1",
+              "id": "3737d637-cc26-484b-bd36-a4cd04a27f19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11121,7 +11121,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "df4e5a0f-8167-4a90-ab06-aff9395aa564",
+                "id": "fa065720-9afc-45d6-a77c-432ccd73f929",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11134,7 +11134,7 @@
           }
         },
         {
-          "id": "fb84bee2-5af5-42a9-b568-34b20592ff44",
+          "id": "4af22833-0638-4131-a900-043cab7f2de8",
           "name": "Reorder SKU files",
           "request": {
             "name": "Reorder SKU files",
@@ -11210,7 +11210,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b5c280eb-b975-465e-b9b7-4849b7baf08e",
+              "id": "39f6959c-09ed-44fd-becd-272975b40e8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11282,7 +11282,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d4f24fe7-6b27-49a3-b875-d562a945eaf5",
+              "id": "ebf74302-6f79-4836-9efd-0d521bdbf55e",
               "name": "Bad request. All files are required.",
               "originalRequest": {
                 "url": {
@@ -11355,7 +11355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "07a70874-65d4-40e3-ab87-c0b820216abe",
+                "id": "3322738c-5c56-4193-9b6e-c7ea9ea24321",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/reorder - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11368,7 +11368,7 @@
           }
         },
         {
-          "id": "e5536395-f446-4144-a26b-01bb3bcb735e",
+          "id": "b6a58adf-9020-4fb0-9349-75a7ece672f3",
           "name": "Copy files from an SKU to another SKU",
           "request": {
             "name": "Copy files from an SKU to another SKU",
@@ -11446,7 +11446,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "90db0392-2af5-4251-a699-d7955de49de3",
+              "id": "20617662-299b-4830-9671-15eedea788ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11517,7 +11517,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "25b17198-0075-40a0-87ca-31cb6b620989",
+                "id": "5da1a1be-c65b-4658-9890-fdd9c68738e5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/copy/:skuIdfrom/:skuIdto/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -11533,7 +11533,7 @@
           }
         },
         {
-          "id": "7547cf4c-4a08-479a-9142-ef09c2f26753",
+          "id": "eba76130-e476-4bd3-bffd-fc7247267847",
           "name": "Disassociate SKU file",
           "request": {
             "name": "Disassociate SKU file",
@@ -11607,7 +11607,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "480b9ace-6b61-4298-bda3-d4a67c044cc4",
+              "id": "105bace2-c604-45cb-acc7-9047a3952cf5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11668,7 +11668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "17dae7ca-00fc-4dfd-85e8-a66adaec2b85",
+                "id": "d10d51b8-9022-48f9-ac6d-268aa58c2463",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/disassociate/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11684,7 +11684,7 @@
       "event": []
     },
     {
-      "id": "7c42997f-f3b5-4273-865c-e92cb00e8de4",
+      "id": "e894467b-97d5-47fe-986a-49bf26070ba1",
       "name": "SKU kit",
       "description": {
         "content": "",
@@ -11692,7 +11692,7 @@
       },
       "item": [
         {
-          "id": "8c7040cc-ba1b-4ea8-b27e-cd3d26035cf8",
+          "id": "bb9ec43a-d312-49ca-b85b-efd22512a2a5",
           "name": "Get SKU kit by SKU ID or parent SKU ID",
           "request": {
             "name": "Get SKU kit by SKU ID or parent SKU ID",
@@ -11764,7 +11764,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b9e4f593-14aa-4180-98cc-1f57bc3f6d45",
+              "id": "5aea86b0-09e2-4bca-932c-7a74f8263f44",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11850,7 +11850,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a1835b5a-1495-43da-933e-d5aa152ff3c0",
+                "id": "5e1f8f56-62ca-46cc-b9a2-40cadbedd167",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -11866,7 +11866,7 @@
           }
         },
         {
-          "id": "997c2c46-773f-4a7b-a1b0-27bd99186589",
+          "id": "b88d15e5-f787-41a3-ba79-4beea323c0bc",
           "name": "Create SKU kit",
           "request": {
             "name": "Create SKU kit",
@@ -11932,7 +11932,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b0e12fd4-03b0-43c0-bffe-14243cb06ef7",
+              "id": "889bbe72-6b7b-4ff1-a11b-c5bcb3dc19ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12012,7 +12012,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "18f20402-a31a-4c1c-91c8-ce84dd18006b",
+                "id": "33f4e387-b934-4aa5-9934-5bcb22877bcc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12028,7 +12028,7 @@
           }
         },
         {
-          "id": "cdd80fc1-5df6-4e3f-9cff-8cbd30138047",
+          "id": "d50f7d61-7a26-4f77-bafb-2fbc606ded01",
           "name": "Delete SKU kit by SKU ID or parent SKU ID",
           "request": {
             "name": "Delete SKU kit by SKU ID or parent SKU ID",
@@ -12096,7 +12096,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "44be84c2-987c-4c68-be5e-f7695d546e8f",
+              "id": "732e370d-9445-4e74-8eab-7257ee7cfc0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12172,7 +12172,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "059afd34-f1cc-4405-bb93-f8986a7da752",
+                "id": "ff20e092-5a2a-4cee-b858-6d86bee3f449",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -12185,7 +12185,7 @@
           }
         },
         {
-          "id": "e1ef9fdf-f2e7-4fa9-bb2d-e88bd53af1ae",
+          "id": "6466ff47-08b9-4136-8a0e-9e7cea99ece3",
           "name": "Get SKU kit",
           "request": {
             "name": "Get SKU kit",
@@ -12250,7 +12250,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fac0e4ed-6dfd-4901-84e1-de77d0bf21c6",
+              "id": "1217a3ae-307e-4270-a747-9cdf9be34b1e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12318,7 +12318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "006cfaae-1337-4187-a5fc-d0259d1c6721",
+                "id": "ddfada41-ad00-4651-a337-05d53520fd8e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunitkit/:kitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12334,7 +12334,7 @@
           }
         },
         {
-          "id": "001e7b56-6708-48b4-95bd-cd6b722bd1c9",
+          "id": "6dff90c2-8fc6-4174-9ffb-b6ceac172f81",
           "name": "Delete SKU kit by kit ID",
           "request": {
             "name": "Delete SKU kit by kit ID",
@@ -12395,7 +12395,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4bcc9dd6-30af-41b0-a19d-27a0cf478731",
+              "id": "ed485ab1-fd35-4ea2-b606-f90618cb2344",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12453,7 +12453,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "53b00c40-ca6d-4b35-9c79-a1518fa15ac5",
+                "id": "2df1bfe1-e2c3-47ec-bdb4-da50acdcc482",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunitkit/:kitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -12469,7 +12469,7 @@
       "event": []
     },
     {
-      "id": "383293e0-881c-4950-a75b-4183641d2371",
+      "id": "a7941b8d-5265-4170-a81e-e78d013c5169",
       "name": "SKU specification",
       "description": {
         "content": "",
@@ -12477,7 +12477,7 @@
       },
       "item": [
         {
-          "id": "260d1068-9b5a-481d-a365-97d6636857a4",
+          "id": "5e92d918-abdd-4759-92f4-e7eda0dc064b",
           "name": "Get SKU specifications",
           "request": {
             "name": "Get SKU specifications",
@@ -12543,7 +12543,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "919f4b25-55d0-4047-8bc8-e837eb7ac7b3",
+              "id": "17e6d678-a420-4c5d-9f39-8207c05253a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12612,7 +12612,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d58d41e3-2bd1-433a-8c9a-4b53ed54bf87",
+                "id": "a1805bba-90e3-4283-ab48-bed1347bf181",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12628,7 +12628,7 @@
           }
         },
         {
-          "id": "1338bbb2-90cf-4f56-af39-9ea3a69da6e3",
+          "id": "9e5d3014-0cf2-4132-9355-1d59e8eb7e50",
           "name": "Associate SKU specification",
           "request": {
             "name": "Associate SKU specification",
@@ -12707,7 +12707,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1fcb8bf8-c632-4f2b-854a-e46b037233e4",
+              "id": "f3522891-4f77-4316-a008-08ee272470ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12789,7 +12789,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "18018a9f-56ac-4ff4-af99-7fdf0b24395a",
+                "id": "03ff8ae4-c953-44a5-91b5-61079cd09fbb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12805,7 +12805,7 @@
           }
         },
         {
-          "id": "bb03bcd0-3c1c-4e96-b1cc-77ab29ab5000",
+          "id": "e2214d73-5a44-4dc4-8bf0-0771e9fe722e",
           "name": "Update SKU specification",
           "request": {
             "name": "Update SKU specification",
@@ -12884,7 +12884,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bf926385-1644-4a57-a7a3-2c113cd8421c",
+              "id": "3a4e7cc4-f559-4629-99d7-cf5411d77197",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12966,7 +12966,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0d774795-988b-4e44-befe-d40ef5aeb9c4",
+                "id": "b9175bbf-3696-4a46-9334-0ed7aa3ec932",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12982,7 +12982,7 @@
           }
         },
         {
-          "id": "65b590ef-70d6-442a-89a0-7314dd3c1793",
+          "id": "bff431ad-1da7-4c6d-be9b-64cf06cb3f35",
           "name": "Delete all SKU specifications",
           "request": {
             "name": "Delete all SKU specifications",
@@ -13044,7 +13044,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dccd9a28-4994-496e-80ad-842600087af4",
+              "id": "55ba7402-4079-4c5e-9475-079a0fcabf8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13103,7 +13103,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dea3b5b4-0081-4487-b8f1-323777c2a1cb",
+                "id": "13fbbd47-2af2-49c3-a68c-1905fb534882",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13116,7 +13116,7 @@
           }
         },
         {
-          "id": "ee90741c-880f-4ca3-9a66-1af8235142c0",
+          "id": "2e9274f4-49a6-41f1-a365-e54077ffad59",
           "name": "Delete SKU specification",
           "request": {
             "name": "Delete SKU specification",
@@ -13189,7 +13189,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "54e1722a-c6c4-4f95-a46a-ff1b4458faf2",
+              "id": "89a72ffe-366a-4e1f-b3c2-e34f7c279260",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13249,7 +13249,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5541d69b-e017-41a5-9011-d5c84b095d5d",
+                "id": "0b652292-d966-4a79-ab64-d7f790d69b71",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13262,7 +13262,7 @@
           }
         },
         {
-          "id": "7ae479cc-c59e-4b24-b9ad-b21c8f910b4e",
+          "id": "290219ea-779f-4891-895e-67eb4dec7667",
           "name": "Associate SKU specification using specification name and group name",
           "request": {
             "name": "Associate SKU specification using specification name and group name",
@@ -13341,7 +13341,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "31e38d40-5eed-4293-a325-618c5c45cba3",
+              "id": "dfa80950-67aa-4941-9712-bd5cd0f306a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13423,7 +13423,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ba581e53-656a-4ee5-a6aa-5a5fdf75a7a9",
+                "id": "158ccd4d-def5-4080-9ce4-c6f48e3ecba5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13442,7 +13442,7 @@
       "event": []
     },
     {
-      "id": "72dafbf2-fcf1-415f-9d17-50c845bb012b",
+      "id": "29f9b645-fe87-4cd6-97d7-743100b237f7",
       "name": "SKU attachment",
       "description": {
         "content": "",
@@ -13450,7 +13450,7 @@
       },
       "item": [
         {
-          "id": "3c90df5d-f889-45e1-8d14-ae512f95d6b1",
+          "id": "8fcd73e5-cae3-4cae-9768-6aebf8611dbc",
           "name": "Associate SKU attachment",
           "request": {
             "name": "Associate SKU attachment",
@@ -13516,7 +13516,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4f8a2302-7fee-436d-abbb-cad00bba54bc",
+              "id": "89e5ff14-762e-4726-9f21-15e999dd804c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13596,7 +13596,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "57527395-f477-4aae-afe3-bcbd1a667fe5",
+                "id": "0f864e44-e939-4e3b-9925-7588defe67d6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13612,7 +13612,7 @@
           }
         },
         {
-          "id": "2fa8d29c-57c6-4f20-b5a2-b81ec73c398b",
+          "id": "f72ec9c7-fc5f-49f6-9551-e25ed6560b1d",
           "name": "Dissociate attachments and SKUs",
           "request": {
             "name": "Dissociate attachments and SKUs",
@@ -13680,7 +13680,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "81fc5558-4f78-4ab7-bfc1-c992b5505f1c",
+              "id": "f42c561c-721b-4eb7-9a74-a72845573981",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13756,7 +13756,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5cce6b73-2f19-4f6c-a100-d52422f1586c",
+                "id": "cc159b0f-f7ab-435a-afc5-979c266de3d2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13769,7 +13769,7 @@
           }
         },
         {
-          "id": "eff33135-1ee4-432f-9f8b-b02c0ebf9676",
+          "id": "ff3b791e-92af-4e22-903c-1c00e6d9f350",
           "name": "Get SKU attachments by SKU ID",
           "request": {
             "name": "Get SKU attachments by SKU ID",
@@ -13835,7 +13835,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a18b0439-6dee-4d37-8cef-aa36383eaec7",
+              "id": "a4f20811-5352-4491-95b9-bcb3167f323e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13904,7 +13904,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5cfb18e9-e1f8-4dca-9ffc-178c22b941b5",
+                "id": "c4703987-f58c-422b-9225-955f94e762ef",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13920,7 +13920,7 @@
           }
         },
         {
-          "id": "43d07a9a-40e9-4dd4-a8af-023896c307c0",
+          "id": "de754b4c-ad3f-4820-a053-bb5ae86b3fca",
           "name": "Delete SKU attachment by attachment association ID",
           "request": {
             "name": "Delete SKU attachment by attachment association ID",
@@ -13981,7 +13981,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8d5f2aa1-24ab-4744-807c-f908f8f1c183",
+              "id": "7464ca34-4512-499b-9dab-93147c053cd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14039,7 +14039,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3693a8d3-44bf-49dd-b099-f31a68aa0ceb",
+                "id": "85b099a2-972b-4d8e-8953-2e0bf594ea7e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuattachment/:skuAttachmentAssociationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -14052,7 +14052,7 @@
           }
         },
         {
-          "id": "2bc4de71-82f7-4029-bc57-784ee9b5855a",
+          "id": "9e948fff-f66f-4b08-9ba3-b4668171f57b",
           "name": "Associate attachments to an SKU",
           "request": {
             "name": "Associate attachments to an SKU",
@@ -14115,7 +14115,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9a200010-2191-4fc8-9b91-07fa1e5a4cdc",
+              "id": "321c015a-97f5-4644-bdf8-f0a726f195e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14186,7 +14186,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ce9bbb72-dea4-4237-ba5c-91a55efb9174",
+                "id": "1bebeffb-8238-4df6-aaf8-50dda85d8ab1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/sku/associateattachments - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -14202,7 +14202,7 @@
       "event": []
     },
     {
-      "id": "924f2a93-9e3a-4964-b945-71177cd93c26",
+      "id": "0a9adfb1-8f53-4a79-aafe-7f0038c41057",
       "name": "SKU complement",
       "description": {
         "content": "",
@@ -14210,7 +14210,7 @@
       },
       "item": [
         {
-          "id": "5937f83d-318e-492f-a92c-6a513d9583ac",
+          "id": "1c50d7ba-9a25-4250-97d3-ff27d6fc30c8",
           "name": "Get SKU complement by SKU ID",
           "request": {
             "name": "Get SKU complement by SKU ID",
@@ -14276,7 +14276,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "44dd91cb-8356-44a8-98df-5cbae5818a1c",
+              "id": "b1d55c7c-0507-488c-93e3-9b40dfc414c9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "934ac958-a530-47b1-93f4-700a7ec19313",
+                "id": "e29f279e-6243-422b-b7f9-a98409524f19",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/complement - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14361,7 +14361,7 @@
           }
         },
         {
-          "id": "eb9bddf8-e90d-4742-8b68-a3ffc5a64083",
+          "id": "ee7cd7bf-c682-47a0-811e-e150081ad9a3",
           "name": "Get SKU complements by complement type ID",
           "request": {
             "name": "Get SKU complements by complement type ID",
@@ -14438,7 +14438,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "549da15e-23ae-47cc-920b-99d0b056466c",
+              "id": "540bfd1e-90b5-4655-9eaa-4862cabf71e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14508,7 +14508,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "91e232d1-c881-4891-a632-70853020e07b",
+                "id": "f5dd9bb2-a211-48a7-b404-2d35dcde3007",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/complement/:complementTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14524,7 +14524,7 @@
           }
         },
         {
-          "id": "232bb594-0403-4701-b9de-5e2aabaca751",
+          "id": "643d6e1d-f5fc-4003-8002-a090a7746d88",
           "name": "Get SKU complements by type",
           "request": {
             "name": "Get SKU complements by type",
@@ -14601,7 +14601,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8cd48bb3-e6a8-4fd2-9e78-d08db1643354",
+              "id": "14c838da-d197-4dcd-9cc0-2de4da261d54",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14671,7 +14671,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "291592c5-5808-4ffa-9cbe-f02c403092d8",
+                "id": "d9587061-a36e-4ff6-8b25-f4b94e31848a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/complements/:parentSkuId/:type - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "9f87a2cd-6878-4a61-be54-7d6e01ea0c37",
+          "id": "4d7a5f5e-a419-47c5-ba53-197512ae89b9",
           "name": "Create SKU complement",
           "request": {
             "name": "Create SKU complement",
@@ -14753,7 +14753,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a1e40576-d023-48f9-b517-2c2773cea4a1",
+              "id": "484cd56e-182c-4967-b90d-c848c339a858",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14833,7 +14833,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1c2a297e-dcb9-417c-ad62-75f60c02d434",
+                "id": "0e0bcaa3-adc5-41a6-898a-ae4028d323ad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skucomplement - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14849,7 +14849,7 @@
           }
         },
         {
-          "id": "61492bdc-ecd0-4c7a-97f0-7266e9d551dd",
+          "id": "b545de7e-c37b-4e5b-a927-b553dcdb8f30",
           "name": "Get SKU complement by SKU complement ID",
           "request": {
             "name": "Get SKU complement by SKU complement ID",
@@ -14914,7 +14914,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3a9c76ab-d57d-4af9-a818-623bbac6ebf9",
+              "id": "0b44e40d-6a38-47e7-ac96-3c9cb3bed08b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14982,7 +14982,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bd782e4d-b71b-428d-bb1c-14ca3092a115",
+                "id": "23b08092-891f-467f-b2fe-2f9998c67284",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skucomplement/:skuComplementId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14998,7 +14998,7 @@
           }
         },
         {
-          "id": "537d5003-5872-4214-aa75-6ff82c153521",
+          "id": "391c1687-0104-4624-9b3e-e19fdcdd4f3c",
           "name": "Delete SKU complement by SKU complement ID",
           "request": {
             "name": "Delete SKU complement by SKU complement ID",
@@ -15059,7 +15059,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "59c161b0-eecf-46ee-ae06-c8fe8d5817d7",
+              "id": "3341a9eb-7c13-410e-a784-5025993568fb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15117,7 +15117,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8261b3e2-2e3c-4074-ae41-e6915dbcbb38",
+                "id": "4ad25395-22ff-4e50-9760-c2f51b43ed23",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skucomplement/:skuComplementId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15133,7 +15133,7 @@
       "event": []
     },
     {
-      "id": "d9263f74-634b-4f55-aeef-01f81b7a51e2",
+      "id": "02e690f1-9b42-4343-a0e3-215f45c44981",
       "name": "Non-structured specification",
       "description": {
         "content": "",
@@ -15141,7 +15141,7 @@
       },
       "item": [
         {
-          "id": "1f9144f4-20da-4372-9eba-ad1cf2c18430",
+          "id": "2f77b378-b5cd-48fc-a3d1-97ea7e44664a",
           "name": "Get non-structured specification by ID",
           "request": {
             "name": "Get non-structured specification by ID",
@@ -15207,7 +15207,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f485d53f-e601-4625-af87-93256a47a886",
+              "id": "24501483-936f-4dd3-be8a-5ed65378f64e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15276,7 +15276,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "418d953e-987e-44f1-a425-08d65521883e",
+                "id": "f035042b-e907-4e93-94ae-1ce7cadf0d6f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/nonstructured/:Id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15292,7 +15292,7 @@
           }
         },
         {
-          "id": "cb9c0dc4-d19f-4b4c-a789-c6c08bdaf5a7",
+          "id": "5683be5e-67f8-4ded-80e5-035b81ff26d7",
           "name": "Delete non-structured specification",
           "request": {
             "name": "Delete non-structured specification",
@@ -15354,7 +15354,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "20580757-d23e-40f6-ba3b-215970392356",
+              "id": "141b793b-df9b-4ccf-9cbe-36780342068f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15413,7 +15413,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "34fa88fe-fc8b-4be7-8c88-0f76fe0c58d2",
+                "id": "7a48cc4b-3b56-4ef1-b5af-aee8c921812c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/specification/nonstructured/:Id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15426,7 +15426,7 @@
           }
         },
         {
-          "id": "50fee0b7-ca6a-4d67-b626-c5aab1d8c50b",
+          "id": "8c07ef4b-3b61-4e92-8046-e59322a1ff7e",
           "name": "Get non-structured specification by SKU ID",
           "request": {
             "name": "Get non-structured specification by SKU ID",
@@ -15490,7 +15490,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "86b22302-e323-4431-bbc0-014c4c76df35",
+              "id": "e3e1cf20-2465-47f7-a2ce-7dcf118306a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15568,7 +15568,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f323281a-63f8-4ece-818a-76079e6ef53f",
+                "id": "5a45ca5f-1cd8-4264-b6be-e37a53b3fc84",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/nonstructured - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15584,7 +15584,7 @@
           }
         },
         {
-          "id": "8e2ec1a7-11bd-4959-a627-05cbd3937851",
+          "id": "1a92f187-611b-47f1-8919-3583561e588d",
           "name": "Delete non-structured specification by SKU ID",
           "request": {
             "name": "Delete non-structured specification by SKU ID",
@@ -15644,7 +15644,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "de16c066-c2eb-42b6-a343-747e92bd2a9b",
+              "id": "f38d50d8-866b-405c-84ec-70397539c329",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15712,7 +15712,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6b60f3ff-4516-4150-8a96-e70b39ef353f",
+                "id": "f033ef29-4ef0-4cc9-8c32-a385dac03097",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/specification/nonstructured - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15728,7 +15728,7 @@
       "event": []
     },
     {
-      "id": "93dd2973-82d8-41ae-aa83-28a9bd2190f5",
+      "id": "9151b87e-8027-4932-874a-290acfdf6d38",
       "name": "Specification field",
       "description": {
         "content": "",
@@ -15736,7 +15736,7 @@
       },
       "item": [
         {
-          "id": "4d2541b9-3854-479c-8e5e-85c3af8c9599",
+          "id": "a86be269-94ac-41fb-9409-f413f08440ff",
           "name": "Get specification field",
           "request": {
             "name": "Get specification field",
@@ -15802,7 +15802,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "085e220e-4a94-4759-8864-54c5b36ac877",
+              "id": "935186e7-27a3-44ed-8851-8ce4fd3c974f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15871,7 +15871,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "af9c821a-3daf-4607-b9e9-d7ac754b88aa",
+                "id": "a5f89f41-ef4b-48b7-9f05-be7238bd944f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/fieldGet/:fieldId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15887,7 +15887,7 @@
           }
         },
         {
-          "id": "4008127f-f833-4972-a74a-bf043d9cb514",
+          "id": "7811839f-b46a-48f0-988d-155b041c5ead",
           "name": "Create specification field",
           "request": {
             "name": "Create specification field",
@@ -15954,7 +15954,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "232b099c-73cb-456c-872d-8faaffb33cb4",
+              "id": "ee2333d6-aa6b-498e-9d77-d80ef12f8951",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16035,7 +16035,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3209f694-a782-4f29-9c29-ecf2643a71a2",
+                "id": "ae0abbf6-6127-4a18-8b0f-492828ba4295",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/specification/field - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16051,7 +16051,7 @@
           }
         },
         {
-          "id": "7e875683-d858-4397-95ea-87feac079269",
+          "id": "b4e6394d-5631-46a4-bee3-4902a9a5ebf9",
           "name": "Update specification field",
           "request": {
             "name": "Update specification field",
@@ -16118,7 +16118,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c0061195-9066-464f-9534-9793d6fe9c6c",
+              "id": "c8a7dee1-7fab-4d7f-beb9-cd7ae4df62f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16199,7 +16199,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "30733728-2a63-4997-8138-aedad956af76",
+                "id": "518844d4-ce48-41b0-872f-8d7991f14942",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/specification/field - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16218,7 +16218,7 @@
       "event": []
     },
     {
-      "id": "515566a3-0c8d-40c3-bc3a-9a3507e6b795",
+      "id": "394c2fb0-b0d4-4c06-b346-fd7446915100",
       "name": "Specification group",
       "description": {
         "content": "",
@@ -16226,7 +16226,7 @@
       },
       "item": [
         {
-          "id": "a641e033-69eb-4a45-a586-c9a7b2578937",
+          "id": "42733321-deb0-4b9d-9c39-8cd5d9f9547c",
           "name": "List specification group by category",
           "request": {
             "name": "List specification group by category",
@@ -16292,7 +16292,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "cf526399-f39c-44d4-b14a-b51893cdc075",
+              "id": "7f5fc300-aae4-434f-93e5-c42592a8c5f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16361,7 +16361,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0694e17e-1d22-41ad-bf97-5832c3ef9ad3",
+                "id": "f38a62b8-72de-4ccc-aaa6-211f9bb153cd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/specification/groupbycategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16377,7 +16377,7 @@
           }
         },
         {
-          "id": "5f8165a4-453a-4e90-a4db-f85cbdb11655",
+          "id": "317d2953-457a-4ccb-bc0b-b4e367a238d1",
           "name": "Get specification group",
           "request": {
             "name": "Get specification group",
@@ -16443,7 +16443,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6be50c7d-9a7b-47f4-affd-1ace4ee73a5d",
+              "id": "09be13d5-1a50-4b50-b847-1560184bc4e6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16512,7 +16512,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "58ab0c21-371c-4213-9988-72998f3a58a1",
+                "id": "f23a851c-7bcb-4a64-b03d-2bcc3a5c6aa9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/groupGet/:groupId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16528,7 +16528,7 @@
           }
         },
         {
-          "id": "5be2dcda-8c23-4790-9691-9696d2b80b28",
+          "id": "838ea4a6-f619-48b9-bc4e-c690cd1d3452",
           "name": "Create specification group",
           "request": {
             "name": "Create specification group",
@@ -16594,7 +16594,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dcf9dbf0-4675-448e-a2d2-586de3876c4d",
+              "id": "3b87fd19-daea-4e99-93fe-74e8e585069b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16674,7 +16674,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a2d881a0-9de3-41a3-8583-43b20d33b129",
+                "id": "b32dd6b2-4fb1-4036-b600-eb3ea78d9cae",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specificationgroup - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16690,7 +16690,7 @@
           }
         },
         {
-          "id": "c85b088b-c492-44bb-964f-f30f5493671e",
+          "id": "ae5ae5bf-4430-49d5-bc99-d508ef26de68",
           "name": "Update specification group",
           "request": {
             "name": "Update specification group",
@@ -16768,7 +16768,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0b80e020-02f0-4b88-9443-0c12aa2cdef0",
+              "id": "af0e3793-136e-4079-9184-5fd3fb5fbe76",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16849,7 +16849,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1fe50780-9cc5-404c-b67a-b99cacba9a46",
+                "id": "341c58b6-37c0-4d36-a5d1-51310193966e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationgroup/:groupId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16868,7 +16868,7 @@
       "event": []
     },
     {
-      "id": "34d04d8c-c1d8-44fc-b749-cdd311025b23",
+      "id": "72334c33-cf73-4a55-a265-94ef79fc68f3",
       "name": "Specification value",
       "description": {
         "content": "",
@@ -16876,7 +16876,7 @@
       },
       "item": [
         {
-          "id": "505b596d-0bac-492b-b91c-e26a39212b2b",
+          "id": "fe2581ae-3cb3-4e5e-abfe-4c00b8510177",
           "name": "Get specification value",
           "request": {
             "name": "Get specification value",
@@ -16941,7 +16941,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1fb98902-cd98-42b8-aa6a-78f861c08100",
+              "id": "68fe8ad6-e52f-4158-9113-e8b8bd7a6815",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17009,7 +17009,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0a676311-2bdf-4924-8c83-14954a8932ad",
+                "id": "96e63bbe-4138-4f6a-8ebd-303f9ad0d8ac",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationvalue/:specificationValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17025,7 +17025,7 @@
           }
         },
         {
-          "id": "206de1c8-8e91-442b-85dc-88a1dfb7fda0",
+          "id": "1855fd5b-731f-4f58-a009-90a1e3639e39",
           "name": "Update specification value",
           "request": {
             "name": "Update specification value",
@@ -17103,7 +17103,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1262fc1a-3a92-4348-9f46-f9ff278bc834",
+              "id": "fee0f2b3-fb02-4808-a358-c8b1934fadbf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17184,7 +17184,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e1527db9-1458-47f3-8ec3-f1258708a017",
+                "id": "5fb04a4f-44a3-4dcc-9723-0ec522793e66",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationvalue/:specificationValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17200,7 +17200,7 @@
           }
         },
         {
-          "id": "56a48217-0218-42cf-b245-b95951d49ff7",
+          "id": "7ba1e35b-37bf-4d1f-8330-caf8bbbcea03",
           "name": "Create specification value",
           "request": {
             "name": "Create specification value",
@@ -17266,7 +17266,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c43d84f8-53fa-4ceb-87e4-93d84083bf04",
+              "id": "5fd47040-1fe6-43d7-9115-715999c79de2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17346,7 +17346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f92d86d2-2184-4ce1-8102-cef015fdc897",
+                "id": "143c4eed-d83f-4b9d-b2a4-c7664e7420a7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17365,7 +17365,7 @@
       "event": []
     },
     {
-      "id": "1ebb5239-28d4-461b-b851-3928efc73291",
+      "id": "c89aa09e-8a1c-432b-a4c4-b8ecfd9de272",
       "name": "Specification field value",
       "description": {
         "content": "",
@@ -17373,7 +17373,7 @@
       },
       "item": [
         {
-          "id": "b791b98e-5c6a-4f4f-a591-b118aa1617b2",
+          "id": "38117166-4af5-4893-a62e-1453bdd2c9a5",
           "name": "Get specification field value",
           "request": {
             "name": "Get specification field value",
@@ -17439,7 +17439,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3ca418a4-730c-4210-89c6-17e7883d76af",
+              "id": "a97845ad-c36f-4baf-9aae-cc907f65a90d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17508,7 +17508,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c5a37d0a-5921-4c6f-a9e6-38fea5bd7ce4",
+                "id": "6986f399-4a72-4376-a466-d14beb972382",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/specification/fieldValue/:fieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17524,7 +17524,7 @@
           }
         },
         {
-          "id": "61763ecc-813f-416d-b627-8f9ade669bfe",
+          "id": "eff2bc8c-ceeb-4f23-9dec-693a23139f13",
           "name": "Get specification values by specification field ID",
           "request": {
             "name": "Get specification values by specification field ID",
@@ -17590,7 +17590,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5a25b596-85d5-45bf-a74f-fb7ad53c234a",
+              "id": "ea7478c7-340c-4cae-8bab-7bd2d34c9c7f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17659,7 +17659,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "31de4b07-9925-40ce-a867-e1e7f4648cbe",
+                "id": "bd8f8e54-d01c-427a-8572-3d3f16112aa6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/fieldvalue/:fieldId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17675,7 +17675,7 @@
           }
         },
         {
-          "id": "d12f7c09-b749-415a-8eff-ba08f28521d5",
+          "id": "c6e405c2-75a5-494a-a930-f26dfd89b846",
           "name": "Create specification field value",
           "request": {
             "name": "Create specification field value",
@@ -17742,7 +17742,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4d1ed4b3-5dd6-40f7-b5cd-4c7d5c1f81d1",
+              "id": "4d5833c1-29e1-418e-9ea4-d24218457a59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17823,7 +17823,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f2407139-b662-48cb-ae30-c17a40fce346",
+                "id": "5f0314f8-66e4-4fe6-bbf2-37b31e10315a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/specification/fieldValue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17839,7 +17839,7 @@
           }
         },
         {
-          "id": "dc93d0fe-4ccd-4d6e-bd2d-582cab78ebbd",
+          "id": "753a6216-8385-4ac2-b6af-1f52fd980e58",
           "name": "Update specification field value",
           "request": {
             "name": "Update specification field value",
@@ -17906,7 +17906,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "45ecd768-37c2-4f49-a248-b62aab859d8d",
+              "id": "9acb5e80-db19-4850-b6ca-ac216a7bf92e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17987,7 +17987,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4ebd0131-bcb9-4512-9608-c9a60fbf3a1e",
+                "id": "8c2f57b0-538b-4e74-8db7-268f5b9d102c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/specification/fieldValue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18006,7 +18006,7 @@
       "event": []
     },
     {
-      "id": "3b3b9a2c-730f-4777-9804-bc508cc276cb",
+      "id": "6790afd4-e26a-40f5-8413-387daf85e51f",
       "name": "Category specification",
       "description": {
         "content": "",
@@ -18014,7 +18014,7 @@
       },
       "item": [
         {
-          "id": "1b3b710b-4a36-42ee-838f-31a5d3e69723",
+          "id": "9f036a0e-4b89-47cc-8ff2-a0c069b1f2cf",
           "name": "Get specifications by category ID",
           "request": {
             "name": "Get specifications by category ID",
@@ -18081,7 +18081,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3b388074-0e52-4e2b-a5c4-ef33437d7e4c",
+              "id": "8b8d29ba-2bbd-4e2c-bbec-d25da2fce4c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18151,7 +18151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e20b6fe6-b77a-4941-a39f-b002574c8339",
+                "id": "e9d20d40-cf04-40ee-a0ca-47a0a2086ef9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/field/listByCategoryId/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18167,7 +18167,7 @@
           }
         },
         {
-          "id": "a69d59cc-e19b-4119-b3e7-7f32a20958cf",
+          "id": "0288ecf3-722c-441d-acf5-f84b42843adf",
           "name": "Get specifications tree by category ID",
           "request": {
             "name": "Get specifications tree by category ID",
@@ -18234,7 +18234,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7d02e71c-7503-44fd-84a4-64d28a81fa74",
+              "id": "46da4f09-9044-4719-b61b-91a56b3533a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18304,7 +18304,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b578cf28-6871-4f06-a4ac-3b092328adaf",
+                "id": "abc3c702-c595-4a13-9a91-0f0e5d5ced51",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/field/listTreeByCategoryId/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18323,7 +18323,7 @@
       "event": []
     },
     {
-      "id": "0594252b-2bfd-487f-9983-639164967fbb",
+      "id": "415c9374-358e-46ed-bed6-0432a48debb1",
       "name": "Specification",
       "description": {
         "content": "",
@@ -18331,7 +18331,7 @@
       },
       "item": [
         {
-          "id": "4b08f73f-decf-4782-9e32-fa4945499229",
+          "id": "6f1bbb52-a722-41cf-ae38-6ec310a54c37",
           "name": "Get specification by specification ID",
           "request": {
             "name": "Get specification by specification ID",
@@ -18396,7 +18396,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9664ae58-71e4-4857-b32b-83e2365d6941",
+              "id": "39d76493-f612-47c5-aa72-dfcb3925ed93",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18464,7 +18464,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5eeef717-e5bf-459d-af4f-0db96810c4bd",
+                "id": "001737d8-e88b-4227-873d-dd189d308021",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18480,7 +18480,7 @@
           }
         },
         {
-          "id": "e521cdf7-42a4-4382-b05d-f2a5b58249d6",
+          "id": "9b1f62a4-2671-4361-87a7-6e4ef7ec8ca7",
           "name": "Update specification",
           "request": {
             "name": "Update specification",
@@ -18558,7 +18558,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ce255043-4d98-485e-9ec1-cce5a40e06e7",
+              "id": "32ee579e-ef0b-4606-b42c-bb4cc2954dae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18639,7 +18639,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a335acb2-3297-4332-bf4c-21e9f6939272",
+                "id": "016fe0da-d196-415d-b64c-635854ec8bb0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18655,7 +18655,7 @@
           }
         },
         {
-          "id": "d2226a38-b506-42f2-a030-368643402970",
+          "id": "c3d5d308-fbd3-4c7f-9cdd-7da56bb04bd4",
           "name": "Create specification",
           "request": {
             "name": "Create specification",
@@ -18721,7 +18721,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7a762662-d3fe-477f-986c-6a011d9c25ca",
+              "id": "0c6049d3-92ab-484e-af64-0f4be27f5379",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18801,7 +18801,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "38119a52-2b9b-44e3-9b0e-2c113e508035",
+                "id": "26f6b156-fb09-47fd-a77c-501d91ac8801",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18820,7 +18820,7 @@
       "event": []
     },
     {
-      "id": "ba7f1fd4-e003-4c5f-a95d-f43bf1347417",
+      "id": "045d9a24-b0ed-4edb-a9a9-11b599b54f73",
       "name": "Subcollection",
       "description": {
         "content": "",
@@ -18828,7 +18828,7 @@
       },
       "item": [
         {
-          "id": "5b620634-85f4-4e1f-bea5-c55e1d795746",
+          "id": "00bc96e5-a3f1-4fad-b32b-228d6d9a7882",
           "name": "Add SKU to subcollection",
           "request": {
             "name": "Add SKU to subcollection",
@@ -18907,7 +18907,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f32ed562-783a-4c99-8ce2-1ee27e8a9442",
+              "id": "ebbf90d4-861b-4e02-95b1-26d56f60aef8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18989,7 +18989,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e2bd80e8-d3a0-46de-88aa-b71dda6160c4",
+                "id": "6d0434f4-9b5f-4742-a3e9-ea2255ff819d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19005,7 +19005,7 @@
           }
         },
         {
-          "id": "76cae780-a9ab-45bc-81c7-a3e91a80defe",
+          "id": "d78bd5cf-504f-495e-853a-a6fa853b12c9",
           "name": "Delete SKU from subcollection",
           "request": {
             "name": "Delete SKU from subcollection",
@@ -19078,7 +19078,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0b00a770-fb5a-402c-9128-1dc2c8f61236",
+              "id": "e9ae6644-e579-4d45-b046-9c38c4ac7821",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19138,7 +19138,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f9bcbaea-0b4d-4009-8340-9182c3c5f9e1",
+                "id": "76502bf2-0e56-4459-b65e-3e772f7af523",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19151,7 +19151,7 @@
           }
         },
         {
-          "id": "8c89f77f-0acf-47fa-9948-07bf22d3a7b9",
+          "id": "a1f29568-6dc1-4527-9327-530772c91554",
           "name": "Associate category to subcollection",
           "request": {
             "name": "Associate category to subcollection",
@@ -19230,7 +19230,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0fc9bd5f-54a1-4984-87de-c75a4be9bdf7",
+              "id": "a42a37eb-7881-4821-968d-3b91a2f6c976",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19312,7 +19312,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "684f1588-425a-4a4a-84f7-b8acd0e84ecd",
+                "id": "352de443-3506-4569-9b53-d8da1c7e442c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/category - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19328,7 +19328,7 @@
           }
         },
         {
-          "id": "3bc6a949-3ee3-4bf7-b317-d5c24440987b",
+          "id": "28afaa87-6dd7-47b5-b95b-06c48c8ba6fb",
           "name": "Delete category from subcollection",
           "request": {
             "name": "Delete category from subcollection",
@@ -19401,7 +19401,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "996f9a9a-5629-442b-bbdb-b2efd9fe3e47",
+              "id": "4e258aab-2102-416e-8d1e-49f56678b5d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19461,7 +19461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "af693d1e-4b96-4b62-9556-b85a6fb04f99",
+                "id": "9c9ea8c4-c874-4a09-b23a-40e9cc944282",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19474,7 +19474,7 @@
           }
         },
         {
-          "id": "a9274a64-a6f2-469c-98cc-b5279b0ee111",
+          "id": "bd9453f2-548b-4ad5-8276-31f853225a85",
           "name": "Associate brand to subcollection",
           "request": {
             "name": "Associate brand to subcollection",
@@ -19553,7 +19553,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a3027620-1d60-4f1f-a392-39ea651d00d9",
+              "id": "39bae14d-75ec-464f-a8fd-c7a75e62bdef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19635,7 +19635,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c14e331e-af69-4499-bd7b-b5f3b2eef74d",
+                "id": "d789cfc0-10d4-4350-af58-2be391e7491b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/brand - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19651,7 +19651,7 @@
           }
         },
         {
-          "id": "62e774b2-7a0c-4773-becd-a6b5a9be23a5",
+          "id": "a79f3e95-5c08-4b31-8c93-6c35cb3bc752",
           "name": "Delete brand from subcollection",
           "request": {
             "name": "Delete brand from subcollection",
@@ -19724,7 +19724,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "767afb89-4bc4-4867-9f46-fbfed49b4694",
+              "id": "5d5f44cd-d2d1-4b28-98fc-728e5467d036",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19784,7 +19784,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8c8d04c9-edc7-4699-8041-e3277f8bed34",
+                "id": "5253da59-1bf7-425a-b749-5b0c0bda886e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19797,7 +19797,7 @@
           }
         },
         {
-          "id": "3fc8b46c-ce87-4d59-a0e6-96df5964e471",
+          "id": "a94c12d4-9c05-47ce-bad5-9821c5dbe868",
           "name": "Get subcollection by collection ID",
           "request": {
             "name": "Get subcollection by collection ID",
@@ -19863,7 +19863,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6f4e0dec-9024-4e95-a15c-d4247dbf4212",
+              "id": "5f7d5579-0fe0-4c21-b322-3ed5923eaf83",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19932,7 +19932,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b0dc71ce-096f-459f-a43e-5e9a811508d3",
+                "id": "ffee0230-e4f8-4fca-9d3b-bc9c98b29e60",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/subcollection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19948,7 +19948,7 @@
           }
         },
         {
-          "id": "c3b9bf7e-3b79-4743-9631-09a0db84a152",
+          "id": "743e17bf-a6e2-48dc-89ed-e8a94af7d54f",
           "name": "Get subcollection by subcollection ID",
           "request": {
             "name": "Get subcollection by subcollection ID",
@@ -20013,7 +20013,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "cbfef596-f73b-4326-8cf7-5575c3b19fa2",
+              "id": "6c00590b-94e8-4c75-aa1b-c15c34a173d5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20081,7 +20081,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6b0d39d2-0f32-481f-877f-127b0a6f84de",
+                "id": "422d6c3d-409d-4526-a05b-f31b5fba2d9d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20097,7 +20097,7 @@
           }
         },
         {
-          "id": "f6aa826a-bf45-4bdf-9b2e-47bef64fbf4a",
+          "id": "62ab02f8-7ca2-4f66-8f1a-9062e9734fb5",
           "name": "Update subcollection",
           "request": {
             "name": "Update subcollection",
@@ -20175,7 +20175,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "810d8c6f-67e1-4845-9ccd-599e31150c90",
+              "id": "9d9afd2c-62c4-45d2-b239-732cf1bf43a6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20256,7 +20256,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "839b5a4d-20e0-4c14-80bd-e531ff553841",
+                "id": "0dfa5fde-78d9-44c1-98de-0ad76cec9c7c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20272,7 +20272,7 @@
           }
         },
         {
-          "id": "c1911ccf-f500-4f5c-b2a8-0794a788caa6",
+          "id": "b2e239be-00ad-4709-9e65-3fc76e0ced6d",
           "name": "Delete subcollection",
           "request": {
             "name": "Delete subcollection",
@@ -20333,7 +20333,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "994d9cf8-9a47-4754-bf85-6b6b3c782511",
+              "id": "39ebecd2-c650-4b10-bd9b-08fad14c629b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20391,7 +20391,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d25a7cde-dee4-48a6-98da-b3a2fb29d962",
+                "id": "8fdf3ab0-448f-4fe4-920b-8d5edb225a64",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -20404,7 +20404,7 @@
           }
         },
         {
-          "id": "cd42345c-b30b-46b8-8c0b-8e338c6b952b",
+          "id": "2ff3a08e-1476-469b-9f57-bde4fb20461d",
           "name": "Create subcollection",
           "request": {
             "name": "Create subcollection",
@@ -20470,7 +20470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "04654609-1bca-4b03-b70f-98e3f0eba776",
+              "id": "cb16b17f-ed5c-4c2c-8498-3ce3f3272504",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20550,7 +20550,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "64494465-e393-4ffc-bd8a-3e2793690703",
+                "id": "aef42b4a-e95d-4cd4-b011-c526c31d1c4a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20566,7 +20566,7 @@
           }
         },
         {
-          "id": "cea32ec2-4a67-42d0-a45d-4be06cce0ed0",
+          "id": "c254b166-fe27-4627-a4fc-8518c2dc7860",
           "name": "Reposition SKU on the subcollection",
           "request": {
             "name": "Reposition SKU on the subcollection",
@@ -20641,7 +20641,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "07772487-8ae5-4fd6-aa3c-f9c22f1680bd",
+              "id": "f6f32183-9c67-4188-93e1-234adcfb149f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20713,7 +20713,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a4e14c09-a484-4863-984d-6a32c7042598",
+                "id": "9e17d6f6-6fc1-4024-a196-56035b1f3014",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/position - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -20726,7 +20726,7 @@
           }
         },
         {
-          "id": "bc380a3d-8b3c-465c-a66c-79c3819522e3",
+          "id": "a3990922-6600-4461-b55d-58205d44dbae",
           "name": "Get specification values by subcollection ID",
           "request": {
             "name": "Get specification values by subcollection ID",
@@ -20792,7 +20792,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6f7cb503-986b-4f39-b1ed-56d8184481a0",
+              "id": "09d256b9-0ee8-4200-90ce-6adcb3e581d6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20861,7 +20861,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c01f3e9d-391c-448f-9760-77824094fb19",
+                "id": "02a4b515-bbf3-44a9-a562-2ceefcc2677e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20877,7 +20877,7 @@
           }
         },
         {
-          "id": "cfcbcbd3-d0d4-4c4f-93f8-00da4f54db9a",
+          "id": "19e2c7f8-e0fb-44d9-8759-94361a4060e8",
           "name": "Use specification value in subcollection by ID",
           "request": {
             "name": "Use specification value in subcollection by ID",
@@ -20956,7 +20956,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "871bf758-4940-438d-b3e9-e25ef16108ba",
+              "id": "2b8b4173-2415-4751-a3ca-5160c0fa8b78",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21038,7 +21038,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c7c105e2-81b7-4572-a1e0-ffed7037f734",
+                "id": "32c4ef66-92ef-4cb8-8028-505602ea7b30",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21054,7 +21054,7 @@
           }
         },
         {
-          "id": "a933a4c8-c843-4e14-9485-ecbd5339c769",
+          "id": "4d119fb4-d845-4783-955d-427cdb01a1e3",
           "name": "Delete specification value from subcollection by ID",
           "request": {
             "name": "Delete specification value from subcollection by ID",
@@ -21116,7 +21116,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c34bccc0-be00-478a-930a-9f1982066b16",
+              "id": "ad83ee49-bae9-467e-b541-967c5476dc8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21175,7 +21175,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c05f9679-d4da-4767-81b2-de0de2cc21f8",
+                "id": "95bc5b1f-c90e-4f7c-9189-407fae48c644",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -21191,7 +21191,7 @@
       "event": []
     },
     {
-      "id": "cbd77fa0-d2e2-4545-90a5-ed5b678a2991",
+      "id": "8cea8db4-c17a-430c-adc8-8011fa15d1a8",
       "name": "Assortment",
       "description": {
         "content": "",
@@ -21199,7 +21199,7 @@
       },
       "item": [
         {
-          "id": "9dbd8d21-6474-42d9-8fca-95e63c260692",
+          "id": "e7d4abca-a5d0-4010-bb04-e7382c0616d9",
           "name": "Create product assortment",
           "request": {
             "name": "Create product assortment",
@@ -21265,7 +21265,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "93b3e80f-0605-44af-8ba6-7cb73635cc75",
+              "id": "d8899700-7167-492c-9cfc-ccd3b91ef0fc",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -21344,7 +21344,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "41d3e33b-2eec-4ad9-86f0-b8eab48e648a",
+              "id": "94210dd2-90e4-4638-958f-8806d8e3acff",
               "name": "Unprocessable Entity",
               "originalRequest": {
                 "url": {
@@ -21424,7 +21424,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8f7454e7-a767-4095-8300-805d41fba59e",
+                "id": "e6f5e054-9156-4329-8bd7-81fced535e4d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21440,7 +21440,7 @@
           }
         },
         {
-          "id": "ae0d192e-fe51-4e88-9ec8-51a1cc70dec5",
+          "id": "8665b48d-58f5-4e87-ba92-88331c26855e",
           "name": "Get all product assortments",
           "request": {
             "name": "Get all product assortments",
@@ -21521,7 +21521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0ec784fe-f83c-4554-ac26-618b338d5983",
+              "id": "bb170fd4-c9c6-4e4e-b91c-ebc4087ddf51",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21616,7 +21616,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5f8014e0-7d59-43ee-8fa1-421f84ecddd4",
+                "id": "bdb76a6f-a9aa-4108-8b1b-f396c6ed6d3b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/assortment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21632,7 +21632,7 @@
           }
         },
         {
-          "id": "9ab46347-ab46-463e-984f-fe15df6f107a",
+          "id": "99cc90b5-93c2-480d-9620-debc87420e32",
           "name": "Get product assortment by ID",
           "request": {
             "name": "Get product assortment by ID",
@@ -21688,7 +21688,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "03c1f39b-c1a2-42d8-ab2e-9528d14b0466",
+              "id": "eec8e86c-0c8a-492e-af7a-b82276bbab2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21746,7 +21746,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d754606d-22a6-4079-a79f-f1c473a68d27",
+              "id": "4af65da6-a216-4751-b36c-1dda721c59ff",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -21805,7 +21805,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "964c7de7-5f1d-453f-8142-a75bf098df7b",
+                "id": "e97005c0-dec2-4596-ad6e-1bf00f11ac73",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21821,7 +21821,7 @@
           }
         },
         {
-          "id": "5f45daf4-050a-49a0-9e26-c60032140889",
+          "id": "293bacf5-05b8-4547-af2e-66315d4dfa8f",
           "name": "Update product assortment",
           "request": {
             "name": "Update product assortment",
@@ -21899,7 +21899,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d2e2ed3d-20cd-4996-a415-e428188b2f69",
+              "id": "6b96fad1-4a99-492c-8039-1ec857b189b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21979,7 +21979,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ef4f7857-bed8-4aba-a1a3-b4350d382bd3",
+              "id": "642adb8c-3d82-4373-9446-3d6d0016ae23",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22059,7 +22059,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "17eb18ee-85f1-4959-88f0-f00d019c7db6",
+              "id": "79aaa592-74b3-4e5f-8cca-0043cad06fa5",
               "name": "Unprocessable Entity",
               "originalRequest": {
                 "url": {
@@ -22140,7 +22140,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b90cedae-ec92-40b3-ad83-9e65b198bc9f",
+                "id": "938261ef-e8f9-4c00-90dc-217064226ebd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22156,7 +22156,7 @@
           }
         },
         {
-          "id": "05ac42cb-6bd5-46ee-873f-2f58a946438b",
+          "id": "84e8e957-a3c0-46d3-a799-00546632731d",
           "name": "Delete product assortment",
           "request": {
             "name": "Delete product assortment",
@@ -22212,7 +22212,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bb849b93-288f-4775-803d-a04167169e21",
+              "id": "5da42a38-8638-4291-ba3a-e2b314dc9436",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22270,7 +22270,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6370d2d0-08f2-47b7-927a-4f22e2e7f5a3",
+              "id": "f671eba7-09c7-4aa8-8a8f-8f940b7e03e4",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -22328,7 +22328,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "835c1afe-cd85-463c-a876-1e1b48253fc9",
+              "id": "bf5f32b6-e445-445e-8f50-30b12f9d5ec6",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22387,7 +22387,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45b6e613-5d1c-40f4-881a-77d26b0270ed",
+                "id": "abe52513-91c0-46ac-8ff8-51f2f9633e9a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22403,7 +22403,7 @@
           }
         },
         {
-          "id": "681bfccb-03f5-49e0-b043-64a7919c54f7",
+          "id": "3ce536a8-0a06-497f-8497-43b51a7310e6",
           "name": "Add included collection to product assortment",
           "request": {
             "name": "Add included collection to product assortment",
@@ -22471,7 +22471,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "55d1767b-c1db-4cd6-bd75-3886cd1d1ce4",
+              "id": "71d1c2f4-8626-43f0-9b96-b6d1216add07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22531,7 +22531,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c77a50cf-f1aa-461c-bcdd-fecb16bdf98e",
+              "id": "b2f2644d-ee29-44ea-88fd-dc723fed628a",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -22592,7 +22592,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3e3eb5d0-70eb-4a5b-a584-1671138e00de",
+                "id": "e59183c6-6dde-4c38-b23f-55436220973d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment/:productAssortmentID/included-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22608,7 +22608,7 @@
           }
         },
         {
-          "id": "cfd5d2ca-a0d7-4d56-ab95-6f5f8ddee47b",
+          "id": "1f034428-10ce-4578-815a-cd9583488338",
           "name": "Remove included collection from product assortment",
           "request": {
             "name": "Remove included collection from product assortment",
@@ -22676,7 +22676,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7c45ff5d-fb46-4d11-9a02-80401e87ccc0",
+              "id": "d85e9116-d1d1-4bab-bc88-2b4d58fd1db7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22736,7 +22736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "384b7886-1151-414b-9eae-8daf5d860918",
+              "id": "6690d44a-7185-4787-a3c4-22e0ee11610b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22797,7 +22797,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cd6e18a3-5e80-4732-84a7-f5cf5628fafc",
+                "id": "45b36268-3d90-4368-9891-fa18a63b8b3f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID/included-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22813,7 +22813,7 @@
           }
         },
         {
-          "id": "ea358583-e363-48e6-8e93-422e43524ba6",
+          "id": "7a601b44-a18b-457a-bb27-4def488c69d8",
           "name": "Add excluded collection to product assortment",
           "request": {
             "name": "Add excluded collection to product assortment",
@@ -22881,7 +22881,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dade3ba3-1420-4934-af6e-fa2afa93fc34",
+              "id": "4a8b9c06-7af9-4b2b-975a-82029a93fb76",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22941,7 +22941,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6c13bc7d-ee93-463b-bdf8-ce987b438500",
+              "id": "c8ac96e8-09f1-4a44-b806-9a498328004d",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -23002,7 +23002,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a9e554df-bf15-455f-9358-5c5e12f3e285",
+                "id": "063e3e8d-edda-47f4-b3b5-7b942c56e371",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment/:productAssortmentID/excluded-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23018,7 +23018,7 @@
           }
         },
         {
-          "id": "1b73ef62-7ad8-4f1d-b743-e8b501c45923",
+          "id": "648b1384-ae8a-4f23-873b-257f057ce947",
           "name": "Remove excluded collection from product assortment",
           "request": {
             "name": "Remove excluded collection from product assortment",
@@ -23086,7 +23086,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0c1ec01c-a987-40c5-97f9-d2b156df630c",
+              "id": "4356fb93-a701-4b2f-985e-f48eb435c1d2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23146,7 +23146,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3c42455f-b778-46e3-bb94-a6e2da0283e0",
+              "id": "1ecb1cc4-7bb3-4833-951f-7f515048455f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -23207,7 +23207,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a8273724-f9da-4aa4-9b88-763e6945c4fc",
+                "id": "9222a2e6-544d-426f-9590-e75332e12728",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID/excluded-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23226,7 +23226,7 @@
       "event": []
     },
     {
-      "id": "1f5d39c6-0bbd-42c1-85f3-959e43bc7110",
+      "id": "0fe7a5bd-bd11-40c8-b6af-3f55b06a2f36",
       "name": "Collection",
       "description": {
         "content": "",
@@ -23234,7 +23234,7 @@
       },
       "item": [
         {
-          "id": "b89b4d90-a705-48eb-a3d8-3f37102d3424",
+          "id": "c45a876d-bb6c-4a9a-b32f-4e28451f6837",
           "name": "Get all inactive collections",
           "request": {
             "name": "Get all inactive collections",
@@ -23288,7 +23288,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e248d90a-a47a-4dad-a886-52c36e247e35",
+              "id": "5e7dbfaa-8c36-4597-bc86-24f0f1d7e534",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23356,7 +23356,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d10f9bd3-6eb0-4716-b5e8-ab61e055180e",
+                "id": "6eff2e1d-2a6a-4505-99cd-a22724e8ce48",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/inactive - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23372,7 +23372,7 @@
           }
         },
         {
-          "id": "507726b4-4738-4a03-94b1-da270779f4eb",
+          "id": "bbdf2a85-a533-4890-8df1-e23b416e7f61",
           "name": "Create collection",
           "request": {
             "name": "Create collection",
@@ -23424,7 +23424,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": -18504615.878519416,\n  \"Type\": -93214454.76493557\n}",
+              "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": 96462598.64613372,\n  \"Type\": -69511683\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -23438,7 +23438,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5745f425-5fb2-4e8b-a519-db1918b09627",
+              "id": "7bba6974-bb52-4bba-953a-7bc6d72ee561",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23493,7 +23493,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": -18504615.878519416,\n  \"Type\": -93214454.76493557\n}",
+                  "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": 96462598.64613372,\n  \"Type\": -69511683\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -23518,7 +23518,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5eb16098-e552-42c6-a05c-7c66d9e93150",
+                "id": "ff760e17-c609-471e-b5b4-a6cb26d5e49d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23534,7 +23534,7 @@
           }
         },
         {
-          "id": "ac3d80dd-2fcd-46b6-80f2-e58b931f3024",
+          "id": "f69dfb28-837e-425b-a8f3-67b5b78ae96d",
           "name": "Import collection file example",
           "request": {
             "name": "Import collection file example",
@@ -23580,7 +23580,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "54ac06ff-0e5b-4f95-acf7-1bbe2a24749d",
+              "id": "15bbaf1e-acb5-436c-a712-0d3fce88e789",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23640,7 +23640,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "15aca668-ae05-40e8-9a43-d0373aca0164",
+                "id": "a1bfa693-583d-4a70-8577-19cf1667cf4f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/stockkeepingunit/importfileexample - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23654,7 +23654,7 @@
           }
         },
         {
-          "id": "b58d9b8d-6471-4b06-a019-4f8d64691088",
+          "id": "63d508ef-1f2c-49a7-8826-064e6cc72ecc",
           "name": "Add products to collection by imported file",
           "request": {
             "name": "Add products to collection by imported file",
@@ -23734,7 +23734,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "79d7f818-5d7f-4ade-9721-41e18e868cca",
+              "id": "1feae8e3-d17d-4388-8f36-c2234dd9fef3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23811,7 +23811,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5984e6f2-c1b6-4fa9-ba9b-407df3bca6b9",
+                "id": "1c9836f0-9191-4fa8-bfea-3f3ba4ba2699",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/stockkeepingunit/importinsert - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -23824,7 +23824,7 @@
           }
         },
         {
-          "id": "321b22ee-2585-44c2-87c6-7d1295998dc1",
+          "id": "45caf4da-73ee-4af7-8032-3a7d07afc865",
           "name": "Remove products from collection by imported file",
           "request": {
             "name": "Remove products from collection by imported file",
@@ -23904,7 +23904,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cb9e6602-3529-4662-bd6a-788e42609a79",
+              "id": "fe2a686e-835f-470e-9781-d7353216f0bb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23981,7 +23981,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4a423371-b043-4f73-bb62-9bcc13c6e924",
+                "id": "48021f71-4c02-4e68-89b5-a61ce2f138f1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/stockkeepingunit/importexclude - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -23994,7 +23994,7 @@
           }
         },
         {
-          "id": "4974c91f-b353-4f84-8d04-ce3fa8128dfe",
+          "id": "5be991c7-1b7a-4e6d-aade-be6770e88feb",
           "name": "Get products from a collection",
           "request": {
             "name": "Get products from a collection",
@@ -24178,7 +24178,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8021bf31-5ca8-470c-986b-c75c18e0b77b",
+              "id": "5661767d-871f-430f-8aaf-a523662bc26f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24365,7 +24365,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3ff9cc93-8efa-45cd-aabc-f8d0a2382fcb",
+                "id": "6fde97b1-fb2d-4cb3-964b-ed90fa920907",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24381,7 +24381,7 @@
           }
         },
         {
-          "id": "6f5f2315-00bf-4553-9fe3-fd5d25bee857",
+          "id": "59967d79-9cae-4b42-8f9d-76ec0b730d06",
           "name": "Get collection by ID",
           "request": {
             "name": "Get collection by ID",
@@ -24446,7 +24446,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ecf76140-6717-4991-b44e-74bd31cbd718",
+              "id": "0ab4df78-a31c-438d-ab99-72046beea668",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24514,7 +24514,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be8078e7-f270-4cd2-a202-9902b0ebc3cb",
+                "id": "2d371ef1-bf72-4adc-a010-d1a076b61faf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24530,7 +24530,7 @@
           }
         },
         {
-          "id": "e754836b-0b85-44e4-848e-c7fa948a5581",
+          "id": "02e06878-73ad-4f55-995c-4b1b34e35faa",
           "name": "Update collection",
           "request": {
             "name": "Update collection",
@@ -24608,7 +24608,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ed3fa146-99ae-4282-9720-7d887468b4cd",
+              "id": "11c631ad-0bc8-469c-8152-5f3a356fd582",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24689,7 +24689,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0d397c08-0d4d-4153-9018-f67e91e4b40b",
+                "id": "0cb483c0-e7f5-45f3-8897-ab32c84bbc61",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24705,7 +24705,7 @@
           }
         },
         {
-          "id": "c91d3f71-d277-4c5b-81cd-b201272926e6",
+          "id": "39503d9f-ac79-42d4-83d4-ab2f45516f1f",
           "name": "Delete collection",
           "request": {
             "name": "Delete collection",
@@ -24766,7 +24766,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e6704970-d1d8-4a99-808a-337206a617ae",
+              "id": "c1f0bb96-707e-47fc-89e7-5bfaafc601aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24824,7 +24824,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "37ab6135-fdf5-4e32-b441-8b3f408ec6c2",
+                "id": "08c498e0-455d-4f19-9a2b-8d8e475a0efc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -24840,7 +24840,7 @@
       "event": []
     },
     {
-      "id": "4b1ea72f-6e06-4bf3-815b-6f52d15397bc",
+      "id": "75193b55-b405-4208-afab-49aa1b11e9cd",
       "name": "Supplier",
       "description": {
         "content": "",
@@ -24848,7 +24848,7 @@
       },
       "item": [
         {
-          "id": "d6f82be5-1285-493a-a323-2757fa035fff",
+          "id": "d2b4ada9-17dd-423e-b59e-896729a1de3b",
           "name": "Create supplier",
           "request": {
             "name": "Create supplier",
@@ -24914,7 +24914,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b804da7a-aafd-4962-8034-9b6577704234",
+              "id": "22faf26f-2474-45ba-a7c5-05940c2d39bf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24994,7 +24994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d5465cea-1d43-491d-85c7-028c5c395b68",
+                "id": "96e5247c-a001-40ff-a181-fae2ea3c3679",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/supplier - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25010,7 +25010,7 @@
           }
         },
         {
-          "id": "b822bc9a-e3df-45a9-b8fb-c8daf01b1687",
+          "id": "a5c47c0b-9f1f-4f3b-b295-7c3cb7213940",
           "name": "Update supplier",
           "request": {
             "name": "Update supplier",
@@ -25088,7 +25088,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bc7b1324-2c7b-4caf-8e29-1f4b31c61e69",
+              "id": "fa301e0d-e17a-4cce-9131-8d789bce26ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25169,7 +25169,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bfbc9d7f-4786-4570-ab1a-c417dd164528",
+                "id": "cf6833d1-9238-4284-9bba-c3c60e3eb4ea",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/supplier/:supplierId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25185,7 +25185,7 @@
           }
         },
         {
-          "id": "f503579a-bc24-48bb-beb6-7895bebf94e9",
+          "id": "3f4226e6-5637-4b1e-b2fc-b58850aee86a",
           "name": "Delete supplier",
           "request": {
             "name": "Delete supplier",
@@ -25246,7 +25246,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4aabfe93-630d-4355-8418-6da4881c6dd8",
+              "id": "34d37de9-b7ee-4bff-b0c3-e4de0a518443",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25304,7 +25304,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7c505ac8-3837-4a77-8dff-ea78d603c162",
+                "id": "bda347ae-39c1-4e46-a38a-13846c2d41c0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/supplier/:supplierId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -25320,7 +25320,7 @@
       "event": []
     },
     {
-      "id": "ba06b7b0-cf4f-45ef-b515-13050a01f02c",
+      "id": "59f728a9-5385-4a36-9589-9922a5d6d974",
       "name": "Sales channel",
       "description": {
         "content": "",
@@ -25328,7 +25328,7 @@
       },
       "item": [
         {
-          "id": "41d03f15-ec07-4293-8799-4b6ffd35db61",
+          "id": "dbdd3002-290f-4b9f-9a29-a537d28e7f07",
           "name": "Get sales channel list",
           "request": {
             "name": "Get sales channel list",
@@ -25382,7 +25382,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "28fa3a34-c16d-4573-a59f-bc1ede0f1488",
+              "id": "dd775990-b424-4067-b2db-003685d78093",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25450,7 +25450,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "23676faa-ea34-4dc4-b7fd-20156bf5bb0b",
+                "id": "aa546b72-f695-4546-a532-b01373c3422c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/saleschannel/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25466,7 +25466,7 @@
           }
         },
         {
-          "id": "e0ea1774-363b-4629-b6a8-a18d92ccff18",
+          "id": "c002b7e6-6eb0-49f7-9486-e9721578ba4b",
           "name": "Get sales channel by ID",
           "request": {
             "name": "Get sales channel by ID",
@@ -25531,7 +25531,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "073dcb08-92e8-42a2-8c97-b74e49536222",
+              "id": "8ec5115c-c7b7-49f4-b56e-3e2ec71ebd60",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25599,7 +25599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3a9c198d-ff46-4e80-b6f5-32f07e8f1e3e",
+                "id": "016bfb70-ea84-4c48-8fa5-4d0639189ad5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/saleschannel/:salesChannelId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25615,7 +25615,7 @@
           }
         },
         {
-          "id": "e991356c-8e1e-4da1-a153-bfbd7426cdde",
+          "id": "3a57bc0d-c104-4b24-8ab8-c48bc47315a0",
           "name": "Get sales channel by product ID",
           "request": {
             "name": "Get sales channel by product ID",
@@ -25681,7 +25681,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fa6ead6d-ff50-4a08-98bd-b9ddb99c57b9",
+              "id": "21ad1bdf-438b-4c77-adcb-494ffd931c8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25750,7 +25750,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1b773ae7-d2fc-4fda-9807-3b00bcd2a391",
+                "id": "bd9c881a-764c-463b-9f97-fa86f1f3cc28",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/salespolicy - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25766,7 +25766,7 @@
           }
         },
         {
-          "id": "46100b16-63a5-43f1-8a90-cc34c006fb3a",
+          "id": "61de5677-0512-4b89-8dc6-4691438a441d",
           "name": "Associate product with sales channel",
           "request": {
             "name": "Associate product with sales channel",
@@ -25839,7 +25839,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d0660c16-2c70-455a-82b8-f3450d997562",
+              "id": "bfe245e6-e4fb-41bf-9826-74a78bd1930a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25899,7 +25899,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "47498d11-1d66-4d68-a130-5c7e2583f6ac",
+                "id": "f035e226-1d4f-4105-b2a9-2c356c4b5a4b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/salespolicy/:tradepolicyId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -25912,7 +25912,7 @@
           }
         },
         {
-          "id": "3041a5d3-dc14-4d25-81d3-51032ec716d8",
+          "id": "7ec6259a-76fb-4447-97a0-7b5607b2dd67",
           "name": "Remove product from sales channel",
           "request": {
             "name": "Remove product from sales channel",
@@ -25985,7 +25985,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "878f3e8b-82fe-4887-bc6a-be8b31ad409c",
+              "id": "f0d6b660-3561-404d-9bdf-7f618fdc6910",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26045,7 +26045,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d031b0fd-6eb4-4ee9-8d6f-00a323e6043b",
+                "id": "fc874477-38e8-4d15-8c2b-37596d430a84",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/salespolicy/:tradepolicyId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -26058,7 +26058,7 @@
           }
         },
         {
-          "id": "e94147dc-84bb-431a-b1b3-e05a900fbebc",
+          "id": "fbcc5d5c-3af3-4882-86a5-e4f087a76e3e",
           "name": "List all SKUs in a sales channel",
           "request": {
             "name": "List all SKUs in a sales channel",
@@ -26149,7 +26149,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "40e0b39d-73ec-4452-a242-ed00fe2cb1c4",
+              "id": "b84435bf-fd54-4366-8e07-0bcbc02725a4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26254,7 +26254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9b0ed08c-0ad0-4be3-8e31-b0b4ef40a22e",
+                "id": "b63834bf-819f-4863-b1f3-293486bdd6be",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitidsbysaleschannel - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26273,7 +26273,7 @@
       "event": []
     },
     {
-      "id": "8506a94b-06e3-4cc7-b841-8bfc115e240b",
+      "id": "73b2500e-275b-4978-b3f0-392422239e7e",
       "name": "Seller",
       "description": {
         "content": "",
@@ -26281,7 +26281,7 @@
       },
       "item": [
         {
-          "id": "f85fa6f3-09f9-45d7-98ac-ac50da9e9459",
+          "id": "1af609c0-537d-45da-8f3b-37229e64cf9e",
           "name": "Get seller list",
           "request": {
             "name": "Get seller list",
@@ -26363,7 +26363,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b22debe5-f815-4fd1-b45a-3d41b22a6e5f",
+              "id": "ec1f5711-956d-4935-8b76-6ca63ceb1704",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26459,7 +26459,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d04eb792-4782-4e8c-bd97-017596f288e4",
+                "id": "99ca13f4-0fec-4cf8-9609-defc8a33703b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/seller/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26475,7 +26475,7 @@
           }
         },
         {
-          "id": "e44c56ac-6053-450a-a132-3a4056f58ffa",
+          "id": "b5430deb-1044-43ce-b99e-7bd4713fa25c",
           "name": "Get seller by ID",
           "request": {
             "name": "Get seller by ID",
@@ -26540,7 +26540,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "33533115-42ad-49ab-970c-af6611d1a2e3",
+              "id": "80bd28c9-af0a-4693-88c3-8cbad71db507",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26608,7 +26608,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "005decbe-9c85-47f5-9718-0313b89a6420",
+                "id": "1b948a25-3b30-4aaa-980f-e8020d728fac",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/seller/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26624,7 +26624,7 @@
           }
         },
         {
-          "id": "3f63095f-4281-4473-b7e5-9110fe8f0371",
+          "id": "2be6ce0a-bc1b-498a-83fa-e5756f9dd475",
           "name": "Update seller",
           "request": {
             "name": "Update seller",
@@ -26690,7 +26690,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "92bfa5a6-989f-4e75-a29b-5bfdf1656fb9",
+              "id": "e5c89539-1780-4551-99e8-d9ffe0476604",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26770,7 +26770,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "434dc46e-694e-4c9e-86cc-bc14f7e13c50",
+                "id": "6ff6c7c5-36d3-400f-87a5-b0df14d1bef9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/seller - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26786,7 +26786,7 @@
           }
         },
         {
-          "id": "cd61dd29-21cc-4b04-859b-650dab1434bc",
+          "id": "853d6abb-f542-4a4d-9cce-8a085da8c119",
           "name": "Create seller",
           "request": {
             "name": "Create seller",
@@ -26852,7 +26852,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e779dbd3-a9ce-4d40-b2f9-fd5780c30f4d",
+              "id": "62295ad6-e168-46cd-b2f7-d63cc6ed870d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26932,7 +26932,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "20b9ae62-b045-421d-8af1-87b1abb96bb9",
+                "id": "68b8ad2a-8c9d-471d-8a07-7f553e82aac1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/seller - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26948,7 +26948,7 @@
           }
         },
         {
-          "id": "a61223f2-94f4-4eb0-b6c3-e2138d1eb5bc",
+          "id": "2d8703ee-265e-488f-896b-912abc0da22e",
           "name": "Get seller by ID",
           "request": {
             "name": "Get seller by ID",
@@ -27013,7 +27013,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "73dbc467-31f5-437d-943e-374f3f7882f5",
+              "id": "a9c2f4db-0150-4abb-8daf-c0b822b0efd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27081,7 +27081,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c710d73f-9434-4dc1-ab20-e21e5d902174",
+                "id": "fc1a1270-5c10-4e2d-8272-4aa900385c72",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sellers/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27100,7 +27100,7 @@
       "event": []
     },
     {
-      "id": "f2303a2f-ca7e-47d8-a7a2-aaacedcaade5",
+      "id": "e1387b66-11b8-48ee-82ce-e4aad3c73078",
       "name": "SKU seller",
       "description": {
         "content": "",
@@ -27108,7 +27108,7 @@
       },
       "item": [
         {
-          "id": "2cf05397-698f-450c-9843-96bb41c6195d",
+          "id": "19302f19-cdc4-465b-9454-47582a75eace",
           "name": "Get details of a seller's SKU",
           "request": {
             "name": "Get details of a seller's SKU",
@@ -27184,7 +27184,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d8e88c8d-0cf5-4554-afa0-2a9c70a8ea39",
+              "id": "33aba400-1323-409a-85c0-5d8412474596",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27253,7 +27253,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f3c37137-a17e-42fd-b61e-8d4fe8a40d46",
+                "id": "d7979c89-5018-4aad-93ad-d947c580bab0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/skuseller/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27269,7 +27269,7 @@
           }
         },
         {
-          "id": "e9af789c-957a-4fa3-86d3-c58d16c62672",
+          "id": "26db6438-d057-4176-93e9-f3ffbc327d7f",
           "name": "Remove a seller's SKU binding",
           "request": {
             "name": "Remove a seller's SKU binding",
@@ -27342,7 +27342,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "13b20d2d-bad8-41b8-bc58-d425da11e05b",
+              "id": "a39c7fd9-1151-4a5c-a5fb-d3c21ef5b40e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27402,7 +27402,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d1c6f903-fb8d-4ef8-8b8c-68b39b067762",
+                "id": "fb078d75-8e75-4ebb-841f-eaa870798d86",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/remove/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -27415,7 +27415,7 @@
           }
         },
         {
-          "id": "66a632f3-e84b-4b57-8fe7-a2bc86bff881",
+          "id": "441a6992-51a5-4567-a621-ecec23a21815",
           "name": "Change notification with seller ID and seller SKU ID",
           "request": {
             "name": "Change notification with seller ID and seller SKU ID",
@@ -27488,7 +27488,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2f2dd6bf-008c-4410-969e-f0e48cbc2802",
+              "id": "c10c780c-0b98-4b2e-96b9-b50983f98a1b",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -27548,7 +27548,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3f9494b5-4294-4011-b79a-50bebba21d3e",
+                "id": "2d288684-ebc2-4f21-b4d7-b08be3e69258",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/changenotification/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27562,7 +27562,7 @@
           }
         },
         {
-          "id": "ca8a7985-3e27-4ee2-9758-534bf0a8493e",
+          "id": "a1a73694-f355-4083-87fa-fe56e054ec10",
           "name": "Change notification with SKU ID",
           "request": {
             "name": "Change notification with SKU ID",
@@ -27628,7 +27628,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e254fffd-1086-4135-9a23-ea77b60626cc",
+              "id": "674be70e-bff5-440f-aae8-092254b0fff0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27686,7 +27686,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ed99552c-7a9b-4f4d-8b78-8abd9d8504cb",
+              "id": "ff7c8f46-4871-4d91-b61b-b24aec37658d",
               "name": "Forbidden",
               "originalRequest": {
                 "url": {
@@ -27744,7 +27744,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5cdb4963-b5c7-4859-b947-110bcfdbb05e",
+              "id": "541904f5-7e19-4e76-a805-d355087f531a",
               "name": "Not found",
               "originalRequest": {
                 "url": {
@@ -27812,7 +27812,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "35ae660c-59d0-4f70-8897-deb36f2dc91a",
+              "id": "4a44d065-8bb4-4a67-82c7-559f8aa41883",
               "name": "Too many requests",
               "originalRequest": {
                 "url": {
@@ -27871,7 +27871,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "47d53f6e-6bd3-4767-a25f-d58039de3043",
+                "id": "ad1ecddf-c06a-4e19-8ec2-a2195c39f06f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/changenotification/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -27887,7 +27887,7 @@
       "event": []
     },
     {
-      "id": "0463abaf-739c-4e2f-9569-ad3627bbc37f",
+      "id": "b237ae47-cc2a-4b87-9196-fcca2134831d",
       "name": "SKU attribute",
       "description": {
         "content": "",
@@ -27895,7 +27895,7 @@
       },
       "item": [
         {
-          "id": "eff414d4-0028-4e40-8459-ec3c59c98264",
+          "id": "b186a6e6-bc9f-42aa-aafa-ff514f797c95",
           "name": "Create SKU attribute",
           "request": {
             "name": "Create SKU attribute",
@@ -27974,7 +27974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9864c9d6-80fa-4b14-82fc-e0fa29a44deb",
+              "id": "bbd18ddf-f1a3-406c-8350-7471a9b084d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28055,7 +28055,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a485ebae-50f6-438f-be8c-ec6cfd22f680",
+              "id": "b7af658c-44bf-4438-a8b7-499d43adc819",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -28137,7 +28137,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ac29b036-cb27-4f20-8d26-0b09492bef44",
+                "id": "eadfdd56-488e-4dd2-9112-af18186eb914",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28153,7 +28153,7 @@
           }
         },
         {
-          "id": "27c8ccd1-59fc-4cb8-b596-b16d1b259579",
+          "id": "4cb445e3-b3c4-4029-ba16-b6a28a05d148",
           "name": "Get all SKU attributes",
           "request": {
             "name": "Get all SKU attributes",
@@ -28219,7 +28219,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ced6ca0d-830c-42e0-a336-f443ceae4ffb",
+              "id": "2b6bb46a-a9fb-403b-bc14-0bf1c56d9040",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28288,7 +28288,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c3b25286-c4d2-42a8-a8f0-b8d7027b0a2f",
+                "id": "5fc1dcb3-97b8-4b64-b17c-e061c0fefbb4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28304,7 +28304,7 @@
           }
         },
         {
-          "id": "272344a8-ce3e-4c56-b934-793f7801bc47",
+          "id": "887f06bc-c31b-4dc1-9d06-058f387715be",
           "name": "Delete all SKU attributes",
           "request": {
             "name": "Delete all SKU attributes",
@@ -28366,7 +28366,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f9adfc3a-4909-4b32-9678-957ef5a5a561",
+              "id": "ec4420fc-0942-4015-b19f-b759755de54c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28425,7 +28425,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5afe9fb4-314e-4001-a6e9-3fde8cca3054",
+                "id": "f2c99e4b-87a3-4c56-8897-2c39477ee66d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -28438,7 +28438,7 @@
           }
         },
         {
-          "id": "f38cecba-d827-4e59-8007-b701d0e6e8de",
+          "id": "974e8434-540b-4cb0-8400-ff95e425d404",
           "name": "Get SKU attribute by ID",
           "request": {
             "name": "Get SKU attribute by ID",
@@ -28515,7 +28515,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c5a951ee-d412-4483-a014-62447e25bfb8",
+              "id": "21f1300a-52d7-449f-9917-f5b199a2d867",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28585,7 +28585,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "146fd75d-6784-4122-b8e5-3db5b9569ec1",
+                "id": "16f2a088-4fbb-4cac-8a6f-dc4cc9a91f39",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28601,7 +28601,7 @@
           }
         },
         {
-          "id": "cfdb7ba3-8259-41a1-8d09-147bf13e7969",
+          "id": "fae5f01f-9f91-4797-86a7-ba887607823e",
           "name": "Update SKU attribute",
           "request": {
             "name": "Update SKU attribute",
@@ -28691,7 +28691,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "631f86ef-2333-4def-b7b6-8364a5326cea",
+              "id": "7ee3cf36-16f0-4840-8bbb-8304082840ab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28773,7 +28773,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cdd2b832-e3fc-43e9-a94d-5d38113c1ded",
+              "id": "16f71622-aaa5-43bf-b61a-92bea96840e9",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -28856,7 +28856,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9e581dc0-60d1-4688-b6c2-8310e4ed0d68",
+                "id": "8bbab6d4-b171-4b3a-acc0-5abdc466c7b8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28872,7 +28872,7 @@
           }
         },
         {
-          "id": "9af5ba76-e81d-4fa4-bf8a-42a24e16bb9c",
+          "id": "1b7ad0b3-ebcb-4d14-ad50-4e1837963d6d",
           "name": "Delete SKU attribute",
           "request": {
             "name": "Delete SKU attribute",
@@ -28945,7 +28945,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "664b3fca-32aa-4e32-abd0-19736a9d958e",
+              "id": "66e0ac4b-8eb8-4d46-98b2-675ac9510a05",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29005,7 +29005,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fbb5cd28-95f7-46c1-b866-71f4b717b495",
+                "id": "480f2d41-2986-4e08-ad31-21ca9557c679",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -29021,7 +29021,7 @@
       "event": []
     },
     {
-      "id": "287639b3-ae5f-495f-9b4b-fe3a978aedb9",
+      "id": "0fb65ea4-79db-4b84-b0cb-4da7d070a668",
       "name": "Multi-language",
       "description": {
         "content": "",
@@ -29029,7 +29029,7 @@
       },
       "item": [
         {
-          "id": "0eb9f700-c3c0-4459-a6af-ac0f1328388d",
+          "id": "4bc3e13a-1fc1-46db-a7cb-d40722fe2e06",
           "name": "Get product translation by product ID",
           "request": {
             "name": "Get product translation by product ID",
@@ -29106,7 +29106,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4dce3e93-033e-444f-bdc9-195e66f04c5f",
+              "id": "a8941a01-0c97-4fcf-b0bf-664ae483f1c7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29175,7 +29175,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4834438b-ed7e-43b9-b4ac-8774df2e9300",
+              "id": "ae64e636-560b-4259-adc3-bca7d472eb5b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29235,7 +29235,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "62703a02-e41f-40d2-84c8-28661a06334d",
+                "id": "77d4f4c1-005b-47b6-b2d6-d709b916fbc1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -29251,7 +29251,7 @@
           }
         },
         {
-          "id": "dc38271d-df37-47f6-a0df-f98956c13983",
+          "id": "9bf5f4ce-538a-4a5a-bfdd-6827357f9108",
           "name": "Create or update product translation by product ID",
           "request": {
             "name": "Create or update product translation by product ID",
@@ -29326,7 +29326,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3b98d402-f696-4b2d-a701-bb3318906b09",
+              "id": "d4584d10-cd7c-48a2-a133-f4772203f9dc",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -29397,7 +29397,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "699eb546-7bad-4f80-9f68-312c26a5d252",
+              "id": "6c1c2e4f-e40f-473d-b68d-628ad436bcb7",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -29468,7 +29468,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d15acb82-7d72-4af8-9e7d-ceadeda58407",
+              "id": "751b164f-5433-4180-9516-8c338a4ecf22",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29539,7 +29539,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d16efa46-b0b2-4306-9c13-7846a2fa8596",
+              "id": "30fd6f2d-ca7d-4edd-8149-609fb8fa858a",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -29611,7 +29611,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "06683d62-b079-4bae-9fdb-207bc2053307",
+                "id": "6fde2405-9800-480b-8458-4fcd19cb5f8a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -29624,7 +29624,7 @@
           }
         },
         {
-          "id": "03a516ec-48ed-4ded-b923-a239e458a6bc",
+          "id": "f2bc5eab-03e1-4c0d-917a-c1cf669a4e34",
           "name": "Get product specification translation by product ID",
           "request": {
             "name": "Get product specification translation by product ID",
@@ -29713,7 +29713,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "eec9cb46-90ec-45ba-8076-1eae4cba7547",
+              "id": "3e33e258-c919-457a-a721-d712ec481e61",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29784,7 +29784,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e8d732ad-9db3-4e8b-89d1-4cb237ca913f",
+              "id": "4bb8d8cb-fbe0-411b-9aa8-31c4bd3d2592",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29846,7 +29846,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7e5f5cd8-8c11-41dc-940d-04a8c5bbf718",
+                "id": "e09207c7-ecb3-4924-8bf8-466ae01995a2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/products/:productId/specification/:specificationId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -29862,7 +29862,7 @@
           }
         },
         {
-          "id": "311382fa-4af8-480c-9c7b-571f835b4cc9",
+          "id": "40d31223-9ff9-4725-aeac-40662c56b847",
           "name": "Create or update product specification translation by product ID",
           "request": {
             "name": "Create or update product specification translation by product ID",
@@ -29949,7 +29949,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "20a904d2-9a3c-4b7a-bbaf-bc6e196db1b2",
+              "id": "f4c768dc-1a17-4259-aeb5-c91005837f1e",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -30022,7 +30022,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5dc7b9a1-45e9-4f83-930b-e26b3998b14b",
+              "id": "2a125049-9c5a-45e2-a341-c4aca79d8b85",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -30095,7 +30095,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2c08e0aa-a946-444b-948c-5e1f91a04c3d",
+              "id": "7e27e3e9-1bad-46a1-ad20-2719503eb74f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30168,7 +30168,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "179ccc66-3966-45ea-915e-0677c1bb0c55",
+              "id": "7e85e45f-338b-4e1c-bcad-7d79a6304e6f",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -30242,7 +30242,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "95ab0a65-1949-4560-b226-7617ef7208c5",
+                "id": "994d5677-8af1-4dbc-9a42-7e272b7a98df",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/products/:productId/specification/:specificationId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -30258,7 +30258,7 @@
       "event": []
     },
     {
-      "id": "363647b7-aaa2-4d70-be70-bfff528b4a6e",
+      "id": "960c3eb1-e223-4a54-a978-cd6cdd524b81",
       "name": "Multi-language SKU",
       "description": {
         "content": "",
@@ -30266,7 +30266,7 @@
       },
       "item": [
         {
-          "id": "9b4e69d3-84e9-449c-a37e-43b97f30a88e",
+          "id": "47f02fa9-48c6-4d90-b7ad-621a7e429848",
           "name": "Get SKU translation by SKU ID",
           "request": {
             "name": "Get SKU translation by SKU ID",
@@ -30343,7 +30343,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "af880e67-8a1b-4eda-b685-022fb347e1b1",
+              "id": "5448487d-b50e-4dd4-8c59-da9da20d6a87",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -30412,7 +30412,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7ba869a7-dd32-4eb3-818d-0fca2ae95d2a",
+              "id": "879727bf-b596-41e4-8b5c-833cecae625b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30472,7 +30472,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d4c723cf-f0db-41b0-9f78-8ccdb753cef4",
+                "id": "5e577754-41c7-4493-934a-388bfa82e96c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -30488,7 +30488,7 @@
           }
         },
         {
-          "id": "fe55dfb1-d364-4e0d-90c5-db19d43388b2",
+          "id": "9693dd13-caf6-47c6-a5b5-e7274db62d89",
           "name": "Create or update SKU translation by SKU ID",
           "request": {
             "name": "Create or update SKU translation by SKU ID",
@@ -30563,7 +30563,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "af11b8a4-52ba-4967-8afd-c1340bf77396",
+              "id": "8bd9d5f4-3eec-403a-aaee-bffd482bf3af",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -30634,7 +30634,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "39284efe-7796-42e7-bf0c-378c36b49ad5",
+              "id": "d7db3654-5e05-4d60-9e70-8383f1ec50fe",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -30705,7 +30705,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fc965a73-b0d2-43cb-b8b9-86fdb086196c",
+              "id": "c59886e0-26a4-4640-a97f-d58cf686cfb7",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30776,7 +30776,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "43dc60ec-7b05-44bc-9ff3-9e9e390b750b",
+              "id": "9123288b-e653-4770-a1b1-a62051a91904",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -30848,7 +30848,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8917f2f8-fb5b-4e3a-9a72-95b66b8f4240",
+                "id": "726f99e1-9921-4e60-a5ef-b0bafe5a55a9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -30861,7 +30861,7 @@
           }
         },
         {
-          "id": "16c7a121-f67e-460f-b202-e38d70ace1ea",
+          "id": "a00c437f-7a16-4bb4-b102-919682be4a8b",
           "name": "Get SKU attribute translation by SKU ID",
           "request": {
             "name": "Get SKU attribute translation by SKU ID",
@@ -30950,7 +30950,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9d6f1ff6-a282-49bf-9cf4-029f82072476",
+              "id": "99d795ee-2a79-40a1-b991-78653e3599a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -31021,7 +31021,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a699884f-3bda-48b3-b177-787655f11b1a",
+              "id": "b55ab24d-0714-4fee-8962-d7dfebc623e6",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31083,7 +31083,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "06c5dea4-c10b-4993-89b7-b83d3bee6d43",
+                "id": "cc30c915-6b6b-4688-aa1c-77e5e05fb69f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -31099,7 +31099,7 @@
           }
         },
         {
-          "id": "4e900a38-b173-4fda-a00a-882b3501f517",
+          "id": "df243714-c2b7-41d5-aecc-6b01244b2988",
           "name": "Create or update SKU attribute translation by SKU ID",
           "request": {
             "name": "Create or update SKU attribute translation by SKU ID",
@@ -31186,7 +31186,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2f8229bc-ab87-4115-8677-60afdede9ac9",
+              "id": "c2319fd7-0d49-40b1-ad6e-c6a05b513d14",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -31259,7 +31259,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7d651f6a-dec1-4afb-a696-b6932173837f",
+              "id": "5a5e3829-064a-46a4-974b-915c88e22177",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -31332,7 +31332,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "42bb3f09-2c05-4966-abe9-ce650dc26ae8",
+              "id": "a5342320-3c58-4405-927e-e2a7c1f3cbac",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31405,7 +31405,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0c46dd5b-1646-4bf8-9dd2-0270f605764a",
+              "id": "16d5cf0a-732c-4dec-a5a9-d3c791bef6bd",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -31479,7 +31479,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ce1f32ce-09d0-435f-bb44-a30023b8b1c8",
+                "id": "ba08af7c-6311-4f2b-bcdf-3a57e000ceca",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -31492,7 +31492,7 @@
           }
         },
         {
-          "id": "05a57c92-4d44-4fd1-a3dc-55a942980b2b",
+          "id": "7158b644-3b03-4bfb-93e1-b4acc62ba82b",
           "name": "Get SKU file translation by SKU ID",
           "request": {
             "name": "Get SKU file translation by SKU ID",
@@ -31581,7 +31581,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ca08b9d6-03a2-43e6-9320-f0ec8fb8d8ba",
+              "id": "73352ce1-b8cb-4064-9a4e-bd47dfae76de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -31652,7 +31652,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "67d3675a-0ec6-4a40-b630-4b2e594bcc4a",
+              "id": "7cbd3bf4-3c28-4321-86b0-254db45e6978",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31714,7 +31714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2ba752f2-d1ab-4e19-99f5-5190b8cde658",
+                "id": "3f2d71c2-9fc9-4f80-8d66-3a44c23d3135",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -31730,7 +31730,7 @@
           }
         },
         {
-          "id": "c6c85c14-719f-4164-ad35-0148d4780adf",
+          "id": "4d0147d7-4c53-4b89-a4d8-87a04af06006",
           "name": "Create or update SKU file translation by SKU ID",
           "request": {
             "name": "Create or update SKU file translation by SKU ID",
@@ -31817,7 +31817,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e57a4de6-1c83-4f6d-bf35-5246223a5c7f",
+              "id": "fd26fff3-8661-41eb-9fe8-13f610918874",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -31890,7 +31890,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "20f42b96-e263-4f4b-8ec9-4b773957a51a",
+              "id": "e6b1a3ca-702f-4347-a09b-10af81feebdd",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -31963,7 +31963,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "38879844-803e-42dc-bf49-19dcd46f5520",
+              "id": "cb5f4371-c1ba-412d-81f0-90f2d90b6b62",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32036,7 +32036,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "005f1f70-e05e-47b2-8e07-6a04ec312693",
+              "id": "41b27836-2c0e-4d72-b8e6-30a77b618a10",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -32110,7 +32110,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f48003e6-e957-4984-bbe2-6343efada626",
+                "id": "e26e595a-200c-460d-8def-0b66246b57f5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -32126,7 +32126,7 @@
       "event": []
     },
     {
-      "id": "4bd9663c-d6c3-4f52-844e-21b2c27f4a74",
+      "id": "083d585e-12e4-4921-bf0d-a5159d57cb54",
       "name": "Multi-language specification",
       "description": {
         "content": "",
@@ -32134,7 +32134,7 @@
       },
       "item": [
         {
-          "id": "4bc767cf-a954-4082-8afd-5eacfec8f098",
+          "id": "6ca6f18c-6bbc-4124-8ed6-466a3ade3bcd",
           "name": "Get specification group translation",
           "request": {
             "name": "Get specification group translation",
@@ -32211,7 +32211,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "72ee726b-7923-45a2-afb3-a7e059af1b2b",
+              "id": "6512fa5e-74cf-4a92-a2fb-be7a32bd733d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -32280,7 +32280,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8dcb1439-df24-4e1d-815f-92152641eeaa",
+              "id": "dc5a477a-27f4-40e6-89e5-0f515522597b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32340,7 +32340,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ec6eef77-0fea-4301-8035-909cabb436fd",
+                "id": "7a6d2616-612d-4374-81f2-44d8af9f5bfe",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationgroup/:specificationGroupId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -32356,7 +32356,7 @@
           }
         },
         {
-          "id": "2feb8c3d-8396-4215-9057-226a9104cfae",
+          "id": "c3517981-da2b-4cb0-afeb-626b33345c41",
           "name": "Create or update specification group translation",
           "request": {
             "name": "Create or update specification group translation",
@@ -32431,7 +32431,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8ed8e30c-944f-4780-9de7-6a92a742638b",
+              "id": "a9f0c28c-08ab-4e3e-98ae-93dff4db71eb",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -32502,7 +32502,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1c82f82d-8418-48c3-a291-91cccba8f76b",
+              "id": "04505f55-aa0b-4165-9601-fd7e65937e25",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -32573,7 +32573,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "277c1cbe-5689-4fd9-ae5c-d2b036028602",
+              "id": "ec98c179-4abf-4a53-a6bc-baab8ac8b5d4",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32644,7 +32644,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "559c8fd3-05e2-421e-a686-303875c40e9c",
+              "id": "39eb3179-e670-4a24-ba10-6decb3f7ee60",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -32716,7 +32716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "adf8698b-2699-42e4-af28-cf104f4bbb67",
+                "id": "8708e202-513d-4755-aba3-091350803391",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationgroup/:specificationGroupId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -32729,7 +32729,7 @@
           }
         },
         {
-          "id": "4fed2b1c-2bde-43cc-a10d-c2b4c9f6b69d",
+          "id": "cbc30c00-6901-40ac-bad2-de3ac7d5db5a",
           "name": "Get specification translation",
           "request": {
             "name": "Get specification translation",
@@ -32806,7 +32806,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "abed3a3a-ffe8-4b59-a4ce-397845a25688",
+              "id": "6b8b667b-db29-43b9-914d-b5e7ff429fe3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -32875,7 +32875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "74305a0b-1b54-4e61-bd17-613ede19b1ff",
+              "id": "49391fd3-8b72-4403-bef2-6de125cb7db2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32935,7 +32935,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "09246efc-9ced-4fd2-a30b-ac7f1ce65cd3",
+                "id": "a7e5a2fe-a481-4eec-9fa1-f11b2eaed947",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -32951,7 +32951,7 @@
           }
         },
         {
-          "id": "a7060bc1-f829-4aa8-8617-a697ce42fa98",
+          "id": "208c6735-ff74-424d-9ade-79f08cf0c546",
           "name": "Create or update specification translation",
           "request": {
             "name": "Create or update specification translation",
@@ -33026,7 +33026,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "836cf3f7-5761-4d5c-8854-da83a7ab5ce1",
+              "id": "d16f91a6-af9e-4f74-a13a-6f2b0a523bba",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -33097,7 +33097,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "abe38431-d749-495c-8287-ab671f45b7c8",
+              "id": "074d0b7e-7d98-4036-acd6-133a58b7d98f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -33168,7 +33168,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5e1a5c88-063b-4758-bbb5-bfe34d822870",
+              "id": "55b35c2b-9610-40f2-99f7-1a20ab47c2a4",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33239,7 +33239,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cac752f4-0309-4f0e-8e22-611b9561f094",
+              "id": "2cf8732d-74ad-4299-befc-4e487124ce4b",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -33311,7 +33311,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1922b802-63cc-473d-b888-f92328473be7",
+                "id": "6d4a3b4c-7740-4f60-9440-e0ce712c6f9d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specification/:specificationId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -33324,7 +33324,7 @@
           }
         },
         {
-          "id": "6daf42ec-bee9-451e-8141-9339131170fc",
+          "id": "aaa2174d-ac7f-43da-af98-340ed0d54bc1",
           "name": "Get specification value translation",
           "request": {
             "name": "Get specification value translation",
@@ -33401,7 +33401,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7f1eb67f-98b2-4de0-9c43-3791bcd48408",
+              "id": "39caf0a4-1481-4218-a1f3-361aa60965f2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -33470,7 +33470,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8f0444d4-c1e4-425d-bb50-e792a1a2193f",
+              "id": "eb362f65-ba43-469b-b514-c83161c988ce",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33530,7 +33530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c17db870-f041-4119-880c-f05c7a68c23d",
+                "id": "ca03f61c-07ec-4c16-a391-60bca7de9772",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationvalue/:valueId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -33546,7 +33546,7 @@
           }
         },
         {
-          "id": "ff37f4dd-552f-4305-a91f-00d4cb5840a4",
+          "id": "19044e58-fd0d-49d9-a8c0-f7acb7e6eb12",
           "name": "Create or update specification value translation",
           "request": {
             "name": "Create or update specification value translation",
@@ -33621,7 +33621,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "953464a9-71e4-4b81-82c9-faf6276983fa",
+              "id": "2e37244c-8771-4521-b580-72c8cd810ac6",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -33692,7 +33692,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cf1880ea-cd57-433e-8c51-5f6604c74012",
+              "id": "c17832be-971d-48f2-95ec-2cef6ca78ce8",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -33763,7 +33763,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1f485896-5530-4c04-bf88-01ff0891405e",
+              "id": "84eb7f51-97aa-4e96-9f15-bcf20a7ec6cd",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33834,7 +33834,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5ad61d2b-bd31-4d5f-916c-ae0106ed2b2b",
+              "id": "f63c8e3a-783f-4f57-b49c-66402942b363",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -33906,7 +33906,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "20d0c403-9383-4607-ae28-c61d74de2ab0",
+                "id": "2561226a-2731-4b6d-8866-82d78f26d976",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationvalue/:valueId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -33922,7 +33922,7 @@
       "event": []
     },
     {
-      "id": "966a5ea7-8617-4636-aceb-fd936df09515",
+      "id": "ede453e8-06c6-4c4d-858f-672d3525abd3",
       "name": "Multi-language category",
       "description": {
         "content": "",
@@ -33930,7 +33930,7 @@
       },
       "item": [
         {
-          "id": "d8fbb270-d92c-462e-a2ad-735a08cb6797",
+          "id": "c4ec2087-dda0-4f93-a6c9-80829d828a14",
           "name": "Get category translation",
           "request": {
             "name": "Get category translation",
@@ -34007,7 +34007,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ad61f2a3-bd48-4ea7-89c5-2d284fe922d3",
+              "id": "b9e95268-3e2b-4255-88f0-9c10229521b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -34076,7 +34076,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c7d66d21-a511-4fb3-9023-3c0b72286aa1",
+              "id": "d8cee33c-1ac7-4653-9860-f49a21ca1bc6",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34136,7 +34136,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9640259d-37df-432a-bd13-4e84ed879fa9",
+                "id": "15a52144-17ac-4086-9ff1-e67298d3a697",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/category/:categoryId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -34152,7 +34152,7 @@
           }
         },
         {
-          "id": "ae27eaa5-5106-43c0-8246-6a36504d8847",
+          "id": "e93b84d4-e60f-459d-bda8-711d6bcf0a0a",
           "name": "Create or update category translation",
           "request": {
             "name": "Create or update category translation",
@@ -34227,7 +34227,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "04c551f1-5d1b-485f-9afc-fcc497745310",
+              "id": "e5647776-265c-476d-be32-6bb9779565b0",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -34298,7 +34298,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "31e403c4-5bfb-4158-ba63-e71f98ac464f",
+              "id": "979fe475-d8a3-4903-9a48-4ff6d6e60a2e",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -34369,7 +34369,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b039b35e-ada0-4123-b5be-682f1ae1be50",
+              "id": "0d8edcb0-6383-4ceb-9b08-69f718705f5c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34440,7 +34440,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "938709c8-5915-484b-9763-1d13538ff5ae",
+              "id": "24ef6714-d386-4a88-93e0-22b1de14095d",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -34512,7 +34512,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4fe407f7-ae20-4901-8719-56225098b39a",
+                "id": "44d5c2f6-0c3c-40bd-ab8d-dd7c260e65d3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/category/:categoryId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -34528,7 +34528,7 @@
       "event": []
     },
     {
-      "id": "fc1025e4-e876-4b91-93c8-b9099f9567d4",
+      "id": "ed8e5d05-1bfb-48ab-a995-530adc34a540",
       "name": "Multi-language brand",
       "description": {
         "content": "",
@@ -34536,7 +34536,7 @@
       },
       "item": [
         {
-          "id": "3fd54365-79bf-4400-b1c1-46aa162939ea",
+          "id": "aa8001be-fbd1-46f9-920e-7ff353420e3e",
           "name": "Get brand translation",
           "request": {
             "name": "Get brand translation",
@@ -34613,7 +34613,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d480f1f6-fdcc-433f-ac36-1d947c5068af",
+              "id": "5cf74015-90fe-43a6-a74b-0be344f8276b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -34682,7 +34682,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "30498e61-4826-4e64-af30-45103d8ed375",
+              "id": "d5068750-00af-4e84-8e05-8dbd3c106982",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34742,7 +34742,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8f60846d-6720-42bf-a7f0-2d026033ae97",
+                "id": "3ab28f12-96ac-492f-9ea9-cdefb7d6c787",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/brand/:brandId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -34758,7 +34758,7 @@
           }
         },
         {
-          "id": "291386d7-6885-4239-9e13-33eb8f0f9f18",
+          "id": "ee9ad34d-4f1e-4a60-abb5-ba082ab5b75c",
           "name": "Create or update brand translation",
           "request": {
             "name": "Create or update brand translation",
@@ -34833,7 +34833,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "44a9c6e9-1ce1-4731-8076-0e3a08782fb7",
+              "id": "3b10f4db-b400-476b-a015-3ccaf036559f",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -34904,7 +34904,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "92aae173-31a1-4f66-824a-0af911e7bb23",
+              "id": "537d1ef2-9a06-4982-9375-42654bb1116a",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -34975,7 +34975,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6741f933-f7e1-4bce-acfb-dfaa3f88b0ed",
+              "id": "0509c31b-3e8e-486f-835b-7b1de8f0d053",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35046,7 +35046,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d5e057db-b504-4070-82b9-d434990ef559",
+              "id": "03db09e6-4a00-4f2f-a21a-e4d51524bd91",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -35118,7 +35118,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b2d043e8-eb3e-44e8-8273-c78a4afca751",
+                "id": "896f7788-d2bc-44f7-b2a8-56c648c68b53",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/brand/:brandId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -35134,7 +35134,7 @@
       "event": []
     },
     {
-      "id": "62a7bc7d-ffad-4052-8c04-ee83022a98c6",
+      "id": "0acbf5a5-d1ec-4416-ab57-32942d88bd9d",
       "name": "Multi-language attachment and service",
       "description": {
         "content": "",
@@ -35142,7 +35142,7 @@
       },
       "item": [
         {
-          "id": "2c61190a-7fda-4c49-9f16-195993062558",
+          "id": "f8b98163-4f47-4386-a11a-a5608f9b71a8",
           "name": "Get attachment translation",
           "request": {
             "name": "Get attachment translation",
@@ -35219,7 +35219,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "77a190a7-b6b9-4490-942f-c9b667f72f49",
+              "id": "005a6693-ef73-4c53-bb09-2cad0493e6e9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -35288,7 +35288,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1450c2ed-7bec-4f0d-a130-957344a2d370",
+              "id": "82538e49-bc49-4839-b0dd-dcbd3ebe5739",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35348,7 +35348,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c4a93f63-a3f2-4eed-a732-7ef68188052f",
+                "id": "d3cab42f-5d68-40f9-8651-72dbe09fd79c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachment/:attachmentId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -35364,7 +35364,7 @@
           }
         },
         {
-          "id": "6dc0f009-6bcf-4c34-8b48-f2f18f4cf87d",
+          "id": "48091c8a-e627-4e16-a573-1354ac445b06",
           "name": "Create or update attachment translation",
           "request": {
             "name": "Create or update attachment translation",
@@ -35439,7 +35439,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "eb06cd4e-2caa-4450-baae-7106a73f46e1",
+              "id": "7c8920da-9b17-4f8f-b42a-89af2903484b",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -35510,7 +35510,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e1de4de5-e342-4473-b07e-ecbb393914ed",
+              "id": "eafd30d6-968b-4f9a-a36c-7a15de4e74b6",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -35581,7 +35581,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d8aae626-5d76-45ba-afdb-49779b3213ab",
+              "id": "132afbcd-e4d7-4f11-9afb-bff8a01e40f2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35652,7 +35652,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "031fa4be-b062-49a0-b302-3d09903f07f0",
+              "id": "fd4eda20-2599-457b-8e55-6ff34a4948fb",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -35724,7 +35724,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cc721579-3180-48c1-bbe1-b9eda21f05a7",
+                "id": "2a9994dc-8f96-4b01-987c-8a58c898b872",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/attachment/:attachmentId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -35737,7 +35737,7 @@
           }
         },
         {
-          "id": "f69b0967-dbb9-47ef-b02f-876c55d44800",
+          "id": "5412a51d-30a9-41f4-8414-8d5bdea5dd98",
           "name": "Get SKU service type translation",
           "request": {
             "name": "Get SKU service type translation",
@@ -35814,7 +35814,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b30d90fe-c49d-400d-8731-380654e9387b",
+              "id": "ea27d719-72d6-41e0-8799-ce6c34f052c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -35883,7 +35883,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "042df46e-175d-4040-bec9-3fb907fc165a",
+              "id": "1bbcad73-e5da-41f8-99fd-698a1d037a40",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35943,7 +35943,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "adc65205-a146-414b-9da4-d61bb5e6aca9",
+                "id": "96419c92-f527-4860-92e9-c4d830495bb2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -35959,7 +35959,7 @@
           }
         },
         {
-          "id": "5d2a95da-4273-4e68-8ba4-cb526ac85c5d",
+          "id": "d58ac0ac-db8e-4797-978a-592d7eaa055a",
           "name": "Create or update SKU service type translation",
           "request": {
             "name": "Create or update SKU service type translation",
@@ -36034,7 +36034,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f896eac9-601e-4762-9844-4c936fa3c5ad",
+              "id": "f1ab5dc0-6ec1-4c9a-bfc2-99428a63e21f",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -36105,7 +36105,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "307898b9-7bdb-45a5-9e19-6e7d571e5256",
+              "id": "d59fcc7a-5489-47ad-a765-2e51006a6b03",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -36176,7 +36176,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a4888f9a-5465-45a0-993f-24de65f25a59",
+              "id": "d5ada780-3025-444d-9554-ec4849eafbea",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36247,7 +36247,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "773c51fa-fa23-4ca6-b6d9-35e2c72e7795",
+              "id": "9ad1ad35-44ff-4afb-af29-bb1f23c1c4d4",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -36319,7 +36319,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "391b167f-4840-48cf-abfe-bf04a46f7395",
+                "id": "6655c8de-1f67-4f95-8640-cb6a5354ba16",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -36332,7 +36332,7 @@
           }
         },
         {
-          "id": "0cc46812-3c02-4e90-92e3-5d0014462955",
+          "id": "89a8aad0-4944-4406-962a-a1e83070ccc8",
           "name": "Get SKU service translation",
           "request": {
             "name": "Get SKU service translation",
@@ -36409,7 +36409,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3a86559e-e3c4-40e2-9122-661ea73dc91e",
+              "id": "2be52a8e-dcda-487a-9303-b847712ff710",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -36478,7 +36478,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ec2d2492-85be-4c52-94dd-dcde16e967ff",
+              "id": "5ad1ea6f-b072-42df-b872-b3e838771ead",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36538,7 +36538,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f19a5993-0361-4b51-acb8-93fed2174878",
+                "id": "38cffb39-9b2c-4070-8c38-559cc799783d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservice/:skuserviceId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -36554,7 +36554,7 @@
           }
         },
         {
-          "id": "c58033fe-c8a2-4597-b079-2ebf97df4401",
+          "id": "a1ced1ee-d86d-4949-b0a2-3d345f90faa6",
           "name": "Create or update SKU service translation",
           "request": {
             "name": "Create or update SKU service translation",
@@ -36629,7 +36629,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4e6a3dad-f6e7-4934-a222-53775ffbcc0a",
+              "id": "88449550-99c6-43bf-8ba5-071f7ac97013",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -36700,7 +36700,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "96eff3f3-80a9-4f45-8509-0ae56214728e",
+              "id": "affd698f-861e-4eab-9673-97fb1a9cc31a",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -36771,7 +36771,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "48910aa4-303a-47a4-b735-06bca22285c8",
+              "id": "5f8a8a2e-8d4c-4eea-9926-a73fa7423d49",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36842,7 +36842,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f564c689-1577-4fcc-938b-82cf1e624c7c",
+              "id": "6260bcd7-5cbd-4542-9f71-063974414df6",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -36914,7 +36914,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "547da57f-e763-4504-8f42-244ebcf0c273",
+                "id": "71d037c5-1383-499c-9879-690c40596e65",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservice/:skuserviceId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -36927,7 +36927,7 @@
           }
         },
         {
-          "id": "ec57405f-d6a9-4f67-8e2a-0b41df154e83",
+          "id": "e38a181e-fe24-4aa7-ad3f-9409d2aa0e9b",
           "name": "Get SKU service value translation",
           "request": {
             "name": "Get SKU service value translation",
@@ -37004,7 +37004,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7f79a877-89af-476c-98d4-325715c3f502",
+              "id": "d852b233-eeb5-4084-8a79-253fbb99d1db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -37073,7 +37073,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d95447da-b892-4739-a2e9-c1487d6b8430",
+              "id": "c1bcdedd-732f-41bc-ab51-ec820a4e0a3f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37133,7 +37133,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7ca2694f-c2bc-4173-bc65-a3b3e2a5bd54",
+                "id": "cf4b74a3-cf57-4ca3-ac8b-e36b75418e0b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -37149,7 +37149,7 @@
           }
         },
         {
-          "id": "8e913b7e-d565-470b-9c4b-775d66556602",
+          "id": "78c791c1-beee-42d8-a7a7-16f646f390a7",
           "name": "Create or update SKU service value translation",
           "request": {
             "name": "Create or update SKU service value translation",
@@ -37224,7 +37224,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7113459a-e5d1-48ac-8f82-9a4c8cad18c3",
+              "id": "76fce57f-5a7a-4e23-9948-330bb2579f0d",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -37295,7 +37295,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4c74c334-4b7a-4a47-9dd6-0e63497fd364",
+              "id": "b7e4a04c-634e-4183-8787-29607d6ef748",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -37366,7 +37366,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e6166a1e-e199-4d69-9b89-3001d3291eb2",
+              "id": "20d4599b-aec6-43ac-833e-ff37eecad063",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37437,7 +37437,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3a78bb61-7fba-48a1-8f50-5ddcef47f00f",
+              "id": "b3922c2e-16b5-4b7f-9e81-92c8c1c49c3c",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -37509,7 +37509,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b53b760a-6e4b-4af0-8069-55f404b6ca60",
+                "id": "189a485b-a10b-4bc1-94a7-67f041b6887c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -37525,7 +37525,7 @@
       "event": []
     },
     {
-      "id": "839d6a0d-d6f3-4a30-8355-229c9ac68b8f",
+      "id": "fbf0651d-2383-430e-8b9e-833095eab3b5",
       "name": "Multi-language collection",
       "description": {
         "content": "",
@@ -37533,7 +37533,7 @@
       },
       "item": [
         {
-          "id": "97380df1-0125-44d8-8ce2-96e8abd1932b",
+          "id": "39a82a1d-48e2-4a62-b012-79620d00e02f",
           "name": "Get collection translation",
           "request": {
             "name": "Get collection translation",
@@ -37610,7 +37610,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "34b8035a-3459-4cf1-8db2-5eb8cfd7333d",
+              "id": "770666c8-82e6-4f5c-af1c-2cbc05f3de95",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -37679,7 +37679,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3f43df42-1026-4514-a15f-41cf9a621af9",
+              "id": "a406f09e-b3b3-4b25-b3e8-73b97608e6cb",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37739,7 +37739,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e68fe53b-11ac-4ddf-a2a2-2f89ebb34551",
+                "id": "35a0f8e8-02fa-4168-bc81-52d108b1acff",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -37755,7 +37755,7 @@
           }
         },
         {
-          "id": "e36edf4d-0070-4ff4-bd46-e7df698b4d73",
+          "id": "867b6adb-710d-467f-9ba5-8ce26bd78248",
           "name": "Create or update collection translation",
           "request": {
             "name": "Create or update collection translation",
@@ -37830,7 +37830,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "be3f149e-e18a-4e94-901a-a23809c6ca9e",
+              "id": "9e759069-fb6f-4b84-8d9e-d3216da5a425",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -37901,7 +37901,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "87ad770c-0a44-482e-b6d9-5bbc3b2a6648",
+              "id": "06e2115c-bdd7-46e7-996c-b03776c51be5",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -37972,7 +37972,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "822f0f7d-f039-4e30-b412-92592dab01db",
+              "id": "b9300d3c-594f-4a93-ac27-47936821b438",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -38043,7 +38043,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c8e10c12-3f70-4415-88c8-22cf56f61db0",
+              "id": "0d21e161-563b-4dfd-8d9f-abe3580b90d8",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -38115,7 +38115,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c6928ecd-7dc0-444c-8128-5d8b4d83d406",
+                "id": "661e77ae-97aa-48f9-ac1a-499439eb00db",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/collection/:collectionId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -38131,7 +38131,7 @@
       "event": []
     },
     {
-      "id": "37fe95bc-a3e1-4bb5-a0de-b564da6fef9b",
+      "id": "81dd555c-468e-4cb3-bab3-3a2bf7d64737",
       "name": "Product indexing",
       "description": {
         "content": "",
@@ -38139,7 +38139,7 @@
       },
       "item": [
         {
-          "id": "e5e2b890-f0f1-4ae0-821c-e73e754aa5af",
+          "id": "da599ecc-8c94-4465-bce9-c0110761f4b7",
           "name": "Get product indexed information",
           "request": {
             "name": "Get product indexed information",
@@ -38205,7 +38205,7 @@
               "_": {
                 "postman_previewlanguage": "xml"
               },
-              "id": "5464d46a-2bb3-4bf0-b481-5351214812a2",
+              "id": "3fb91e1f-5cff-456f-8b48-56417c895446",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38274,7 +38274,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6713ad1b-072b-4ecb-b3d7-141f16aeac90",
+                "id": "69344a2d-bc90-4f2a-b85f-b42a77bb1bd3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/GetIndexedInfo/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38291,7 +38291,7 @@
       "event": []
     },
     {
-      "id": "a59e4e9c-841c-42c0-8b50-73614af897d1",
+      "id": "61625277-4c8f-4d99-b907-8c09a739d9b8",
       "name": "Commercial conditions",
       "description": {
         "content": "",
@@ -38299,7 +38299,7 @@
       },
       "item": [
         {
-          "id": "abc51ecf-ba3f-401e-b723-9393b5494810",
+          "id": "abb9b287-ff24-4a92-946b-fccc250e3dff",
           "name": "Get all commercial conditions",
           "request": {
             "name": "Get all commercial conditions",
@@ -38353,7 +38353,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a88b2ca4-a6b6-4a97-a2c4-04dc5baeeeab",
+              "id": "70ffc267-e4df-46c2-8e17-899f602b9eed",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38421,7 +38421,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6926a967-c20e-4c39-b6b9-627b06af7f81",
+                "id": "e00bd8b3-f980-4d8e-b80e-88795fd430f9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/commercialcondition/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38437,7 +38437,7 @@
           }
         },
         {
-          "id": "89788846-fd95-4b81-8eab-6f1730699c15",
+          "id": "0c68a077-66e3-41cb-ba38-fb42034f039d",
           "name": "Get commercial condition",
           "request": {
             "name": "Get commercial condition",
@@ -38502,7 +38502,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "80db7fcc-2648-4f80-90b9-f1bc1e87f223",
+              "id": "134b3afc-3c0b-4480-8bee-7bf9c12df1b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38570,7 +38570,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d10c1118-0ee0-4056-be2b-ac776bd48291",
+                "id": "42503647-bad2-4b5f-96b6-c7842ff9aed1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/commercialcondition/:commercialConditionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38589,7 +38589,7 @@
       "event": []
     },
     {
-      "id": "ee53b5c7-6850-4c2a-a655-e30611a679be",
+      "id": "9beba852-5bee-4b56-a324-56eb491be455",
       "name": "Gift list",
       "description": {
         "content": "",
@@ -38597,7 +38597,7 @@
       },
       "item": [
         {
-          "id": "d4830c09-9ae9-4ee4-8efe-bb8b2622c273",
+          "id": "cbfb1f3f-4afa-4660-93d8-461c11b3977c",
           "name": "Get gift list",
           "request": {
             "name": "Get gift list",
@@ -38663,7 +38663,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "09a1e941-7740-40af-8ffb-108967a932d8",
+              "id": "1c018422-0e6e-4259-9117-9f0f12529c19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38732,7 +38732,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ddc5204c-0177-4faf-b0cb-c331b7d07211",
+                "id": "1588d2af-24d7-4335-b501-6dfbe3a4db96",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/addon/pvt/giftlist/get/:listId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38790,7 +38790,7 @@
     }
   ],
   "info": {
-    "_postman_id": "6a4d6e50-11af-4db4-b939-ac4ad681926d",
+    "_postman_id": "82e5b7cf-e13e-4881-8ff3-a854ee80fa7b",
     "name": "Catalog API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Catalog API.json
+++ b/PostmanCollections/VTEX - Catalog API.json
@@ -32868,7 +32868,7 @@
                   "value": "application/json"
                 }
               ],
-              "body": "[\n  {\n    \"Id\": 59,\n    \"Locale\": \"en-US\",\n    \"Name\": \"Color\",\n    \"Description\": \"Navy blue\",\n    \"Values\": null\n  }\n]",
+              "body": "[\n  {\n    \"Id\": 59,\n    \"Locale\": \"en-US\",\n    \"Name\": \"Color\",\n    \"Values\": null\n  }\n]",
               "cookie": []
             },
             {
@@ -32941,7 +32941,7 @@
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"Object containing language-specific information for a specification.\",\"properties\":{\"Id\":{\"type\":\"integer\",\"description\":\"Unique identifier of the specification.\"},\"Locale\":{\"type\":\"string\",\"description\":\"The locale code for this translation. It follows the IETF BCP 47 standard, such as 'en-US' for English (United States), 'en-ES' for Spanish (Spain), or 'pt-BR' for Portuguese (Brazil).\"},\"Name\":{\"type\":\"string\",\"description\":\"Translated name of the specification.\"},\"Description\":{\"type\":[\"string\",\"null\"],\"description\":\"Translated description of the specification.\"},\"Values\":{\"type\":[\"array\",\"null\"],\"description\":\"List of the translated specification values.\",\"items\":{\"type\":\"string\",\"description\":\"Translated specification value.\"}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"Object containing language-specific information for a specification.\",\"properties\":{\"Id\":{\"type\":\"integer\",\"description\":\"Unique identifier of the specification.\"},\"Locale\":{\"type\":\"string\",\"description\":\"The locale code for this translation. It follows the IETF BCP 47 standard, such as 'en-US' for English (United States), 'en-ES' for Spanish (Spain), or 'pt-BR' for Portuguese (Brazil).\"},\"Name\":{\"type\":\"string\",\"description\":\"Translated name of the specification.\"},\"Values\":{\"type\":[\"array\",\"null\"],\"description\":\"List of the translated specification values.\",\"items\":{\"type\":\"string\",\"description\":\"Translated specification value.\"}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -33012,7 +33012,7 @@
             "method": "PUT",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\",\n  \"Description\": \"Navy blue\"\n}",
+              "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -33079,7 +33079,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\",\n  \"Description\": \"Navy blue\"\n}",
+                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -33150,7 +33150,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\",\n  \"Description\": \"Navy blue\"\n}",
+                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -33221,7 +33221,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\",\n  \"Description\": \"Navy blue\"\n}",
+                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -33292,7 +33292,7 @@
                 "method": "PUT",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\",\n  \"Description\": \"Navy blue\"\n}",
+                  "raw": "{\n  \"Locale\": \"en-US\",\n  \"Name\": \"Color\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",

--- a/PostmanCollections/VTEX - Catalog API.json
+++ b/PostmanCollections/VTEX - Catalog API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "82e5b7cf-e13e-4881-8ff3-a854ee80fa7b"
+    "postman_id": "61081289-d1ab-41ac-930b-5782b19058c6"
   },
   "item": [
     {
-      "id": "e1008a21-bc04-4927-8bd1-61963f191109",
+      "id": "f717c928-87e1-420f-a8f0-0552357ab75f",
       "name": "SKU service",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "34c48b28-f1c2-4fce-9ee8-3bc5e2bb70ae",
+          "id": "518abf57-51ef-4abe-a910-36991cefb366",
           "name": "Get SKU service",
           "request": {
             "name": "Get SKU service",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "40a0ee86-8fac-495b-a09a-9f4869a6bd26",
+              "id": "85f70fd3-66de-4987-9e91-b29f3b9184a8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -145,7 +145,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "699c3cb5-abbf-4b00-9ac7-812d0246ea19",
+                "id": "49557c80-04e8-4ce0-bea5-88fbf6ca848f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -161,7 +161,7 @@
           }
         },
         {
-          "id": "ea5c5a88-d07b-4d2a-ab30-04d4f5a9c64b",
+          "id": "a7c3bbaf-224c-46c3-a20b-89c3fb97416f",
           "name": "Update SKU service",
           "request": {
             "name": "Update SKU service",
@@ -239,7 +239,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bb27a46f-16e0-4de0-82cb-567790aa6cbc",
+              "id": "24a3ae27-a685-42cc-b057-f7ac4889a47e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -320,7 +320,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d60801b4-53ef-4625-8fd2-9dee72f7b69b",
+                "id": "0a74c16b-cd2d-47b6-8728-38717aa783ed",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -336,7 +336,7 @@
           }
         },
         {
-          "id": "ccd106d7-749e-476f-ba3c-777304f83080",
+          "id": "ed0945fd-266e-4a0d-9c70-90c8c7cd304f",
           "name": "Dissociate SKU service",
           "request": {
             "name": "Dissociate SKU service",
@@ -397,7 +397,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ea25c3d5-9bf2-4244-879d-537d73e958ff",
+              "id": "5aea7091-ac9b-4260-b5ef-2e55d5fe2cca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -455,7 +455,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f9224928-3aa8-4863-829a-b5c05b2bdc14",
+                "id": "445fffe0-80a1-44b4-a0d5-bbbef5871a7a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -468,7 +468,7 @@
           }
         },
         {
-          "id": "a12c80db-76af-41d1-8ac8-bf760692e88a",
+          "id": "2dce4d1f-8516-451b-80fe-4767b8b95323",
           "name": "Associate SKU service",
           "request": {
             "name": "Associate SKU service",
@@ -534,7 +534,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "08bda5d8-07ff-4fca-b44c-d3ae95dfa6d1",
+              "id": "c41c1237-d61b-4e73-b4f6-81fb89d9c7c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -614,7 +614,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ee853710-c33d-4aee-9b7e-820f63174cc1",
+                "id": "45e41cb7-32d7-4b4c-9fc5-bcd68bda979c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservice - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -633,7 +633,7 @@
       "event": []
     },
     {
-      "id": "f591b1a8-839f-4440-97b5-573fd63724c5",
+      "id": "d3a657e4-9ee3-4368-a2ed-9569fcbe8688",
       "name": "SKU service attachment",
       "description": {
         "content": "",
@@ -641,7 +641,7 @@
       },
       "item": [
         {
-          "id": "e4a9a6f0-560c-4dec-a76c-9ceac0b24f14",
+          "id": "45abbc1e-21bc-43ca-add5-cdb52663510a",
           "name": "Associate SKU service attachment",
           "request": {
             "name": "Associate SKU service attachment",
@@ -707,7 +707,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "340f8906-3fa6-4c59-aff3-fbcebd787164",
+              "id": "1a6fc768-2b5a-42a6-8dc4-21d0f206d6a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -787,7 +787,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7a150656-707b-4c65-9b42-5fdc7435bc79",
+                "id": "720c366e-3a29-4cca-b4be-4defced3aebd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicetypeattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -803,7 +803,7 @@
           }
         },
         {
-          "id": "b9292fc5-9af6-47f7-a0f3-b8d408038023",
+          "id": "598bc71d-b2bd-48c2-8f14-c5f94f3201f3",
           "name": "Dissociate attachment by attachment ID or SKU service type ID",
           "request": {
             "name": "Dissociate attachment by attachment ID or SKU service type ID",
@@ -871,7 +871,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b28d2ec5-d6ff-49fe-85ab-4a4786fe2f73",
+              "id": "b989d748-6928-45a0-8ecf-83b65773224f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -947,7 +947,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2860fa95-a5a4-4829-9f2c-daf8159bff19",
+                "id": "0068012f-0ff6-4ed3-b840-44a11e833c1d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetypeattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -960,7 +960,7 @@
           }
         },
         {
-          "id": "1d4ffab1-cd2a-4303-b985-e4d916e27592",
+          "id": "ef01cdc1-7ebf-4fd6-9574-fb26fb64ab69",
           "name": "Dissociate attachment from SKU service type",
           "request": {
             "name": "Dissociate attachment from SKU service type",
@@ -1021,7 +1021,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7a3e4c6e-ecb5-4f05-b0c3-4443bffe469b",
+              "id": "11e4c5b5-3376-42ad-8726-b7aa96b433f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1079,7 +1079,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9e1d26ed-c2d2-49cd-82b2-de64865b0462",
+                "id": "20fd66d6-7c32-46ee-bc97-6eabbea44422",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetypeattachment/:skuServiceTypeAttachmentId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1095,7 +1095,7 @@
       "event": []
     },
     {
-      "id": "d386a583-75aa-4327-a58a-251a3f47fa4d",
+      "id": "4ef63ca4-ce6d-407c-907f-ebe6ecaf404f",
       "name": "SKU service value",
       "description": {
         "content": "",
@@ -1103,7 +1103,7 @@
       },
       "item": [
         {
-          "id": "7e5b97b7-00e8-4e41-8b89-27746e5fc456",
+          "id": "dd804642-b21e-4b94-ad28-2b71d923c310",
           "name": "Create SKU service value",
           "request": {
             "name": "Create SKU service value",
@@ -1169,7 +1169,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "49aa0fff-f3fd-4d07-bd5e-927b8835e2a4",
+              "id": "fa02ab7c-6abd-4e8a-95f8-3cd8b2702128",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1249,7 +1249,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0ae28f28-2fa0-4ff1-97b4-2d517a343cf4",
+                "id": "623c9a95-14b9-413d-9f8e-7f693dbe137b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicevalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1265,7 +1265,7 @@
           }
         },
         {
-          "id": "1dcccdfe-25de-4995-8e7b-12b638ccad4f",
+          "id": "f299d600-4341-4313-b888-99106a91990e",
           "name": "Get SKU service value",
           "request": {
             "name": "Get SKU service value",
@@ -1330,7 +1330,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1f34bf69-65c0-4767-8c36-eb7ea5fb8095",
+              "id": "6c58205e-3413-4c17-b15b-7b3430e55953",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1398,7 +1398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8e11955c-3d55-4d6f-aa1b-857263c5989d",
+                "id": "044ed3a9-df4d-462a-971e-e69b32526541",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1414,7 +1414,7 @@
           }
         },
         {
-          "id": "a0e8893a-69a9-4b30-9b4b-bb55768d84d5",
+          "id": "51c03627-af97-4928-bc19-da5c50836477",
           "name": "Update SKU service value",
           "request": {
             "name": "Update SKU service value",
@@ -1492,7 +1492,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ed514723-d9ef-46eb-a7dd-e003618331ef",
+              "id": "ffad6f44-4a65-4b8e-9006-75ddb5232597",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1573,7 +1573,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "accd0467-20e9-4790-94a6-d5aa1dfa2561",
+                "id": "7e615a4f-41d0-4d8e-88fb-da55b69dbdec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1589,7 +1589,7 @@
           }
         },
         {
-          "id": "6411c135-1bb5-4d7a-b22e-09208a5e127f",
+          "id": "40f623dd-e519-4f0b-b0e9-5a551cf9ad7e",
           "name": "Delete SKU service value",
           "request": {
             "name": "Delete SKU service value",
@@ -1650,7 +1650,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4c833a57-44ad-4b23-828f-5167910dc8f8",
+              "id": "40d4a28d-5161-450f-b516-3bad083bd283",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1708,7 +1708,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ed0c9c7d-c214-4df0-afca-c92833bb5e64",
+                "id": "a551b70f-c3cc-4fc5-90c4-3ff371ebb5c7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1724,7 +1724,7 @@
       "event": []
     },
     {
-      "id": "e3a51c8e-6d8f-424e-b08b-8183147af5ac",
+      "id": "29c954f5-6006-42f3-b31f-3ce3dc3fa59b",
       "name": "SKU service type",
       "description": {
         "content": "",
@@ -1732,7 +1732,7 @@
       },
       "item": [
         {
-          "id": "5bcb1c01-db11-475a-b29a-e4a95bb97496",
+          "id": "c0af0dff-00e6-4cba-a7d2-c2e8e69acd04",
           "name": "Create SKU service type",
           "request": {
             "name": "Create SKU service type",
@@ -1798,7 +1798,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c65e2722-c6bc-4151-a706-8db9c5207b77",
+              "id": "006d505a-3be9-47a2-9f37-45e7442a1e35",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1878,7 +1878,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2591b159-02ca-476b-a0c0-96b4fc2b326a",
+                "id": "49925166-6e05-422c-b047-5e9f343b6344",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicetype - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1894,7 +1894,7 @@
           }
         },
         {
-          "id": "6eec43ff-7622-48fa-80fb-7c8bfaf13b05",
+          "id": "d9f0a048-4222-4451-b859-5091528f8b47",
           "name": "Get SKU service type",
           "request": {
             "name": "Get SKU service type",
@@ -1959,7 +1959,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "903baf3c-e0bb-4d86-b194-08b138e247db",
+              "id": "14ce8a8c-ee10-4121-b508-7b29a778ea66",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2027,7 +2027,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "13abe5f5-4f17-44ab-9557-e79c98f54887",
+                "id": "0a0bd91e-1833-4538-8c6b-78f638a0ae2c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2043,7 +2043,7 @@
           }
         },
         {
-          "id": "00bc0edc-241e-4aba-a251-3a2f53af07ba",
+          "id": "38717760-6e4e-4a72-a709-551873f16f30",
           "name": "Update SKU service type",
           "request": {
             "name": "Update SKU service type",
@@ -2121,7 +2121,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3f039737-2f83-4e28-9e05-75ac1b25ec0d",
+              "id": "99d867e2-cad4-443e-b9d1-52f329dee4b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2202,7 +2202,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "95ae3272-5b18-4b4f-9972-dbf6ff8bbb67",
+                "id": "caff7b78-1c28-4b6b-8777-755c1ad9d4ee",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2218,7 +2218,7 @@
           }
         },
         {
-          "id": "6504ef02-c818-4e6b-a3b7-2e57e7d5dea8",
+          "id": "1e8a13cd-e200-4dcc-a725-201804f75d6d",
           "name": "Delete SKU service type",
           "request": {
             "name": "Delete SKU service type",
@@ -2279,7 +2279,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c3b50a24-c37a-48eb-9366-2853c2860643",
+              "id": "5dc8e4a8-5b43-42a1-b612-af2d5bb250b5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2337,7 +2337,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c527cd2c-fcdf-4bbd-b807-644a92bd8d11",
+                "id": "01331373-d6a0-492d-b51a-504a31594540",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2353,7 +2353,7 @@
       "event": []
     },
     {
-      "id": "fb54e575-bc02-44d1-8477-8e8c3ce56f01",
+      "id": "6f871c4f-b7e6-4865-99a1-2fbec569c3ff",
       "name": "Category",
       "description": {
         "content": "",
@@ -2361,7 +2361,7 @@
       },
       "item": [
         {
-          "id": "075a0745-f035-4859-b3e7-4509d52ab010",
+          "id": "e6ab487e-1259-4d89-90f7-70923bf7e8f1",
           "name": "Get category tree",
           "request": {
             "name": "Get category tree",
@@ -2427,7 +2427,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "29238de3-41e2-4a22-ac52-94cac05a3850",
+              "id": "f563315d-2ad2-4f57-85b1-5a2d1e28e7c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2496,7 +2496,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "52e3aef7-10fd-497d-b87f-45abce206dbf",
+                "id": "073e2cdd-d009-466d-923c-439fadd0a8d1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/category/tree/:categoryLevels - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2512,7 +2512,7 @@
           }
         },
         {
-          "id": "3dddf2d1-79db-495f-9247-7a90466c788c",
+          "id": "96a1d79f-01b3-40e2-9301-8dc4e0618f5f",
           "name": "Get category by ID",
           "request": {
             "name": "Get category by ID",
@@ -2587,7 +2587,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f80428f8-b845-4f56-84a0-15812f1ef9e6",
+              "id": "6d8b91db-6f88-450a-a9a6-43bfb75afa2e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2665,7 +2665,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "05884947-4f0d-4c8f-8280-40c778a2e459",
+                "id": "29d87a50-152d-4382-aa48-30bd6d1ba0d4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2681,7 +2681,7 @@
           }
         },
         {
-          "id": "bd83b1cd-dcbd-4f5c-bfa1-abbe477103d2",
+          "id": "3a392461-b800-43f1-b377-a70b065499d4",
           "name": "Update category",
           "request": {
             "name": "Update category",
@@ -2759,7 +2759,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ad3affab-71b9-4f17-95c6-48117ec337c4",
+              "id": "8ee0126d-79bd-4ffb-82dd-b437128b561b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2840,7 +2840,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0b7d0b67-9b16-4458-b74f-2b17f694dfca",
+                "id": "855de729-23b4-48a8-b9c1-4f593d5bdbe8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2856,7 +2856,7 @@
           }
         },
         {
-          "id": "4a3ae9a5-8684-4df5-8f78-1d79818e9971",
+          "id": "8c4f11fc-fa9f-4b96-a498-0d0d868618ec",
           "name": "Create category",
           "request": {
             "name": "Create category",
@@ -2922,7 +2922,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8eef1840-8d2a-4ba4-8758-9550fe6883fc",
+              "id": "e0962082-d831-4767-8912-c2b58f63e1a3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3002,7 +3002,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "861d5c73-799a-47c3-9307-ca6808f42ac8",
+                "id": "34d3ba1a-4658-45dd-afa8-6133ccf639e1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/category - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3021,7 +3021,7 @@
       "event": []
     },
     {
-      "id": "c4b1e249-b3cf-48df-af22-30b6a14797e6",
+      "id": "2a48d1bf-f7df-451b-bf5c-f2e008840c5d",
       "name": "Brand",
       "description": {
         "content": "",
@@ -3029,7 +3029,7 @@
       },
       "item": [
         {
-          "id": "03f3cfa1-b887-437f-b4c8-a42f910fa7ba",
+          "id": "30c3fe0f-ba3d-4242-a8fc-6585df055a13",
           "name": "Get brand list",
           "request": {
             "name": "Get brand list",
@@ -3083,7 +3083,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "25a145d5-7e9c-4b40-9994-8cb9b30b2b43",
+              "id": "bda0e81c-7367-443d-a99e-fec6b2149caa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "39473602-bd6b-47e9-bed3-f5ebeeb75bb8",
+                "id": "30438e37-5ca7-4eab-85bc-a31064368db8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3167,7 +3167,7 @@
           }
         },
         {
-          "id": "6db88c5b-78bc-4373-a0b1-80eb9b7b8af8",
+          "id": "74fdb7a2-51c9-4d26-aa2b-cd0129786550",
           "name": "Get paginated brand list",
           "request": {
             "name": "Get paginated brand list",
@@ -3240,7 +3240,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "34c16dbe-b7b0-4fb3-93b9-55c7de66b3e8",
+              "id": "5daa3290-556f-422c-adea-7ef3230cd802",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3327,7 +3327,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3cfe9769-893a-4348-9693-b2e267d72d1f",
+                "id": "856b7700-8552-4c17-9c89-d6c60bf0d84b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/pagedlist - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3343,7 +3343,7 @@
           }
         },
         {
-          "id": "828d6dfd-2119-4fbd-8a86-2cca463f5fd5",
+          "id": "6c497a56-94a2-41a9-8889-99ec60764ec8",
           "name": "Get brand by ID",
           "request": {
             "name": "Get brand by ID",
@@ -3408,7 +3408,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "64ea31e1-35e5-496c-9c63-7fcc6c860ad6",
+              "id": "b27fbca2-0b3b-421a-90f0-c11470e02a40",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3476,7 +3476,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8807225b-e151-48cf-a50c-98d8c649d64b",
+                "id": "0564021d-fdf5-4bc8-bd0c-86e7f947567d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3492,7 +3492,7 @@
           }
         },
         {
-          "id": "be267fb9-2c74-4015-8bc5-92c84660901b",
+          "id": "2ca2aab5-010f-4934-b100-a19cd6de73aa",
           "name": "Create brand",
           "request": {
             "name": "Create brand",
@@ -3558,7 +3558,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8c6e1755-7bb3-465c-865a-0da81bf50539",
+              "id": "1cebe7b5-1eaf-40d8-8c5a-782239d1d7f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3638,7 +3638,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "84243fb5-d6bb-4e87-a1de-bbc08dac6313",
+                "id": "073f4ee3-c7d3-4cca-ba58-61de80ba30cf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/brand - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3654,7 +3654,7 @@
           }
         },
         {
-          "id": "d3aa4c46-3c3c-4cae-9aa0-71b1a078ca89",
+          "id": "cc9d8404-15b9-46bf-b419-3050bd4d0341",
           "name": "Get brand and context",
           "request": {
             "name": "Get brand and context",
@@ -3719,7 +3719,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b21a7852-a1ef-4b66-a5e4-0e7d70aafeb9",
+              "id": "230154de-03c5-4dc0-a359-202ac7ad8604",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3787,7 +3787,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "de2d2d7d-aa5a-459e-9e37-582461d379db",
+                "id": "dca403f4-e0b7-437e-8e63-8184f39961c2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3803,7 +3803,7 @@
           }
         },
         {
-          "id": "beaa8826-0e3a-42da-b47d-18fce5a6eb2c",
+          "id": "d67052cb-6f6f-47dd-9f46-76fa5f627747",
           "name": "Update brand",
           "request": {
             "name": "Update brand",
@@ -3881,7 +3881,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ace2982c-fa4d-4a27-b508-74bf82a9b2e9",
+              "id": "c8c73245-e19d-4b6e-886d-85fd178af70d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3962,7 +3962,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "154f43c7-2a37-4505-9388-1660b2fc23fc",
+                "id": "409c4f88-01a5-4dfe-b784-c363562c73c3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3978,7 +3978,7 @@
           }
         },
         {
-          "id": "109c5382-bb7b-4da6-bd10-508af8ef12ae",
+          "id": "b085fb05-e54d-4358-a45e-87b69461749f",
           "name": "Delete brand",
           "request": {
             "name": "Delete brand",
@@ -4039,7 +4039,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "78b726a5-1f5a-48fa-aca8-40b0e83e59a4",
+              "id": "611d9153-b670-4304-b48f-3e0e1143cf19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4097,7 +4097,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "756ae5dc-a2b5-410f-b407-f1b6a503e555",
+                "id": "76f54a27-2bf3-4898-aef2-7b528e02291f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4113,7 +4113,7 @@
       "event": []
     },
     {
-      "id": "0bf6a118-0d83-47d4-8dee-1fae35d9dd02",
+      "id": "0bd2fa09-a12c-4670-9e08-c23441ebb45a",
       "name": "Attachment",
       "description": {
         "content": "",
@@ -4121,7 +4121,7 @@
       },
       "item": [
         {
-          "id": "320c1be0-aa13-4eb6-8a93-f12eef4d7294",
+          "id": "ad67a339-6db0-48c3-8a77-d4487db44ac4",
           "name": "Get attachment by ID",
           "request": {
             "name": "Get attachment by ID",
@@ -4186,7 +4186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bf0ffc1b-3b1a-4f34-888f-c39bf44523a3",
+              "id": "f201b681-1628-4aba-b8e7-6eff791af3d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4254,7 +4254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6f138a49-6b4d-4457-892b-82acb81b53e2",
+                "id": "095b0572-fd2e-468c-a7cb-9b38294a04c9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4270,7 +4270,7 @@
           }
         },
         {
-          "id": "ac1587df-1cd9-4a1b-93de-49f40488f535",
+          "id": "7c90ce14-aa38-482e-a1eb-aaa70a642120",
           "name": "Update attachment",
           "request": {
             "name": "Update attachment",
@@ -4348,7 +4348,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "95f005e0-ae9b-455d-82d2-18f69e68391d",
+              "id": "e73f819c-4132-4c38-9fe6-3c776b3f53de",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4429,7 +4429,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "83778db2-5563-4ba8-9535-5b79852feab1",
+                "id": "8b2c7fa5-8bbc-44d0-b0d0-0e3e61cc2cf5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4445,7 +4445,7 @@
           }
         },
         {
-          "id": "7856cc4b-0a4b-43f7-bdb3-099a9c32626d",
+          "id": "fd120b1f-8cab-4351-ab2b-1cfc6ab85b43",
           "name": "Delete attachment",
           "request": {
             "name": "Delete attachment",
@@ -4506,7 +4506,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4b89a93a-4a0f-4066-a82e-74fb654f3b75",
+              "id": "51f281a4-8048-4079-bd11-e7651ae7c8f9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4564,7 +4564,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f8ad2ea5-8b8a-441f-8a8c-c099d4b5ff1f",
+                "id": "6a663047-80b3-43ce-91c6-2cce9096d06c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4577,7 +4577,7 @@
           }
         },
         {
-          "id": "e20a6c82-5d47-4ba6-9521-ebc0718cfcc1",
+          "id": "19912574-7814-42d4-91a5-12312dd99e79",
           "name": "Create attachment",
           "request": {
             "name": "Create attachment",
@@ -4643,7 +4643,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c9af5e62-cf97-467f-9ec5-c83390b9b2c3",
+              "id": "5694f6f5-bd2e-4fc1-b8cc-fe89a3d13585",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4723,7 +4723,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "76c39380-f729-4823-8909-ff65fd7be4bf",
+                "id": "1625a009-a7d4-4214-88d9-b18a71ee9b7f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/attachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "9b5dab68-fa85-44b2-ae17-f288167870af",
+          "id": "cca3e8c1-0c93-4054-a405-a638834a8af7",
           "name": "Get all attachments",
           "request": {
             "name": "Get all attachments",
@@ -4792,7 +4792,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3404fe12-d634-4e50-a307-53e32ad94444",
+              "id": "4d082ca2-052d-4c06-8eea-b9a1fc9bbf50",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4859,7 +4859,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3060882c-449c-4de5-add0-7a8371e7530e",
+                "id": "48acdf72-e744-4081-bb84-7cf4f0e1fb82",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachments - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4878,7 +4878,7 @@
       "event": []
     },
     {
-      "id": "ddf6a414-6f4b-4255-b544-afca907e14f0",
+      "id": "25654eec-9139-4867-8827-2434ed47d13c",
       "name": "Product",
       "description": {
         "content": "",
@@ -4886,7 +4886,7 @@
       },
       "item": [
         {
-          "id": "de6efe3a-31b0-4df5-b187-311c35259c30",
+          "id": "ed6c4658-4af2-423a-88cf-ed6c683c2b12",
           "name": "Get product and SKU IDs",
           "request": {
             "name": "Get product and SKU IDs",
@@ -4968,7 +4968,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d8004402-16b8-4ad3-a8b8-655c563c8fae",
+              "id": "cf15e2ed-611c-4234-ad8c-8f07849886a5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5064,7 +5064,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ddfaab69-dfad-4573-a9bc-f21d3add8257",
+                "id": "6b6e3033-e2e4-4832-ad37-a778597dbf8b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/GetProductAndSkuIds - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5080,7 +5080,7 @@
           }
         },
         {
-          "id": "7875bb8b-c0a4-48ea-9b46-5a3dc4982db6",
+          "id": "5295359b-44c2-4d87-aa87-360b70b9c874",
           "name": "Get product by ID",
           "request": {
             "name": "Get product by ID",
@@ -5145,7 +5145,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a11007d0-a7b8-4c14-8e15-8722fe89bbc6",
+              "id": "5e97b436-4869-4803-8853-c189f0e04db6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5213,7 +5213,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "94c7a985-817d-4e53-91cf-d4cb79517920",
+                "id": "1f7282e7-19ff-46e3-ab75-7e646871babd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5229,7 +5229,7 @@
           }
         },
         {
-          "id": "5c6be730-52fb-4c61-8a2c-69b106bcbee8",
+          "id": "dbe0f36d-52cc-4785-971b-de92b0bfef18",
           "name": "Update product",
           "request": {
             "name": "Update product",
@@ -5307,7 +5307,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8665c0e9-ffa5-4a86-90c0-707359091585",
+              "id": "da6acff5-a477-4e87-b6d8-36c7a2dc94a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5388,7 +5388,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5f341192-8808-4879-a3c2-1623921c8b5c",
+                "id": "5eb8895e-8f17-4041-a84a-7c1818a5818e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5404,7 +5404,7 @@
           }
         },
         {
-          "id": "b97ac861-1557-4382-937e-62708ced85e3",
+          "id": "49a98c5f-6668-46d8-831a-19ac6d4bd85b",
           "name": "Get product and its general context",
           "request": {
             "name": "Get product and its general context",
@@ -5470,7 +5470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d8a62fc9-4646-4dda-b0bd-76be9105a1a4",
+              "id": "2bb665f7-39a0-4f7e-af88-79b54295b17e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5539,7 +5539,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e6c34b44-2063-49b6-b3c3-7f7983c34695",
+                "id": "cdee966b-c384-4600-9e99-e5e77e02490a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/productget/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5555,7 +5555,7 @@
           }
         },
         {
-          "id": "302b30e8-5fbd-4f01-af19-72505aa1af3e",
+          "id": "862cab70-7948-4862-a55f-e3e4db0315a5",
           "name": "Get product by reference ID",
           "request": {
             "name": "Get product by reference ID",
@@ -5621,7 +5621,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f4b57a64-c0d6-465a-8421-6dc1a6abe7f4",
+              "id": "63869c39-3bbb-4f25-b1f8-e434b6b38c07",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5690,7 +5690,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "718cca1f-50bf-4734-9c4e-5cceacfe4ffa",
+                "id": "23cb0d37-4c6c-46d1-8a45-67def543bfbc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/productgetbyrefid/:refId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5706,7 +5706,7 @@
           }
         },
         {
-          "id": "1a333c6c-0589-4cfd-8703-82601ff440aa",
+          "id": "6986c744-1fbc-4fe1-8a61-6a1998b7cf06",
           "name": "Get product's SKUs by product ID",
           "request": {
             "name": "Get product's SKUs by product ID",
@@ -5772,7 +5772,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "667ac87c-5cde-4452-bd05-517a3f196161",
+              "id": "8ac184a4-c26b-4c7d-af55-faad8f9b71cf",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "90ef69b5-277b-4ecb-85d3-e3ebd86e5660",
+                "id": "88c29599-cc14-4cda-a55a-44de129843c1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/products/variations/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5857,7 +5857,7 @@
           }
         },
         {
-          "id": "67ae2d41-2aa6-481b-9a63-9298692ea397",
+          "id": "4c8ae790-9446-4abe-b09e-8c01df5c4d53",
           "name": "Get product review rate by product ID",
           "request": {
             "name": "Get product review rate by product ID",
@@ -5923,7 +5923,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "89e41ad3-887a-4318-982d-d438f223e775",
+              "id": "20d0fe9d-ed95-4383-aac1-fc70d20ccf08",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5992,7 +5992,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e1db01a8-99df-42e2-b0b3-6722377947d9",
+                "id": "8537f5ca-1201-4686-856c-e9b9033787d8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/addon/pvt/review/GetProductRate/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6008,7 +6008,7 @@
           }
         },
         {
-          "id": "5557b5eb-0213-4041-9a66-d69bc26f0ef7",
+          "id": "bd6170d4-8c0c-4d7a-a7b4-349cdce1a8a6",
           "name": "Create product with category and brand",
           "request": {
             "name": "Create product with category and brand",
@@ -6074,7 +6074,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4eecafcc-6117-456d-b0e8-9fd6d7fedb7e",
+              "id": "d00494e9-ec44-4cbf-b9d5-d38d2064734b",
               "name": "New category and brand",
               "originalRequest": {
                 "url": {
@@ -6153,7 +6153,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f71e13c7-715b-4841-b163-310931878221",
+              "id": "2b636326-53fb-435b-b40d-f2ea40077f07",
               "name": "Associating it to an existing category and brand",
               "originalRequest": {
                 "url": {
@@ -6233,7 +6233,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "03872bdb-5629-485d-b4bb-ccc835d21aae",
+                "id": "0f295db7-34fa-4b9b-a252-14bd5f8d2fcf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6252,7 +6252,7 @@
       "event": []
     },
     {
-      "id": "91223772-4f10-4003-82aa-a462fd472288",
+      "id": "e0f7f14b-0d69-41cb-a291-79aac8a47691",
       "name": "Product specification",
       "description": {
         "content": "",
@@ -6260,7 +6260,7 @@
       },
       "item": [
         {
-          "id": "0428a40f-f3ef-48f4-948e-2e669fb9d55e",
+          "id": "765deea1-62f6-4d3c-a9bd-abf7f224bb36",
           "name": "Get product specifications by product ID",
           "request": {
             "name": "Get product specifications by product ID",
@@ -6326,7 +6326,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4e062ce3-42ce-4572-8019-9957b1702b05",
+              "id": "57216793-5f5d-48ea-a662-2af6579664b7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6395,7 +6395,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5e892261-8eae-4955-b16c-208836c2391f",
+                "id": "984f4ae3-e242-4518-8b2a-1d9f5a85a190",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6411,7 +6411,7 @@
           }
         },
         {
-          "id": "bef38734-6740-44b9-8c16-f246c2629e59",
+          "id": "f913451b-56f2-479d-94c2-b06bb5447000",
           "name": "Update product specification by product ID",
           "request": {
             "name": "Update product specification by product ID",
@@ -6486,7 +6486,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9e0158a9-ed2b-47e3-b044-ddd96d77f8ae",
+              "id": "06218e72-1aa4-46dd-b862-c4b64b315523",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6558,7 +6558,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "df8c6954-ff1d-4c88-822d-fb4dfac9c2da",
+                "id": "aa5125e5-aced-4227-b346-dc0ac312b823",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/products/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -6571,7 +6571,7 @@
           }
         },
         {
-          "id": "2e798d08-68d3-46cb-a8c8-e1d3cd437bc4",
+          "id": "0dd60d81-0e75-4f09-8c31-b57e8817a77f",
           "name": "Get product specifications and their information by product ID",
           "request": {
             "name": "Get product specifications and their information by product ID",
@@ -6637,7 +6637,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "506d9524-f498-49e1-b05c-2d3c1a6cd226",
+              "id": "16737b42-64fb-4c42-b41c-22dc17dc543b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6706,7 +6706,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7fa4f4ee-9441-4255-b56d-9cbf34be8747",
+                "id": "7e8244e6-1812-4779-a0a1-77b30ea939be",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6722,7 +6722,7 @@
           }
         },
         {
-          "id": "a3ec4f3e-66fb-4452-9df1-25241bc0d512",
+          "id": "c6ed8262-ca10-4902-a612-9c385beeb0fb",
           "name": "Associate product specification",
           "request": {
             "name": "Associate product specification",
@@ -6801,7 +6801,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "52425594-7725-4678-8b25-edbf41ac9644",
+              "id": "91e89147-6132-44bd-b461-33f2a5c2be14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6883,7 +6883,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "62ab3cc0-6e04-4cdc-a91a-ed26f1eccd21",
+                "id": "bca9fef6-87db-42ca-ab68-dc8009020749",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6899,7 +6899,7 @@
           }
         },
         {
-          "id": "dcfd2828-f470-4cd3-b8c2-a9f0c16a7643",
+          "id": "58a83876-65a3-4102-b7b7-df336fb51d78",
           "name": "Delete all product specifications by product ID",
           "request": {
             "name": "Delete all product specifications by product ID",
@@ -6961,7 +6961,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ec503271-f777-4116-bd93-f897c1741530",
+              "id": "2a99136f-267e-499e-b420-6c14bc39ff28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7020,7 +7020,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4b8908ce-45d7-41bb-b92e-7e3be7a642db",
+                "id": "33ebe212-12be-4ab7-a72a-0a29a6363275",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7033,7 +7033,7 @@
           }
         },
         {
-          "id": "b14fd579-d2e4-407f-8909-08f13c31beeb",
+          "id": "c9239ed7-1d8f-47a4-8c77-5ae83c8aeeb4",
           "name": "Delete a product specification",
           "request": {
             "name": "Delete a product specification",
@@ -7110,7 +7110,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c14574bb-94fc-469f-99a2-68eeeed1b351",
+              "id": "ad0e3ffb-c29c-4d48-9cef-ced278461de5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7169,7 +7169,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "49b4b1de-f9e2-4009-9f48-9bc4fcdc58e2",
+              "id": "49d2eecd-4c18-4bae-8161-fa7b108b5503",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -7239,7 +7239,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "921f6f1c-3b40-4cac-a87c-6fb0cc43aa7a",
+                "id": "49f48421-68fb-417e-ac81-bf3fbe73de46",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7252,7 +7252,7 @@
           }
         },
         {
-          "id": "78506448-08c6-417a-84e7-e56332037949",
+          "id": "3ca152e2-ca63-4370-9c80-9f71ff3a5647",
           "name": "Associate product specification using specification name and group name",
           "request": {
             "name": "Associate product specification using specification name and group name",
@@ -7331,7 +7331,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "016e1a41-2549-41f8-9b95-dea95f523104",
+              "id": "cd9c3209-db3b-4f91-86ae-64ffe1b6e4d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7413,7 +7413,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "692f3980-46a3-4157-80e5-47484ef1bdd1",
+                "id": "48855756-5cee-4a94-8f42-dbf6cc4ff53a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7432,7 +7432,7 @@
       "event": []
     },
     {
-      "id": "e84579ef-785e-46dc-aea6-7389468370be",
+      "id": "1d6611f2-63e5-4f98-9547-af20a962f59a",
       "name": "Similar category",
       "description": {
         "content": "",
@@ -7440,7 +7440,7 @@
       },
       "item": [
         {
-          "id": "c818f7ba-a603-4dc6-8a1e-09afc080790d",
+          "id": "f9f0f24c-44c1-469a-a7e1-1eb33fac3653",
           "name": "Get similar categories",
           "request": {
             "name": "Get similar categories",
@@ -7506,7 +7506,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9c32643c-8e24-4de8-bf00-0e4682e864aa",
+              "id": "a0caef08-b5a8-46ca-bd42-87ed43758ff6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7575,7 +7575,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0941595a-e41c-4d21-be74-6e0feb4c3892",
+                "id": "30a6e74b-e876-4d72-8a62-fb1a22ab12e9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/similarcategory - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7591,7 +7591,7 @@
           }
         },
         {
-          "id": "094a100e-3773-4e3f-9a9c-7b63b5a9d1ab",
+          "id": "2b34974f-c6be-44e3-a1ab-d7fd2c89841b",
           "name": "Add similar category",
           "request": {
             "name": "Add similar category",
@@ -7668,7 +7668,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "893cf51e-d9df-4e39-bffb-be9a669d2d06",
+              "id": "a2502d83-5b23-485a-8443-9d9d62334afd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7738,7 +7738,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "de4194cf-e454-499c-a599-49b67b7dc65b",
+                "id": "9bb8018b-41fc-4228-af7c-f9fa336a0663",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/similarcategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7754,7 +7754,7 @@
           }
         },
         {
-          "id": "a96bb4ef-76b6-4129-b704-b2cfdba47c8d",
+          "id": "ecc0210c-46f2-4131-8bb3-f4e2dedeaa60",
           "name": "Delete similar category",
           "request": {
             "name": "Delete similar category",
@@ -7827,7 +7827,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2d91c747-7dc5-4644-8082-fdf54e09013d",
+              "id": "32932aa8-6a6f-454a-8b95-40fedf62ad26",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7887,7 +7887,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8d03866e-e7d7-4aec-9c93-2b970c71ef57",
+                "id": "500169e9-d1bd-4d91-b0fb-4b289f8b9b24",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/similarcategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7903,7 +7903,7 @@
       "event": []
     },
     {
-      "id": "a591877f-89d2-4268-99ec-9aef39b280ed",
+      "id": "d08c7814-15b3-44b4-88c7-3e8e6259d085",
       "name": "SKU",
       "description": {
         "content": "",
@@ -7911,7 +7911,7 @@
       },
       "item": [
         {
-          "id": "200ec43d-3be8-48fb-8047-e47efacc5ae9",
+          "id": "468e6188-ec6e-4339-aef4-300241c2ac3f",
           "name": "List all SKU IDs",
           "request": {
             "name": "List all SKU IDs",
@@ -7984,7 +7984,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9ce11613-0ece-4840-b133-1ea6dcd540cf",
+              "id": "5dea25a1-5806-4688-9040-09dc791292f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8071,7 +8071,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3fe1a5c6-40ff-4d42-bb9c-ef7f22af1695",
+                "id": "45348ea2-5a41-472d-95bc-b8acaa9610f2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitids - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8087,7 +8087,7 @@
           }
         },
         {
-          "id": "66833670-fbb8-44a1-9234-235f6a7176c4",
+          "id": "0e75f7b7-7f34-4097-b9a6-df4f4fb99791",
           "name": "Get SKU and context",
           "request": {
             "name": "Get SKU and context",
@@ -8163,7 +8163,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0331ac4d-e333-4b6e-a1d6-d6429d25d84c",
+              "id": "c3a2cd97-76e8-4c78-a54d-5019f4217252",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8242,7 +8242,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cb0b57ea-99af-4603-88ed-5cae3f91c720",
+                "id": "6a52936c-7130-40bc-a35b-78d2f57d466f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyid/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8258,7 +8258,7 @@
           }
         },
         {
-          "id": "23a5416d-abc0-488b-9b0c-5167a63e397c",
+          "id": "7018e77e-005d-4db1-8acd-447ce43af126",
           "name": "Get SKU by reference ID",
           "request": {
             "name": "Get SKU by reference ID",
@@ -8321,7 +8321,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f4e48e4f-2add-4f9f-8e49-cfd3c65f5ca1",
+              "id": "b2e08058-55af-4161-8675-16942b20b1c3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8398,7 +8398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bf470a21-3e95-44e4-a498-20458838dbd6",
+                "id": "159dc80c-3f2d-44d4-8c2f-009fdc832429",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8414,7 +8414,7 @@
           }
         },
         {
-          "id": "c8732ffe-72e3-47e5-b7a9-4edd3307e494",
+          "id": "af2e7038-5595-4390-a8c1-c6636fa04fbf",
           "name": "Create SKU",
           "request": {
             "name": "Create SKU",
@@ -8480,7 +8480,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "025ec6d3-5250-4ea3-9491-431fd92b7ca4",
+              "id": "412667ab-ee4e-4566-a9c0-35fdde83e6ad",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8560,7 +8560,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f03cb0fb-ba66-4007-bb2a-1298de14921e",
+                "id": "4070c08a-4fa1-43d9-8f06-21cf7a06e0b9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8576,7 +8576,7 @@
           }
         },
         {
-          "id": "701eca28-bdf8-43b9-a5b5-bca4b43376cc",
+          "id": "389d5210-b402-4da9-b397-8a569483ecbd",
           "name": "Get SKU ID by reference ID",
           "request": {
             "name": "Get SKU ID by reference ID",
@@ -8642,7 +8642,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5e7d8b8e-c439-4af0-acad-0a0ad82d8e93",
+              "id": "27eb7047-376f-4ecb-9c38-08e69152a08a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8711,7 +8711,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b623e46f-562f-4769-84b8-e9a44dc1f902",
+                "id": "b8d99633-ac64-4cf5-b613-892ad7c88799",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitidbyrefid/:refId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8727,7 +8727,7 @@
           }
         },
         {
-          "id": "e8981ccf-39a6-4cc6-8dff-7c1169e8268f",
+          "id": "3bcce1bc-5e88-4a42-aa6e-e900c2e9a039",
           "name": "Get SKU by alternate ID",
           "request": {
             "name": "Get SKU by alternate ID",
@@ -8793,7 +8793,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "afc611a2-4a54-4716-a0f2-7057872e87d4",
+              "id": "34642290-60f9-4d9b-90c7-196aa02b07c5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8862,7 +8862,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3b63815b-eab1-49ae-a87f-7737cea0e689",
+                "id": "3e5bae34-d3e5-4f75-b98f-015a5e2b72a0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyalternateId/:alternateId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8878,7 +8878,7 @@
           }
         },
         {
-          "id": "1a876dbe-483a-47dc-9c5e-465a7f98a481",
+          "id": "7daa6cd9-f5ec-4314-b79a-9724e53fa1c0",
           "name": "Get SKU list by product ID",
           "request": {
             "name": "Get SKU list by product ID",
@@ -8944,7 +8944,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e375ce69-170d-47af-bb3f-fa3a912d003b",
+              "id": "cb029211-5a2b-429f-847a-c69c0692fc19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9013,7 +9013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "760b2c0e-1054-4d89-9752-855bc1092f44",
+                "id": "076b9e44-3f6b-4190-9d40-4cf0414c1542",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitByProductId/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9029,7 +9029,7 @@
           }
         },
         {
-          "id": "f9fae899-00fe-4be1-9f4e-1b3aab59f0c3",
+          "id": "df2a825f-4b9a-4d7a-9b55-9f44aaa247e5",
           "name": "Retrieve SKU ID list by reference ID list",
           "request": {
             "name": "Retrieve SKU ID list by reference ID list",
@@ -9096,7 +9096,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "44647e22-531d-47db-b5f5-12d028cb9622",
+              "id": "817b9ec1-23f7-4522-8c17-f78459b5a838",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9176,7 +9176,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1ccd8104-52f9-4947-92b7-23447632bf2f",
+              "id": "198c5105-368a-4de8-8df1-ac484db4e403",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -9247,7 +9247,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "96c6dfa2-2c48-437e-9419-61555e74e120",
+                "id": "41b14722-eb97-4a1a-b65a-1a0b64f1cdf9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pub/sku/stockkeepingunitidsbyrefids - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9263,7 +9263,7 @@
           }
         },
         {
-          "id": "29b69c50-4ca8-4a61-b123-fe04e62712f9",
+          "id": "b90db56b-b679-4ac3-8166-6372c336aa1e",
           "name": "Get SKU",
           "request": {
             "name": "Get SKU",
@@ -9328,7 +9328,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fa3dc61d-fdfd-4ad8-8029-daa0bfffdc1a",
+              "id": "9a92ea82-0b3c-4742-85ec-2000b2c83a8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9396,7 +9396,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7cea6679-6e39-4ec7-a8c2-8c31c019bb58",
+                "id": "76bff5d7-2be6-4d89-9b34-1aeb2a4e39b4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9412,7 +9412,7 @@
           }
         },
         {
-          "id": "ea4cc1c3-2b90-4825-ba7f-816ab4b07ea3",
+          "id": "bc7eca6f-d989-4e2e-b0e3-189d0b5b77f0",
           "name": "Update SKU",
           "request": {
             "name": "Update SKU",
@@ -9490,7 +9490,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fa1c327c-d8fc-48e7-9be8-d3a499234d2d",
+              "id": "d91af4ea-6e0b-4684-9bcd-403f523db5af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9571,7 +9571,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "004e98da-203a-41cc-ad27-42763095f6e6",
+                "id": "e004803c-2eb5-49a8-bdb5-245e699df4b2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9590,7 +9590,7 @@
       "event": []
     },
     {
-      "id": "cefe6541-1395-408e-a8e8-637dcd647bfd",
+      "id": "8d925bc3-7863-42ed-aa19-c7ef8f5b7c6f",
       "name": "SKU EAN",
       "description": {
         "content": "",
@@ -9598,7 +9598,7 @@
       },
       "item": [
         {
-          "id": "13483310-9282-4f8e-bb7a-f22509f86d91",
+          "id": "d704482d-b00c-4a04-b053-a6d0fb36b90b",
           "name": "Get SKU by EAN",
           "request": {
             "name": "Get SKU by EAN",
@@ -9664,7 +9664,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4854d900-da00-4332-bcec-95e902cde886",
+              "id": "372f2c48-e7b7-44a3-9630-36a72d468391",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9733,7 +9733,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6c7d143d-0ffc-4f86-88fb-4565f8b75749",
+                "id": "80808c9f-695c-4b7e-9567-d4c78f210844",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9749,7 +9749,7 @@
           }
         },
         {
-          "id": "a9be9bda-effe-42ba-a342-550be77de9d6",
+          "id": "23d8b7e9-4520-4284-a9dc-668540919079",
           "name": "Get EAN by SKU ID",
           "request": {
             "name": "Get EAN by SKU ID",
@@ -9815,7 +9815,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8f82bb55-4dff-4de0-8639-d2fd5d71b566",
+              "id": "e3043b09-66c4-4b3b-a96c-24256a2a28c8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9884,7 +9884,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4ad9bf93-b9a1-4cb3-be65-c58e84125c74",
+                "id": "ff7b91f2-ea66-4b44-a5bf-e9eb836eb1f9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9900,7 +9900,7 @@
           }
         },
         {
-          "id": "f03b9638-7b29-44b4-9646-13962437501d",
+          "id": "e042c369-3494-4165-abb7-8a5ecea28f78",
           "name": "Delete all SKU EAN values",
           "request": {
             "name": "Delete all SKU EAN values",
@@ -9962,7 +9962,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ca59a3ae-08f2-400e-958e-dd9625990577",
+              "id": "66ac736b-c37b-4e8e-9b30-4c336fe777ec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0afafd2b-649a-40c5-a86e-6f8fd18e1a53",
+                "id": "0aa33637-a885-41c3-91a7-349c2ebcfa4d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10034,7 +10034,7 @@
           }
         },
         {
-          "id": "d4efbec5-5bc1-4e44-8e1c-e2f31a7d629a",
+          "id": "8bceb417-dcd2-4f19-81b4-168b1da5afff",
           "name": "Create SKU EAN",
           "request": {
             "name": "Create SKU EAN",
@@ -10107,7 +10107,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4509118e-a6ab-4a71-8bfb-b0f890f50b1a",
+              "id": "662692eb-f1a6-432f-8a97-bedce79c6840",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10167,7 +10167,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1a09f000-8913-4cf0-bc33-10d2c7ce7e8c",
+                "id": "0af5b528-292d-4bee-bdd7-692469e9f1c4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/ean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10180,7 +10180,7 @@
           }
         },
         {
-          "id": "4cc30db3-b910-4bfd-9e64-fab076dc4694",
+          "id": "1e69cfd1-863f-4ec5-b287-abd794bd3076",
           "name": "Delete SKU EAN",
           "request": {
             "name": "Delete SKU EAN",
@@ -10253,7 +10253,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "71a39ab4-e44b-4a9e-8e83-66bad7526675",
+              "id": "fd621005-b1be-4be8-9aec-1bf75e199003",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10313,7 +10313,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "aa198b83-2d88-43a8-8af8-bf9ebb49ddd9",
+                "id": "66e80578-15f1-4dcd-9601-268c753e204b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/ean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10329,7 +10329,7 @@
       "event": []
     },
     {
-      "id": "9f238b11-e32c-4ccc-9258-fc94d1936277",
+      "id": "3cc3153b-77ed-4454-a133-17fe6f878de4",
       "name": "SKU file",
       "description": {
         "content": "",
@@ -10337,7 +10337,7 @@
       },
       "item": [
         {
-          "id": "1793ae64-c93d-4895-a757-1796a1f1cc50",
+          "id": "e56c180e-b8a4-48cc-9b26-90ac9b263b31",
           "name": "Get SKU files",
           "request": {
             "name": "Get SKU files",
@@ -10403,7 +10403,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "72ab5e31-a765-4d73-8615-55cd8f9da66f",
+              "id": "37976b39-15d9-4db8-b8a5-1b86ab4156ac",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10472,7 +10472,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9bdce717-280b-48de-883c-8a28a913f217",
+                "id": "270721e7-d7f2-48d2-bc42-2912ef98d8e1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10488,7 +10488,7 @@
           }
         },
         {
-          "id": "28f8beb5-c6fd-47b8-8795-859d39bf4eb2",
+          "id": "2f2d7fda-ef83-4c1f-9415-b6870d173b22",
           "name": "Create SKU file",
           "request": {
             "name": "Create SKU file",
@@ -10567,7 +10567,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "abcc9771-7036-4caa-993d-57a02a205187",
+              "id": "521e2054-5886-440e-87e4-8211f3921381",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10649,7 +10649,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b40d8db7-3478-4b9f-9479-e8b4cde7d671",
+                "id": "f6bc48b4-a1d5-49f9-a984-0c5da56c2e7b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10665,7 +10665,7 @@
           }
         },
         {
-          "id": "f59be1f5-4e19-4c23-91f8-35812ea26be8",
+          "id": "cca124dc-6932-4d3e-ac86-d1e42ff05c6b",
           "name": "Delete all SKU files",
           "request": {
             "name": "Delete all SKU files",
@@ -10727,7 +10727,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "aac7cfe1-20eb-4e55-b96a-0c691bf96923",
+              "id": "50dbce24-c590-4818-8026-6b3868e72a19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10786,7 +10786,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4da3b50a-21f0-4a2c-af34-0d4532b1171b",
+                "id": "70e4c4fc-53ec-4fc0-913a-daabddc840e4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10799,7 +10799,7 @@
           }
         },
         {
-          "id": "6463a188-21df-4f91-a4ee-d1c92af6727e",
+          "id": "4b83be68-4722-4dd8-b2db-6a3f2b142f5a",
           "name": "Update SKU file",
           "request": {
             "name": "Update SKU file",
@@ -10889,7 +10889,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2a1d5554-df56-4cdd-b2f7-5f75837e25cf",
+              "id": "a0b2ff26-019e-4930-86b1-40c5a4c2a005",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10972,7 +10972,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d2a4da23-58da-469b-960b-cbaadcc14f80",
+                "id": "b08237bd-70e4-4c96-a13c-7a3865e591be",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10988,7 +10988,7 @@
           }
         },
         {
-          "id": "9fd9484d-ccd8-41a2-8153-ae624c0c7a17",
+          "id": "16e6a935-a1fd-4053-a92a-9a4a9d13b43b",
           "name": "Delete SKU image file",
           "request": {
             "name": "Delete SKU image file",
@@ -11061,7 +11061,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3737d637-cc26-484b-bd36-a4cd04a27f19",
+              "id": "fd8df593-2777-46aa-b61a-637c3d678a84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11121,7 +11121,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fa065720-9afc-45d6-a77c-432ccd73f929",
+                "id": "a7119164-633e-4ae1-bfa3-eba386fdb015",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11134,7 +11134,7 @@
           }
         },
         {
-          "id": "4af22833-0638-4131-a900-043cab7f2de8",
+          "id": "f4e0b88d-af49-41e4-9176-639d59ca7dd4",
           "name": "Reorder SKU files",
           "request": {
             "name": "Reorder SKU files",
@@ -11210,7 +11210,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "39f6959c-09ed-44fd-becd-272975b40e8c",
+              "id": "870d88c9-ccd2-4909-bee4-4febc4a6c4f3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11282,7 +11282,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ebf74302-6f79-4836-9efd-0d521bdbf55e",
+              "id": "d4ae161d-6a47-4df1-9570-1a14e8c36dbe",
               "name": "Bad request. All files are required.",
               "originalRequest": {
                 "url": {
@@ -11355,7 +11355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3322738c-5c56-4193-9b6e-c7ea9ea24321",
+                "id": "9566e847-c575-4340-85cf-c5d260151bc0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/reorder - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11368,7 +11368,7 @@
           }
         },
         {
-          "id": "b6a58adf-9020-4fb0-9349-75a7ece672f3",
+          "id": "5ad95b8f-a36d-498a-9f08-df9fd1dedc38",
           "name": "Copy files from an SKU to another SKU",
           "request": {
             "name": "Copy files from an SKU to another SKU",
@@ -11446,7 +11446,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "20617662-299b-4830-9671-15eedea788ac",
+              "id": "b670791f-7df5-4251-aa98-a6c136f855d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11517,7 +11517,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5da1a1be-c65b-4658-9890-fdd9c68738e5",
+                "id": "6fd6c95b-d2c5-447e-a80e-c3c2a3bf8815",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/copy/:skuIdfrom/:skuIdto/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -11533,7 +11533,7 @@
           }
         },
         {
-          "id": "eba76130-e476-4bd3-bffd-fc7247267847",
+          "id": "bf4d911b-9950-48a7-b849-a90429c0cc78",
           "name": "Disassociate SKU file",
           "request": {
             "name": "Disassociate SKU file",
@@ -11607,7 +11607,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "105bace2-c604-45cb-acc7-9047a3952cf5",
+              "id": "8231d13c-0c00-42a0-acaa-b20c9b172f17",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11668,7 +11668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d10d51b8-9022-48f9-ac6d-268aa58c2463",
+                "id": "bdeaec7f-d99c-4d62-a307-4b877dbda953",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/disassociate/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11684,7 +11684,7 @@
       "event": []
     },
     {
-      "id": "e894467b-97d5-47fe-986a-49bf26070ba1",
+      "id": "b471272e-d9a7-4751-b8c5-313934b17075",
       "name": "SKU kit",
       "description": {
         "content": "",
@@ -11692,7 +11692,7 @@
       },
       "item": [
         {
-          "id": "bb9ec43a-d312-49ca-b85b-efd22512a2a5",
+          "id": "9db05215-ce81-41dc-a1f1-98ac53b20d74",
           "name": "Get SKU kit by SKU ID or parent SKU ID",
           "request": {
             "name": "Get SKU kit by SKU ID or parent SKU ID",
@@ -11764,7 +11764,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5aea86b0-09e2-4bca-932c-7a74f8263f44",
+              "id": "cf0c9299-abba-482d-a232-2fe650e27182",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11850,7 +11850,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5e1f8f56-62ca-46cc-b9a2-40cadbedd167",
+                "id": "38c74411-30e7-43a3-a567-4feeac52ab89",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -11866,7 +11866,7 @@
           }
         },
         {
-          "id": "b88d15e5-f787-41a3-ba79-4beea323c0bc",
+          "id": "966d0b4d-0d45-4b06-b3cb-8440d9549b44",
           "name": "Create SKU kit",
           "request": {
             "name": "Create SKU kit",
@@ -11932,7 +11932,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "889bbe72-6b7b-4ff1-a11b-c5bcb3dc19ef",
+              "id": "01facd80-24c6-4841-a1e8-d66320a927ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12012,7 +12012,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "33f4e387-b934-4aa5-9934-5bcb22877bcc",
+                "id": "ca34fbcc-09b7-4771-a87e-784272567301",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12028,7 +12028,7 @@
           }
         },
         {
-          "id": "d50f7d61-7a26-4f77-bafb-2fbc606ded01",
+          "id": "f2e246e7-54f0-4bdc-ad57-8df55ea5c7c5",
           "name": "Delete SKU kit by SKU ID or parent SKU ID",
           "request": {
             "name": "Delete SKU kit by SKU ID or parent SKU ID",
@@ -12096,7 +12096,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "732e370d-9445-4e74-8eab-7257ee7cfc0b",
+              "id": "94082c19-ac46-4ee9-81cd-f3e83816b06e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12172,7 +12172,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ff20e092-5a2a-4cee-b858-6d86bee3f449",
+                "id": "0d1939ca-44c4-47e9-8567-c4e53115824c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -12185,7 +12185,7 @@
           }
         },
         {
-          "id": "6466ff47-08b9-4136-8a0e-9e7cea99ece3",
+          "id": "18c724a9-e735-48df-98ce-c0d322019e30",
           "name": "Get SKU kit",
           "request": {
             "name": "Get SKU kit",
@@ -12250,7 +12250,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1217a3ae-307e-4270-a747-9cdf9be34b1e",
+              "id": "3e09f921-fe78-45df-a4f2-9638c0bb3602",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12318,7 +12318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ddfada41-ad00-4651-a337-05d53520fd8e",
+                "id": "4e8d595c-e9c4-4baa-a0a6-d0acb43d3047",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunitkit/:kitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12334,7 +12334,7 @@
           }
         },
         {
-          "id": "6dff90c2-8fc6-4174-9ffb-b6ceac172f81",
+          "id": "261673c1-09d5-41a4-8a15-d3ed01916a13",
           "name": "Delete SKU kit by kit ID",
           "request": {
             "name": "Delete SKU kit by kit ID",
@@ -12395,7 +12395,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ed485ab1-fd35-4ea2-b606-f90618cb2344",
+              "id": "e693a692-bf4d-40da-84cb-77266f8c2751",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12453,7 +12453,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2df1bfe1-e2c3-47ec-bdb4-da50acdcc482",
+                "id": "6a85c197-fc84-420b-b6c9-9f5b7b624166",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunitkit/:kitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -12469,7 +12469,7 @@
       "event": []
     },
     {
-      "id": "a7941b8d-5265-4170-a81e-e78d013c5169",
+      "id": "45969c5a-e6aa-4fc5-b348-60d017e3f3a9",
       "name": "SKU specification",
       "description": {
         "content": "",
@@ -12477,7 +12477,7 @@
       },
       "item": [
         {
-          "id": "5e92d918-abdd-4759-92f4-e7eda0dc064b",
+          "id": "6742db53-9188-4f7e-91b6-a23d4ce4ac0d",
           "name": "Get SKU specifications",
           "request": {
             "name": "Get SKU specifications",
@@ -12543,7 +12543,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "17e6d678-a420-4c5d-9f39-8207c05253a2",
+              "id": "54c3a159-3361-41f2-990a-fbbef8b7e94f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12612,7 +12612,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a1805bba-90e3-4283-ab48-bed1347bf181",
+                "id": "58fdc4e2-5104-42a2-a02a-56f332d25493",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12628,7 +12628,7 @@
           }
         },
         {
-          "id": "9e5d3014-0cf2-4132-9355-1d59e8eb7e50",
+          "id": "a6a4fa1b-7f71-46a5-9d2c-9a4cfb8b38c3",
           "name": "Associate SKU specification",
           "request": {
             "name": "Associate SKU specification",
@@ -12707,7 +12707,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f3522891-4f77-4316-a008-08ee272470ba",
+              "id": "55e47abe-d886-43c2-b6cd-1151bb2d589b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12789,7 +12789,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "03ff8ae4-c953-44a5-91b5-61079cd09fbb",
+                "id": "851e659f-b15a-49c0-ab9f-16d18f28fdc0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12805,7 +12805,7 @@
           }
         },
         {
-          "id": "e2214d73-5a44-4dc4-8bf0-0771e9fe722e",
+          "id": "be5b63f4-07f8-4377-bb75-d9543852b4f6",
           "name": "Update SKU specification",
           "request": {
             "name": "Update SKU specification",
@@ -12884,7 +12884,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3a4e7cc4-f559-4629-99d7-cf5411d77197",
+              "id": "d2f1e174-92ec-4bf0-b5b0-59788f74906c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12966,7 +12966,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b9175bbf-3696-4a46-9334-0ed7aa3ec932",
+                "id": "bff565d6-4dbd-4b93-a369-d381ed1bd08e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12982,7 +12982,7 @@
           }
         },
         {
-          "id": "bff431ad-1da7-4c6d-be9b-64cf06cb3f35",
+          "id": "13eb273d-ada9-427f-9fc7-f71f3d6558ee",
           "name": "Delete all SKU specifications",
           "request": {
             "name": "Delete all SKU specifications",
@@ -13044,7 +13044,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "55ba7402-4079-4c5e-9475-079a0fcabf8f",
+              "id": "c0e2b08f-7ae6-4c5b-b429-39a05404ddde",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13103,7 +13103,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "13fbbd47-2af2-49c3-a68c-1905fb534882",
+                "id": "a498dbc2-501a-4341-8fa0-bff0027712ad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13116,7 +13116,7 @@
           }
         },
         {
-          "id": "2e9274f4-49a6-41f1-a365-e54077ffad59",
+          "id": "c6e825f7-8560-4021-b538-05293341a8bf",
           "name": "Delete SKU specification",
           "request": {
             "name": "Delete SKU specification",
@@ -13189,7 +13189,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "89a72ffe-366a-4e1f-b3c2-e34f7c279260",
+              "id": "1048b95b-1ac6-4207-bad1-033ba6faee24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13249,7 +13249,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0b652292-d966-4a79-ab64-d7f790d69b71",
+                "id": "1bcd9775-8786-4fca-8cc0-9873eb74e932",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13262,7 +13262,7 @@
           }
         },
         {
-          "id": "290219ea-779f-4891-895e-67eb4dec7667",
+          "id": "31cb3592-794a-4d59-890d-a1873c796db3",
           "name": "Associate SKU specification using specification name and group name",
           "request": {
             "name": "Associate SKU specification using specification name and group name",
@@ -13341,7 +13341,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dfa80950-67aa-4941-9712-bd5cd0f306a0",
+              "id": "9c008cae-c497-4a5b-b10e-1dbf186afe75",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13423,7 +13423,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "158ccd4d-def5-4080-9ce4-c6f48e3ecba5",
+                "id": "be8841b2-3ec1-4052-85bd-51785603d4ad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13442,7 +13442,7 @@
       "event": []
     },
     {
-      "id": "29f9b645-fe87-4cd6-97d7-743100b237f7",
+      "id": "658df6d6-9141-4aa5-a0b2-1820f99ab161",
       "name": "SKU attachment",
       "description": {
         "content": "",
@@ -13450,7 +13450,7 @@
       },
       "item": [
         {
-          "id": "8fcd73e5-cae3-4cae-9768-6aebf8611dbc",
+          "id": "9fd79323-ce7d-46ef-9e85-113599bcb929",
           "name": "Associate SKU attachment",
           "request": {
             "name": "Associate SKU attachment",
@@ -13516,7 +13516,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "89e5ff14-762e-4726-9f21-15e999dd804c",
+              "id": "e4fdd067-caf0-4b00-8f62-37b50be1038c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13596,7 +13596,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0f864e44-e939-4e3b-9925-7588defe67d6",
+                "id": "29b125ae-710f-42d0-8921-ea8c98437ab5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13612,7 +13612,7 @@
           }
         },
         {
-          "id": "f72ec9c7-fc5f-49f6-9551-e25ed6560b1d",
+          "id": "699b92eb-f0db-4e56-83bc-4d6522736673",
           "name": "Dissociate attachments and SKUs",
           "request": {
             "name": "Dissociate attachments and SKUs",
@@ -13680,7 +13680,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f42c561c-721b-4eb7-9a74-a72845573981",
+              "id": "9dbabaff-5904-4218-8f37-11c4d9fd8262",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13756,7 +13756,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cc159b0f-f7ab-435a-afc5-979c266de3d2",
+                "id": "0b62b018-a9d1-48e9-b22b-199f129ddd97",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13769,7 +13769,7 @@
           }
         },
         {
-          "id": "ff3b791e-92af-4e22-903c-1c00e6d9f350",
+          "id": "4031903f-6382-48b7-b7ce-35ced054f659",
           "name": "Get SKU attachments by SKU ID",
           "request": {
             "name": "Get SKU attachments by SKU ID",
@@ -13835,7 +13835,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a4f20811-5352-4491-95b9-bcb3167f323e",
+              "id": "831c3a09-7b29-4fc2-8ae9-f205d5516cd7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13904,7 +13904,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c4703987-f58c-422b-9225-955f94e762ef",
+                "id": "544cd8f5-7686-4584-8385-8a7879ab2a36",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13920,7 +13920,7 @@
           }
         },
         {
-          "id": "de754b4c-ad3f-4820-a053-bb5ae86b3fca",
+          "id": "69d2de72-4664-4733-b3e8-6f6b84f144f1",
           "name": "Delete SKU attachment by attachment association ID",
           "request": {
             "name": "Delete SKU attachment by attachment association ID",
@@ -13981,7 +13981,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7464ca34-4512-499b-9dab-93147c053cd8",
+              "id": "3096660d-6692-4031-9867-edca03e66ec0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14039,7 +14039,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "85b099a2-972b-4d8e-8953-2e0bf594ea7e",
+                "id": "18111110-3c4d-45f5-a7b8-51d20f5d729f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuattachment/:skuAttachmentAssociationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -14052,7 +14052,7 @@
           }
         },
         {
-          "id": "9e948fff-f66f-4b08-9ba3-b4668171f57b",
+          "id": "98d138f4-f570-470f-9f06-c1792418114c",
           "name": "Associate attachments to an SKU",
           "request": {
             "name": "Associate attachments to an SKU",
@@ -14115,7 +14115,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "321c015a-97f5-4644-bdf8-f0a726f195e1",
+              "id": "8f3a77ba-e8ec-4603-8138-fd2008ee5daa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14186,7 +14186,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1bebeffb-8238-4df6-aaf8-50dda85d8ab1",
+                "id": "80e6f7e7-39e6-44f0-90fd-12e95bb350b6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/sku/associateattachments - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -14202,7 +14202,7 @@
       "event": []
     },
     {
-      "id": "0a9adfb1-8f53-4a79-aafe-7f0038c41057",
+      "id": "29c9b96e-74d1-4c1b-ad96-0144fec6b541",
       "name": "SKU complement",
       "description": {
         "content": "",
@@ -14210,7 +14210,7 @@
       },
       "item": [
         {
-          "id": "1c50d7ba-9a25-4250-97d3-ff27d6fc30c8",
+          "id": "21dbe384-d155-4e41-b8b8-270c67f74d6f",
           "name": "Get SKU complement by SKU ID",
           "request": {
             "name": "Get SKU complement by SKU ID",
@@ -14276,7 +14276,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b1d55c7c-0507-488c-93e3-9b40dfc414c9",
+              "id": "b49a6396-499d-4b8d-b7cc-6aa0ba7496db",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e29f279e-6243-422b-b7f9-a98409524f19",
+                "id": "d658c520-ba64-4e13-ac77-9b949e8377de",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/complement - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14361,7 +14361,7 @@
           }
         },
         {
-          "id": "ee7cd7bf-c682-47a0-811e-e150081ad9a3",
+          "id": "c3ba4369-38e4-40e2-b391-6f4f16b95525",
           "name": "Get SKU complements by complement type ID",
           "request": {
             "name": "Get SKU complements by complement type ID",
@@ -14438,7 +14438,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "540bfd1e-90b5-4655-9eaa-4862cabf71e7",
+              "id": "495709b9-6370-4fa3-b62e-b77ebfb9fa4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14508,7 +14508,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f5dd9bb2-a211-48a7-b404-2d35dcde3007",
+                "id": "5d9d94d1-e21c-475e-8a8c-7bb4d0ff114d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/complement/:complementTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14524,7 +14524,7 @@
           }
         },
         {
-          "id": "643d6e1d-f5fc-4003-8002-a090a7746d88",
+          "id": "2e528a1b-cdd5-4828-98ed-40c2efdfd335",
           "name": "Get SKU complements by type",
           "request": {
             "name": "Get SKU complements by type",
@@ -14601,7 +14601,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "14c838da-d197-4dcd-9cc0-2de4da261d54",
+              "id": "6abb7313-02cc-471f-ae43-f9a759fc9b00",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14671,7 +14671,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d9587061-a36e-4ff6-8b25-f4b94e31848a",
+                "id": "bfb429c5-3193-4cf9-a586-d2a6de6ee3b4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/complements/:parentSkuId/:type - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "4d7a5f5e-a419-47c5-ba53-197512ae89b9",
+          "id": "0d31c612-a4b6-4812-b4ac-ca949b3649b5",
           "name": "Create SKU complement",
           "request": {
             "name": "Create SKU complement",
@@ -14753,7 +14753,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "484cd56e-182c-4967-b90d-c848c339a858",
+              "id": "18ef13f0-bef2-4fad-91e0-fea20027e644",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14833,7 +14833,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0e0bcaa3-adc5-41a6-898a-ae4028d323ad",
+                "id": "d67c4176-6a7d-4296-9273-d0b6f78fe166",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skucomplement - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14849,7 +14849,7 @@
           }
         },
         {
-          "id": "b545de7e-c37b-4e5b-a927-b553dcdb8f30",
+          "id": "8f9c2708-6b1b-49e0-be2d-bbaf51c84420",
           "name": "Get SKU complement by SKU complement ID",
           "request": {
             "name": "Get SKU complement by SKU complement ID",
@@ -14914,7 +14914,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0b44e40d-6a38-47e7-ac96-3c9cb3bed08b",
+              "id": "19b63bd5-19ce-4d38-aca2-64fe8be252fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14982,7 +14982,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "23b08092-891f-467f-b2fe-2f9998c67284",
+                "id": "ba44c192-0374-45eb-b99c-c88104be3128",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skucomplement/:skuComplementId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14998,7 +14998,7 @@
           }
         },
         {
-          "id": "391c1687-0104-4624-9b3e-e19fdcdd4f3c",
+          "id": "3dd84700-81d9-46ac-888f-a19d574040a6",
           "name": "Delete SKU complement by SKU complement ID",
           "request": {
             "name": "Delete SKU complement by SKU complement ID",
@@ -15059,7 +15059,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3341a9eb-7c13-410e-a784-5025993568fb",
+              "id": "ea1a8fa1-65fd-45c2-96f3-73820749068c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15117,7 +15117,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4ad25395-22ff-4e50-9760-c2f51b43ed23",
+                "id": "c5bd9b59-cafd-4668-a5ff-9defbce0f916",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skucomplement/:skuComplementId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15133,7 +15133,7 @@
       "event": []
     },
     {
-      "id": "02e690f1-9b42-4343-a0e3-215f45c44981",
+      "id": "80a7a5ec-71b5-4b4b-9463-c39d30becbc5",
       "name": "Non-structured specification",
       "description": {
         "content": "",
@@ -15141,7 +15141,7 @@
       },
       "item": [
         {
-          "id": "2f77b378-b5cd-48fc-a3d1-97ea7e44664a",
+          "id": "782a5ce3-dc68-4a46-af5e-48dde6205dc2",
           "name": "Get non-structured specification by ID",
           "request": {
             "name": "Get non-structured specification by ID",
@@ -15207,7 +15207,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "24501483-936f-4dd3-be8a-5ed65378f64e",
+              "id": "41474cb3-6060-41ad-8317-fbcaf1b2e5b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15276,7 +15276,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f035042b-e907-4e93-94ae-1ce7cadf0d6f",
+                "id": "6dab9f11-6876-460f-aa07-5d59c87abe6a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/nonstructured/:Id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15292,7 +15292,7 @@
           }
         },
         {
-          "id": "5683be5e-67f8-4ded-80e5-035b81ff26d7",
+          "id": "09b3b1a9-d4a6-4a9a-9a64-04b452e4a48a",
           "name": "Delete non-structured specification",
           "request": {
             "name": "Delete non-structured specification",
@@ -15354,7 +15354,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "141b793b-df9b-4ccf-9cbe-36780342068f",
+              "id": "b70e3cea-17f8-4cb8-9cb2-2267fbf75dce",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15413,7 +15413,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7a48cc4b-3b56-4ef1-b5af-aee8c921812c",
+                "id": "415a79ec-5e17-45ba-b91c-6db3db1b4170",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/specification/nonstructured/:Id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15426,7 +15426,7 @@
           }
         },
         {
-          "id": "8c07ef4b-3b61-4e92-8046-e59322a1ff7e",
+          "id": "f8d9cfde-9c06-48e2-9546-b58bbb93c6e9",
           "name": "Get non-structured specification by SKU ID",
           "request": {
             "name": "Get non-structured specification by SKU ID",
@@ -15490,7 +15490,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e3e1cf20-2465-47f7-a2ce-7dcf118306a3",
+              "id": "768ecec6-fd36-424e-bb8b-097fcb71b73b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15568,7 +15568,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5a45ca5f-1cd8-4264-b6be-e37a53b3fc84",
+                "id": "c05fc140-e642-4272-b308-b91d13c545de",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/nonstructured - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15584,7 +15584,7 @@
           }
         },
         {
-          "id": "1a92f187-611b-47f1-8919-3583561e588d",
+          "id": "3b8e96e8-4e5c-4842-8a31-3e7b3e9d5691",
           "name": "Delete non-structured specification by SKU ID",
           "request": {
             "name": "Delete non-structured specification by SKU ID",
@@ -15644,7 +15644,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f38d50d8-866b-405c-84ec-70397539c329",
+              "id": "5cb8cbb4-1d3d-4ed3-970b-06f464dd3c42",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15712,7 +15712,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f033ef29-4ef0-4cc9-8c32-a385dac03097",
+                "id": "6d771f84-34d7-4808-866b-8e5c6b31aada",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/specification/nonstructured - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15728,7 +15728,7 @@
       "event": []
     },
     {
-      "id": "9151b87e-8027-4932-874a-290acfdf6d38",
+      "id": "a0e8bb99-5ec8-4030-89a4-501dc0fb28a4",
       "name": "Specification field",
       "description": {
         "content": "",
@@ -15736,7 +15736,7 @@
       },
       "item": [
         {
-          "id": "a86be269-94ac-41fb-9409-f413f08440ff",
+          "id": "26afed49-06e3-41ad-8b8b-81b145367e9b",
           "name": "Get specification field",
           "request": {
             "name": "Get specification field",
@@ -15802,7 +15802,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "935186e7-27a3-44ed-8851-8ce4fd3c974f",
+              "id": "af45cf88-52c6-491e-af70-bd775bd40f76",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15871,7 +15871,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a5f89f41-ef4b-48b7-9f05-be7238bd944f",
+                "id": "58795bbd-73cb-4fe0-b7f4-46841808a7b4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/fieldGet/:fieldId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15887,7 +15887,7 @@
           }
         },
         {
-          "id": "7811839f-b46a-48f0-988d-155b041c5ead",
+          "id": "b8ad89fc-f81a-4b80-b1db-bae55af58981",
           "name": "Create specification field",
           "request": {
             "name": "Create specification field",
@@ -15954,7 +15954,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ee2333d6-aa6b-498e-9d77-d80ef12f8951",
+              "id": "99fa510c-9c31-4a83-ade0-c8d023c08cde",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16035,7 +16035,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ae0abbf6-6127-4a18-8b0f-492828ba4295",
+                "id": "98013899-71f6-4f02-896a-37c3d022e4a2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/specification/field - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16051,7 +16051,7 @@
           }
         },
         {
-          "id": "b4e6394d-5631-46a4-bee3-4902a9a5ebf9",
+          "id": "0009f4e7-f820-4329-8ba2-c1154d423771",
           "name": "Update specification field",
           "request": {
             "name": "Update specification field",
@@ -16118,7 +16118,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c8a7dee1-7fab-4d7f-beb9-cd7ae4df62f9",
+              "id": "7b85ebd7-3ada-4c3a-9210-4227f1fe0280",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16199,7 +16199,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "518844d4-ce48-41b0-872f-8d7991f14942",
+                "id": "df7016d3-4e87-4e7b-b74e-2d2fe11ebce2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/specification/field - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16218,7 +16218,7 @@
       "event": []
     },
     {
-      "id": "394c2fb0-b0d4-4c06-b346-fd7446915100",
+      "id": "59f6e015-b9c5-4f85-b0f8-321f9158054f",
       "name": "Specification group",
       "description": {
         "content": "",
@@ -16226,7 +16226,7 @@
       },
       "item": [
         {
-          "id": "42733321-deb0-4b9d-9c39-8cd5d9f9547c",
+          "id": "a3d9f82d-f842-4e66-bacc-bb930d505783",
           "name": "List specification group by category",
           "request": {
             "name": "List specification group by category",
@@ -16292,7 +16292,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7f5fc300-aae4-434f-93e5-c42592a8c5f0",
+              "id": "5ad6f821-cc23-4963-87e1-785bfcfedd89",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16361,7 +16361,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f38a62b8-72de-4ccc-aaa6-211f9bb153cd",
+                "id": "e4bbe276-8107-417e-ac4f-15d6537c2497",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/specification/groupbycategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16377,7 +16377,7 @@
           }
         },
         {
-          "id": "317d2953-457a-4ccb-bc0b-b4e367a238d1",
+          "id": "1af188a5-b407-44c2-9525-76d6cfafa9fa",
           "name": "Get specification group",
           "request": {
             "name": "Get specification group",
@@ -16443,7 +16443,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "09be13d5-1a50-4b50-b847-1560184bc4e6",
+              "id": "83a84adf-cf9a-4cb4-bbad-f13311792542",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16512,7 +16512,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f23a851c-7bcb-4a64-b03d-2bcc3a5c6aa9",
+                "id": "26f3fe90-290f-4927-b338-b3b01da60d18",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/groupGet/:groupId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16528,7 +16528,7 @@
           }
         },
         {
-          "id": "838ea4a6-f619-48b9-bc4e-c690cd1d3452",
+          "id": "9fb0db41-f846-4010-8207-a4d2e1d448a6",
           "name": "Create specification group",
           "request": {
             "name": "Create specification group",
@@ -16594,7 +16594,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3b87fd19-daea-4e99-93fe-74e8e585069b",
+              "id": "f983d972-b545-4b9d-87d5-aeb5b213a005",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16674,7 +16674,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b32dd6b2-4fb1-4036-b600-eb3ea78d9cae",
+                "id": "69c27332-1af2-4593-840e-a4f4cd7d2d10",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specificationgroup - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16690,7 +16690,7 @@
           }
         },
         {
-          "id": "ae5ae5bf-4430-49d5-bc99-d508ef26de68",
+          "id": "bfd3f22d-27ce-479d-ac00-e631e79c919e",
           "name": "Update specification group",
           "request": {
             "name": "Update specification group",
@@ -16768,7 +16768,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "af0e3793-136e-4079-9184-5fd3fb5fbe76",
+              "id": "cf2e1da8-a784-4021-a7ce-9e54d54f9925",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16849,7 +16849,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "341c58b6-37c0-4d36-a5d1-51310193966e",
+                "id": "9986738a-7894-4f8b-be50-6e696f9e9781",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationgroup/:groupId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16868,7 +16868,7 @@
       "event": []
     },
     {
-      "id": "72334c33-cf73-4a55-a265-94ef79fc68f3",
+      "id": "c24b8729-bb4b-4467-96b4-17be05cf2366",
       "name": "Specification value",
       "description": {
         "content": "",
@@ -16876,7 +16876,7 @@
       },
       "item": [
         {
-          "id": "fe2581ae-3cb3-4e5e-abfe-4c00b8510177",
+          "id": "1cf30cbe-22b8-45af-9831-d6c112f15d19",
           "name": "Get specification value",
           "request": {
             "name": "Get specification value",
@@ -16941,7 +16941,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "68fe8ad6-e52f-4158-9113-e8b8bd7a6815",
+              "id": "1d91b3fb-ca20-4866-907a-c6f8d8ed86f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17009,7 +17009,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "96e63bbe-4138-4f6a-8ebd-303f9ad0d8ac",
+                "id": "f709721b-5e0b-4bcd-9824-7c34445a12ad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationvalue/:specificationValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17025,7 +17025,7 @@
           }
         },
         {
-          "id": "1855fd5b-731f-4f58-a009-90a1e3639e39",
+          "id": "d4d22340-db88-4941-95f9-e8145e22f5a7",
           "name": "Update specification value",
           "request": {
             "name": "Update specification value",
@@ -17103,7 +17103,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fee0f2b3-fb02-4808-a358-c8b1934fadbf",
+              "id": "63273351-fb61-42e8-b457-6f2413538f56",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17184,7 +17184,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5fb04a4f-44a3-4dcc-9723-0ec522793e66",
+                "id": "98c6dc59-f16e-4064-a382-3f3fa8d4b469",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationvalue/:specificationValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17200,7 +17200,7 @@
           }
         },
         {
-          "id": "7ba1e35b-37bf-4d1f-8330-caf8bbbcea03",
+          "id": "53ee9a9a-3e40-4162-b944-0678ae99dfae",
           "name": "Create specification value",
           "request": {
             "name": "Create specification value",
@@ -17266,7 +17266,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5fd47040-1fe6-43d7-9115-715999c79de2",
+              "id": "7057a111-dbf7-4d74-bd3f-ce3209bbd966",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17346,7 +17346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "143c4eed-d83f-4b9d-b2a4-c7664e7420a7",
+                "id": "445cc4bd-b9da-4a2a-b844-cb72a67b0813",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17365,7 +17365,7 @@
       "event": []
     },
     {
-      "id": "c89aa09e-8a1c-432b-a4c4-b8ecfd9de272",
+      "id": "18fe0b42-0041-42ab-956c-19ccd68699e1",
       "name": "Specification field value",
       "description": {
         "content": "",
@@ -17373,7 +17373,7 @@
       },
       "item": [
         {
-          "id": "38117166-4af5-4893-a62e-1453bdd2c9a5",
+          "id": "28afdcc9-d8fa-4776-9efd-094a1d7b60fa",
           "name": "Get specification field value",
           "request": {
             "name": "Get specification field value",
@@ -17439,7 +17439,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a97845ad-c36f-4baf-9aae-cc907f65a90d",
+              "id": "527e3289-198d-4467-8763-8c045f9d83f6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17508,7 +17508,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6986f399-4a72-4376-a466-d14beb972382",
+                "id": "db15c512-c200-4e5a-8e5b-c3eae0a61453",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/specification/fieldValue/:fieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17524,7 +17524,7 @@
           }
         },
         {
-          "id": "eff2bc8c-ceeb-4f23-9dec-693a23139f13",
+          "id": "0289f363-e009-4464-a738-f769d2b495f0",
           "name": "Get specification values by specification field ID",
           "request": {
             "name": "Get specification values by specification field ID",
@@ -17590,7 +17590,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ea7478c7-340c-4cae-8bab-7bd2d34c9c7f",
+              "id": "58726b0f-6924-4f9b-9b77-1638e5820303",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17659,7 +17659,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bd8f8e54-d01c-427a-8572-3d3f16112aa6",
+                "id": "b875feff-354d-42ea-8be8-582524baabb7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/fieldvalue/:fieldId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17675,7 +17675,7 @@
           }
         },
         {
-          "id": "c6e405c2-75a5-494a-a930-f26dfd89b846",
+          "id": "a8cc21b8-d6f7-4c39-bad5-4005db45c081",
           "name": "Create specification field value",
           "request": {
             "name": "Create specification field value",
@@ -17742,7 +17742,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4d5833c1-29e1-418e-9ea4-d24218457a59",
+              "id": "2262a293-096f-4032-86cd-fc4fab74037f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17823,7 +17823,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5f0314f8-66e4-4fe6-bbf2-37b31e10315a",
+                "id": "f86fb07f-a512-45fa-b04a-1cde1c295860",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/specification/fieldValue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17839,7 +17839,7 @@
           }
         },
         {
-          "id": "753a6216-8385-4ac2-b6af-1f52fd980e58",
+          "id": "cd7a1d8a-9a17-4b39-b501-67c339bd71e8",
           "name": "Update specification field value",
           "request": {
             "name": "Update specification field value",
@@ -17906,7 +17906,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9acb5e80-db19-4850-b6ca-ac216a7bf92e",
+              "id": "c3bc7b23-df32-4256-8d84-3b1a656094dd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17987,7 +17987,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8c2f57b0-538b-4e74-8db7-268f5b9d102c",
+                "id": "dd2d47e6-8a1b-46e1-b8e9-cca286b3828f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/specification/fieldValue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18006,7 +18006,7 @@
       "event": []
     },
     {
-      "id": "6790afd4-e26a-40f5-8413-387daf85e51f",
+      "id": "e7505183-b013-4705-88cf-293e7a0c6dab",
       "name": "Category specification",
       "description": {
         "content": "",
@@ -18014,7 +18014,7 @@
       },
       "item": [
         {
-          "id": "9f036a0e-4b89-47cc-8ff2-a0c069b1f2cf",
+          "id": "7718da1c-f333-4f78-a49a-078453ab6856",
           "name": "Get specifications by category ID",
           "request": {
             "name": "Get specifications by category ID",
@@ -18081,7 +18081,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8b8d29ba-2bbd-4e2c-bbec-d25da2fce4c4",
+              "id": "3d143e91-f61a-4ed4-80a9-78282761cdf2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18151,7 +18151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e9d20d40-cf04-40ee-a0ca-47a0a2086ef9",
+                "id": "fecd64bc-1885-4f4f-b67d-1afea5d412bc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/field/listByCategoryId/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18167,7 +18167,7 @@
           }
         },
         {
-          "id": "0288ecf3-722c-441d-acf5-f84b42843adf",
+          "id": "4c6aa711-9515-4553-bf98-ec0123251a5c",
           "name": "Get specifications tree by category ID",
           "request": {
             "name": "Get specifications tree by category ID",
@@ -18234,7 +18234,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "46da4f09-9044-4719-b61b-91a56b3533a2",
+              "id": "f47ab79f-c6c0-4340-bb17-c7d35abe3b47",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18304,7 +18304,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "abc3c702-c595-4a13-9a91-0f0e5d5ced51",
+                "id": "22c8949b-c4af-4783-838a-08595787a199",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/field/listTreeByCategoryId/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18323,7 +18323,7 @@
       "event": []
     },
     {
-      "id": "415c9374-358e-46ed-bed6-0432a48debb1",
+      "id": "a2e062b8-6270-4ce6-b117-574e081a9467",
       "name": "Specification",
       "description": {
         "content": "",
@@ -18331,7 +18331,7 @@
       },
       "item": [
         {
-          "id": "6f1bbb52-a722-41cf-ae38-6ec310a54c37",
+          "id": "59d7a63f-b3de-4d53-a1a9-e79f312c9e86",
           "name": "Get specification by specification ID",
           "request": {
             "name": "Get specification by specification ID",
@@ -18396,7 +18396,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "39d76493-f612-47c5-aa72-dfcb3925ed93",
+              "id": "41ba65f4-d3af-4ef0-b7c5-258c569475aa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18464,7 +18464,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "001737d8-e88b-4227-873d-dd189d308021",
+                "id": "786d77fe-f13f-49a1-8f57-8715a3105dd7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18480,7 +18480,7 @@
           }
         },
         {
-          "id": "9b1f62a4-2671-4361-87a7-6e4ef7ec8ca7",
+          "id": "e9a5bf3f-7245-41d3-87ac-9520dd6df707",
           "name": "Update specification",
           "request": {
             "name": "Update specification",
@@ -18558,7 +18558,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "32ee579e-ef0b-4606-b42c-bb4cc2954dae",
+              "id": "b4128d05-80c8-4291-8332-7b610c987af4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18639,7 +18639,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "016fe0da-d196-415d-b64c-635854ec8bb0",
+                "id": "5097ba7a-71b8-4091-9112-5e51f589507f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18655,7 +18655,7 @@
           }
         },
         {
-          "id": "c3d5d308-fbd3-4c7f-9cdd-7da56bb04bd4",
+          "id": "b1d76109-767e-405b-8835-791c35697640",
           "name": "Create specification",
           "request": {
             "name": "Create specification",
@@ -18721,7 +18721,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0c6049d3-92ab-484e-af64-0f4be27f5379",
+              "id": "6bad1ba0-d334-4cd3-a86b-91867d2c204c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18801,7 +18801,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "26f6b156-fb09-47fd-a77c-501d91ac8801",
+                "id": "3f5ab6b6-abe3-4345-b079-b040ad898827",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18820,7 +18820,7 @@
       "event": []
     },
     {
-      "id": "045d9a24-b0ed-4edb-a9a9-11b599b54f73",
+      "id": "20959891-12db-4ce4-a824-169e9256393b",
       "name": "Subcollection",
       "description": {
         "content": "",
@@ -18828,7 +18828,7 @@
       },
       "item": [
         {
-          "id": "00bc96e5-a3f1-4fad-b32b-228d6d9a7882",
+          "id": "12c2ce15-412b-4a9d-9184-b02b7b11b710",
           "name": "Add SKU to subcollection",
           "request": {
             "name": "Add SKU to subcollection",
@@ -18907,7 +18907,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ebbf90d4-861b-4e02-95b1-26d56f60aef8",
+              "id": "62d2ab06-476f-4bfc-9be0-337dde9447d3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18989,7 +18989,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6d0434f4-9b5f-4742-a3e9-ea2255ff819d",
+                "id": "6dfb42e1-c07c-4926-8018-a4f34e4db530",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19005,7 +19005,7 @@
           }
         },
         {
-          "id": "d78bd5cf-504f-495e-853a-a6fa853b12c9",
+          "id": "91cf46c7-b22b-419a-9fd0-6c9d44dd1b3c",
           "name": "Delete SKU from subcollection",
           "request": {
             "name": "Delete SKU from subcollection",
@@ -19078,7 +19078,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e9ae6644-e579-4d45-b046-9c38c4ac7821",
+              "id": "c941c4da-3afa-4731-b28d-48332fffc59e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19138,7 +19138,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "76502bf2-0e56-4459-b65e-3e772f7af523",
+                "id": "9988ae0e-d0ee-4b4e-9b73-cc6e2a313f4e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19151,7 +19151,7 @@
           }
         },
         {
-          "id": "a1f29568-6dc1-4527-9327-530772c91554",
+          "id": "b20ef363-5249-472d-a638-f4034db19b96",
           "name": "Associate category to subcollection",
           "request": {
             "name": "Associate category to subcollection",
@@ -19230,7 +19230,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a42a37eb-7881-4821-968d-3b91a2f6c976",
+              "id": "e6a6058f-5891-4737-841a-9b4d641ab4fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19312,7 +19312,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "352de443-3506-4569-9b53-d8da1c7e442c",
+                "id": "27b1cd8d-dfee-4719-a502-4f9dd738933b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/category - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19328,7 +19328,7 @@
           }
         },
         {
-          "id": "28afaa87-6dd7-47b5-b95b-06c48c8ba6fb",
+          "id": "e171ab7c-15b4-4bd5-917c-a3c59f5ada21",
           "name": "Delete category from subcollection",
           "request": {
             "name": "Delete category from subcollection",
@@ -19401,7 +19401,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4e258aab-2102-416e-8d1e-49f56678b5d1",
+              "id": "7a0b4446-708c-43ff-9343-35e717eb90f0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19461,7 +19461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9c9ea8c4-c874-4a09-b23a-40e9cc944282",
+                "id": "edad144f-03b0-433c-b42f-bba652d3abc1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19474,7 +19474,7 @@
           }
         },
         {
-          "id": "bd9453f2-548b-4ad5-8276-31f853225a85",
+          "id": "9216e7c1-7c99-44c9-ac3d-1ff22cc9298e",
           "name": "Associate brand to subcollection",
           "request": {
             "name": "Associate brand to subcollection",
@@ -19553,7 +19553,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "39bae14d-75ec-464f-a8fd-c7a75e62bdef",
+              "id": "2559c716-487e-4641-95f1-39b5d34c4609",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19635,7 +19635,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d789cfc0-10d4-4350-af58-2be391e7491b",
+                "id": "5fa2d03a-fb41-428d-94bd-ae069e57f118",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/brand - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19651,7 +19651,7 @@
           }
         },
         {
-          "id": "a79f3e95-5c08-4b31-8c93-6c35cb3bc752",
+          "id": "d3451fe3-ffa3-436c-9486-adbd5bf1888e",
           "name": "Delete brand from subcollection",
           "request": {
             "name": "Delete brand from subcollection",
@@ -19724,7 +19724,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5d5f44cd-d2d1-4b28-98fc-728e5467d036",
+              "id": "f34d8c14-780f-4ae8-b735-018bb7a25d57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19784,7 +19784,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5253da59-1bf7-425a-b749-5b0c0bda886e",
+                "id": "ad22460a-5d43-49c7-9cb4-f9cf25e28b8f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19797,7 +19797,7 @@
           }
         },
         {
-          "id": "a94c12d4-9c05-47ce-bad5-9821c5dbe868",
+          "id": "ed93dde8-99ca-4fc8-9c56-e33b7da30a28",
           "name": "Get subcollection by collection ID",
           "request": {
             "name": "Get subcollection by collection ID",
@@ -19863,7 +19863,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5f7d5579-0fe0-4c21-b322-3ed5923eaf83",
+              "id": "3a67a16d-d13e-4157-9a1f-cdc6efefba9a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19932,7 +19932,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ffee0230-e4f8-4fca-9d3b-bc9c98b29e60",
+                "id": "5d909fdd-da25-4064-a238-3ee0b7a2b697",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/subcollection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19948,7 +19948,7 @@
           }
         },
         {
-          "id": "743e17bf-a6e2-48dc-89ed-e8a94af7d54f",
+          "id": "f1ae7d3a-1260-4a5a-b5fd-c1674d968a86",
           "name": "Get subcollection by subcollection ID",
           "request": {
             "name": "Get subcollection by subcollection ID",
@@ -20013,7 +20013,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6c00590b-94e8-4c75-aa1b-c15c34a173d5",
+              "id": "030dd31c-5d3e-450f-a58f-0603a27c89bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20081,7 +20081,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "422d6c3d-409d-4526-a05b-f31b5fba2d9d",
+                "id": "d09f6ac7-19c2-496c-9f11-100f2cad9421",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20097,7 +20097,7 @@
           }
         },
         {
-          "id": "62ab02f8-7ca2-4f66-8f1a-9062e9734fb5",
+          "id": "15e5e1be-1cca-479a-8e01-3f02776706a1",
           "name": "Update subcollection",
           "request": {
             "name": "Update subcollection",
@@ -20175,7 +20175,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9d9afd2c-62c4-45d2-b239-732cf1bf43a6",
+              "id": "dca3e479-c38d-4f52-8a12-4018b523001b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20256,7 +20256,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0dfa5fde-78d9-44c1-98de-0ad76cec9c7c",
+                "id": "7863048e-1187-47f6-a883-2033ed494c36",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20272,7 +20272,7 @@
           }
         },
         {
-          "id": "b2e239be-00ad-4709-9e65-3fc76e0ced6d",
+          "id": "37c8d957-d3b6-474b-9482-08c95a0b5fa1",
           "name": "Delete subcollection",
           "request": {
             "name": "Delete subcollection",
@@ -20333,7 +20333,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "39ebecd2-c650-4b10-bd9b-08fad14c629b",
+              "id": "53da41c0-e705-4b67-b6ce-8b3c6d581c9d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20391,7 +20391,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8fdf3ab0-448f-4fe4-920b-8d5edb225a64",
+                "id": "9196f2c7-2781-478a-ab70-4126c3e497f5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -20404,7 +20404,7 @@
           }
         },
         {
-          "id": "2ff3a08e-1476-469b-9f57-bde4fb20461d",
+          "id": "2f3b6782-2de9-4a81-911c-d7cf6923e107",
           "name": "Create subcollection",
           "request": {
             "name": "Create subcollection",
@@ -20470,7 +20470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "cb16b17f-ed5c-4c2c-8498-3ce3f3272504",
+              "id": "42986a43-9758-47f1-bb85-d9b760e07e84",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20550,7 +20550,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "aef42b4a-e95d-4cd4-b011-c526c31d1c4a",
+                "id": "a8219671-e316-431e-b1c6-3b67e9abe4c0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20566,7 +20566,7 @@
           }
         },
         {
-          "id": "c254b166-fe27-4627-a4fc-8518c2dc7860",
+          "id": "f3c5813c-3f39-4a41-b1fe-8a7ed5b5a537",
           "name": "Reposition SKU on the subcollection",
           "request": {
             "name": "Reposition SKU on the subcollection",
@@ -20641,7 +20641,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f6f32183-9c67-4188-93e1-234adcfb149f",
+              "id": "e680bfbe-26aa-476f-9c4d-b1bf35fe3201",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20713,7 +20713,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9e17d6f6-6fc1-4024-a196-56035b1f3014",
+                "id": "1c16d609-15f1-4ff5-91a5-d3976e2e979d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/position - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -20726,7 +20726,7 @@
           }
         },
         {
-          "id": "a3990922-6600-4461-b55d-58205d44dbae",
+          "id": "df44c23d-964c-40b2-9857-2ebc3746bd2b",
           "name": "Get specification values by subcollection ID",
           "request": {
             "name": "Get specification values by subcollection ID",
@@ -20792,7 +20792,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "09d256b9-0ee8-4200-90ce-6adcb3e581d6",
+              "id": "92867682-0b72-4692-9877-c9f6f31884ec",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20861,7 +20861,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "02a4b515-bbf3-44a9-a562-2ceefcc2677e",
+                "id": "c266557f-b859-4b15-acb9-ee36a5472bb5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20877,7 +20877,7 @@
           }
         },
         {
-          "id": "19e2c7f8-e0fb-44d9-8759-94361a4060e8",
+          "id": "5951aadc-c84e-4fad-87d2-86717d385d45",
           "name": "Use specification value in subcollection by ID",
           "request": {
             "name": "Use specification value in subcollection by ID",
@@ -20956,7 +20956,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2b8b4173-2415-4751-a3ca-5160c0fa8b78",
+              "id": "b32bc05e-bdc9-482c-81f2-d5c890378a1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21038,7 +21038,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "32c4ef66-92ef-4cb8-8028-505602ea7b30",
+                "id": "3494d661-70cc-4f7b-af00-3b6b8779bacd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21054,7 +21054,7 @@
           }
         },
         {
-          "id": "4d119fb4-d845-4783-955d-427cdb01a1e3",
+          "id": "3af17caa-7e12-4b81-9a12-1bd14642aa44",
           "name": "Delete specification value from subcollection by ID",
           "request": {
             "name": "Delete specification value from subcollection by ID",
@@ -21116,7 +21116,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ad83ee49-bae9-467e-b541-967c5476dc8d",
+              "id": "03df7e0b-936a-4912-951a-6a8f764bfda3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21175,7 +21175,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "95bc5b1f-c90e-4f7c-9189-407fae48c644",
+                "id": "8b7d998b-2b89-4738-b6fc-5252b12e9d98",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -21191,7 +21191,7 @@
       "event": []
     },
     {
-      "id": "8cea8db4-c17a-430c-adc8-8011fa15d1a8",
+      "id": "0c64a446-1c34-46d7-8462-5ffd5336d162",
       "name": "Assortment",
       "description": {
         "content": "",
@@ -21199,7 +21199,7 @@
       },
       "item": [
         {
-          "id": "e7d4abca-a5d0-4010-bb04-e7382c0616d9",
+          "id": "f99e5739-d75d-45a4-9b99-0d3c6c7dd335",
           "name": "Create product assortment",
           "request": {
             "name": "Create product assortment",
@@ -21265,7 +21265,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d8899700-7167-492c-9cfc-ccd3b91ef0fc",
+              "id": "b79658e3-0b31-44aa-af25-9fb88fda60ee",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -21344,7 +21344,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "94210dd2-90e4-4638-958f-8806d8e3acff",
+              "id": "c8f3e125-d03a-4e1d-982e-015b0d769f6d",
               "name": "Unprocessable Entity",
               "originalRequest": {
                 "url": {
@@ -21424,7 +21424,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e6f5e054-9156-4329-8bd7-81fced535e4d",
+                "id": "8566e0a0-afc1-49d5-9c4d-38f7cdbdfc65",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21440,7 +21440,7 @@
           }
         },
         {
-          "id": "8665b48d-58f5-4e87-ba92-88331c26855e",
+          "id": "0c434a47-2bc9-49c8-a58f-a9fb12847665",
           "name": "Get all product assortments",
           "request": {
             "name": "Get all product assortments",
@@ -21521,7 +21521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bb170fd4-c9c6-4e4e-b91c-ebc4087ddf51",
+              "id": "b991bf01-800b-4276-a2b2-bae19bf5825a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21616,7 +21616,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bdb76a6f-a9aa-4108-8b1b-f396c6ed6d3b",
+                "id": "5926ff02-b571-4ecf-ba5c-785550897340",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/assortment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21632,7 +21632,7 @@
           }
         },
         {
-          "id": "99cc90b5-93c2-480d-9620-debc87420e32",
+          "id": "b81ab51b-0e94-4091-bed1-a1fc6d0168d4",
           "name": "Get product assortment by ID",
           "request": {
             "name": "Get product assortment by ID",
@@ -21688,7 +21688,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "eec8e86c-0c8a-492e-af7a-b82276bbab2b",
+              "id": "b1594dca-29f4-4d15-93c5-de08bf538114",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21746,7 +21746,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4af65da6-a216-4751-b36c-1dda721c59ff",
+              "id": "ecea5a73-dde7-40f6-8de8-4497d8bad94f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -21805,7 +21805,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e97005c0-dec2-4596-ad6e-1bf00f11ac73",
+                "id": "3598f1d6-692e-4c6d-b303-2eb1cdf7e4bf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21821,7 +21821,7 @@
           }
         },
         {
-          "id": "293bacf5-05b8-4547-af2e-66315d4dfa8f",
+          "id": "1f6328a4-d5d7-469d-8817-288d203a109d",
           "name": "Update product assortment",
           "request": {
             "name": "Update product assortment",
@@ -21899,7 +21899,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6b96fad1-4a99-492c-8039-1ec857b189b0",
+              "id": "7a7a1488-621e-4bee-814d-32bb8285a52f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21979,7 +21979,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "642adb8c-3d82-4373-9446-3d6d0016ae23",
+              "id": "cd5e1e4d-96e1-47a6-a94d-9596dc10eb68",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22059,7 +22059,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "79aaa592-74b3-4e5f-8cca-0043cad06fa5",
+              "id": "0a340733-a4c4-47b9-98e3-0398335e9806",
               "name": "Unprocessable Entity",
               "originalRequest": {
                 "url": {
@@ -22140,7 +22140,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "938261ef-e8f9-4c00-90dc-217064226ebd",
+                "id": "ce869ab3-9ef1-4861-afa7-1fea4b3655ea",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22156,7 +22156,7 @@
           }
         },
         {
-          "id": "84e8e957-a3c0-46d3-a799-00546632731d",
+          "id": "0d4ade9f-c140-475a-b11f-15cdf687a576",
           "name": "Delete product assortment",
           "request": {
             "name": "Delete product assortment",
@@ -22212,7 +22212,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5da42a38-8638-4291-ba3a-e2b314dc9436",
+              "id": "29d046cc-05ca-4fed-9e41-d06227737277",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22270,7 +22270,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f671eba7-09c7-4aa8-8a8f-8f940b7e03e4",
+              "id": "4647b46a-1eca-4fd0-a627-4889c9193c99",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -22328,7 +22328,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bf5f32b6-e445-445e-8f50-30b12f9d5ec6",
+              "id": "d4df2bb0-c80a-4729-8982-29409fd72782",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22387,7 +22387,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "abe52513-91c0-46ac-8ff8-51f2f9633e9a",
+                "id": "72d6634b-db83-4add-a366-db5002dfa9fd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22403,7 +22403,7 @@
           }
         },
         {
-          "id": "3ce536a8-0a06-497f-8497-43b51a7310e6",
+          "id": "3c4aa971-32e4-4ede-ac81-599b8891b2f5",
           "name": "Add included collection to product assortment",
           "request": {
             "name": "Add included collection to product assortment",
@@ -22471,7 +22471,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "71d1c2f4-8626-43f0-9b96-b6d1216add07",
+              "id": "ab96dbb7-bc1e-460a-8b4b-af4d1570a289",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22531,7 +22531,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b2f2644d-ee29-44ea-88fd-dc723fed628a",
+              "id": "69dd0ea6-5feb-4f69-98e5-b5319097266d",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -22592,7 +22592,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e59183c6-6dde-4c38-b23f-55436220973d",
+                "id": "8b772a9d-d26a-4447-a629-6c633f03520c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment/:productAssortmentID/included-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22608,7 +22608,7 @@
           }
         },
         {
-          "id": "1f034428-10ce-4578-815a-cd9583488338",
+          "id": "3bcaff3a-f173-4267-9e9c-c41efba4d5d7",
           "name": "Remove included collection from product assortment",
           "request": {
             "name": "Remove included collection from product assortment",
@@ -22676,7 +22676,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d85e9116-d1d1-4bab-bc88-2b4d58fd1db7",
+              "id": "aeff4a3c-0c07-4467-87a3-8b9d216ca2c8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22736,7 +22736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6690d44a-7185-4787-a3c4-22e0ee11610b",
+              "id": "cad17f9e-8b04-4910-8f69-34df96e35d35",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22797,7 +22797,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45b36268-3d90-4368-9891-fa18a63b8b3f",
+                "id": "3f5b488e-38a7-42a7-ae9e-f82a1cd9d19f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID/included-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22813,7 +22813,7 @@
           }
         },
         {
-          "id": "7a601b44-a18b-457a-bb27-4def488c69d8",
+          "id": "827f4cc9-9d0d-424e-a9fb-610c34a80e5a",
           "name": "Add excluded collection to product assortment",
           "request": {
             "name": "Add excluded collection to product assortment",
@@ -22881,7 +22881,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4a8b9c06-7af9-4b2b-975a-82029a93fb76",
+              "id": "92015467-f531-4338-8212-15bf23641617",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22941,7 +22941,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c8ac96e8-09f1-4a44-b806-9a498328004d",
+              "id": "cdfc25e1-61b3-4cef-a454-bec748876cb3",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -23002,7 +23002,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "063e3e8d-edda-47f4-b3b5-7b942c56e371",
+                "id": "d8b06406-f7a9-4282-9fa7-9b41994310c2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment/:productAssortmentID/excluded-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23018,7 +23018,7 @@
           }
         },
         {
-          "id": "648b1384-ae8a-4f23-873b-257f057ce947",
+          "id": "e6ef17da-a29a-44d3-af00-695048f310dc",
           "name": "Remove excluded collection from product assortment",
           "request": {
             "name": "Remove excluded collection from product assortment",
@@ -23086,7 +23086,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4356fb93-a701-4b2f-985e-f48eb435c1d2",
+              "id": "dc829262-baa7-488c-8dbe-84678cc9e12f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23146,7 +23146,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1ecb1cc4-7bb3-4833-951f-7f515048455f",
+              "id": "46b5143f-4208-4406-bfb7-771c6dacdc5e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -23207,7 +23207,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9222a2e6-544d-426f-9590-e75332e12728",
+                "id": "89e8da1e-0bbb-41cb-a647-7423e7404f17",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID/excluded-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23226,7 +23226,7 @@
       "event": []
     },
     {
-      "id": "0fe7a5bd-bd11-40c8-b6af-3f55b06a2f36",
+      "id": "a23bab81-b09d-40c9-b02c-8b64e6414b8c",
       "name": "Collection",
       "description": {
         "content": "",
@@ -23234,7 +23234,7 @@
       },
       "item": [
         {
-          "id": "c45a876d-bb6c-4a9a-b32f-4e28451f6837",
+          "id": "91295d78-fc81-42e1-ab61-3f657f7303a8",
           "name": "Get all inactive collections",
           "request": {
             "name": "Get all inactive collections",
@@ -23288,7 +23288,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5e7dbfaa-8c36-4597-bc86-24f0f1d7e534",
+              "id": "6fc5d941-1f24-4f72-a759-3ea43099a77f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23356,7 +23356,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6eff2e1d-2a6a-4505-99cd-a22724e8ce48",
+                "id": "98b705fe-5726-4711-80c8-2eff98bc57fc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/inactive - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23372,7 +23372,7 @@
           }
         },
         {
-          "id": "bbdf2a85-a533-4890-8df1-e23b416e7f61",
+          "id": "b713cde0-1db5-454f-b9c7-2e02c94a9e7e",
           "name": "Create collection",
           "request": {
             "name": "Create collection",
@@ -23424,7 +23424,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": 96462598.64613372,\n  \"Type\": -69511683\n}",
+              "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": true,\n  \"Type\": \"in cillum non dolor\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -23438,7 +23438,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7bba6974-bb52-4bba-953a-7bc6d72ee561",
+              "id": "bdd4abdc-4e24-4331-a03b-5e71404ef607",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23493,7 +23493,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": 96462598.64613372,\n  \"Type\": -69511683\n}",
+                  "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": true,\n  \"Type\": \"in cillum non dolor\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -23518,7 +23518,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ff760e17-c609-471e-b5b4-a6cb26d5e49d",
+                "id": "e8fb2685-9927-4d00-86d4-0e8d33e1f18c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23534,7 +23534,7 @@
           }
         },
         {
-          "id": "f69dfb28-837e-425b-a8f3-67b5b78ae96d",
+          "id": "b2f9aeeb-fe0e-4415-8c17-e0d7a0c447d3",
           "name": "Import collection file example",
           "request": {
             "name": "Import collection file example",
@@ -23580,7 +23580,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "15bbaf1e-acb5-436c-a712-0d3fce88e789",
+              "id": "e8e0e9ea-4cdb-442e-b841-2361a15766bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23640,7 +23640,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a1bfa693-583d-4a70-8577-19cf1667cf4f",
+                "id": "9e8802a1-2541-49d9-b158-2ddf7fb1ae7f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/stockkeepingunit/importfileexample - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23654,7 +23654,7 @@
           }
         },
         {
-          "id": "63d508ef-1f2c-49a7-8826-064e6cc72ecc",
+          "id": "0cbe3941-4bfc-4688-aed5-f247f0e47bca",
           "name": "Add products to collection by imported file",
           "request": {
             "name": "Add products to collection by imported file",
@@ -23734,7 +23734,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1feae8e3-d17d-4388-8f36-c2234dd9fef3",
+              "id": "b0fd01dc-2d61-45a2-a691-965c982aa719",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23811,7 +23811,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1c9836f0-9191-4fa8-bfea-3f3ba4ba2699",
+                "id": "0813e74b-475c-4917-86fe-da5e4bae8f59",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/stockkeepingunit/importinsert - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -23824,7 +23824,7 @@
           }
         },
         {
-          "id": "45caf4da-73ee-4af7-8032-3a7d07afc865",
+          "id": "fbf54679-0f00-47e2-8ef7-69b8ba24136f",
           "name": "Remove products from collection by imported file",
           "request": {
             "name": "Remove products from collection by imported file",
@@ -23904,7 +23904,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fe2a686e-835f-470e-9781-d7353216f0bb",
+              "id": "9992b7fd-617a-4ef0-a86d-8291d8d3ea3d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23981,7 +23981,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "48021f71-4c02-4e68-89b5-a61ce2f138f1",
+                "id": "4098949a-60e3-44e6-9b58-c097bb3ba1f7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/stockkeepingunit/importexclude - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -23994,7 +23994,7 @@
           }
         },
         {
-          "id": "5be991c7-1b7a-4e6d-aade-be6770e88feb",
+          "id": "b91f1bbf-17d9-4bd2-ade0-3a8820798298",
           "name": "Get products from a collection",
           "request": {
             "name": "Get products from a collection",
@@ -24178,7 +24178,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5661767d-871f-430f-8aaf-a523662bc26f",
+              "id": "a8208c88-035a-443e-bf27-76d3a90bb0ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24365,7 +24365,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6fde97b1-fb2d-4cb3-964b-ed90fa920907",
+                "id": "fa64ce4a-332f-4009-98a2-bfe596fc135d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24381,7 +24381,7 @@
           }
         },
         {
-          "id": "59967d79-9cae-4b42-8f9d-76ec0b730d06",
+          "id": "c1b9e6f1-5d2e-452f-bae0-e684068e80f5",
           "name": "Get collection by ID",
           "request": {
             "name": "Get collection by ID",
@@ -24446,7 +24446,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0ab4df78-a31c-438d-ab99-72046beea668",
+              "id": "c3b3f5c4-bacf-4d28-8bac-59be4f7b04a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24514,7 +24514,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2d371ef1-bf72-4adc-a010-d1a076b61faf",
+                "id": "cf796139-4102-4f3b-911e-1f5c90dd6d9c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24530,7 +24530,7 @@
           }
         },
         {
-          "id": "02e06878-73ad-4f55-995c-4b1b34e35faa",
+          "id": "a8da0781-fd0f-43ea-86f8-e9efca7381f5",
           "name": "Update collection",
           "request": {
             "name": "Update collection",
@@ -24608,7 +24608,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "11c631ad-0bc8-469c-8152-5f3a356fd582",
+              "id": "e7f45b34-1679-4278-a71c-cd78bd31a6fd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24689,7 +24689,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0cb483c0-e7f5-45f3-8897-ab32c84bbc61",
+                "id": "68d1e3c9-bc22-4c85-b3df-7845d5203476",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24705,7 +24705,7 @@
           }
         },
         {
-          "id": "39503d9f-ac79-42d4-83d4-ab2f45516f1f",
+          "id": "8b69e862-8885-47b7-a3a0-c0df2d69e332",
           "name": "Delete collection",
           "request": {
             "name": "Delete collection",
@@ -24766,7 +24766,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c1f0bb96-707e-47fc-89e7-5bfaafc601aa",
+              "id": "4c786463-98f0-42f1-b565-b00f624e1bd7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24824,7 +24824,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "08c498e0-455d-4f19-9a2b-8d8e475a0efc",
+                "id": "00b49734-d124-4d0f-b206-c2c1e5912486",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -24840,7 +24840,7 @@
       "event": []
     },
     {
-      "id": "75193b55-b405-4208-afab-49aa1b11e9cd",
+      "id": "89e32ad7-a8c7-4c56-a993-581a88eb5657",
       "name": "Supplier",
       "description": {
         "content": "",
@@ -24848,7 +24848,7 @@
       },
       "item": [
         {
-          "id": "d2b4ada9-17dd-423e-b59e-896729a1de3b",
+          "id": "01ba2aab-4711-4863-b7e0-c8b1bae89161",
           "name": "Create supplier",
           "request": {
             "name": "Create supplier",
@@ -24914,7 +24914,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "22faf26f-2474-45ba-a7c5-05940c2d39bf",
+              "id": "2f2dc81e-7e2b-41d7-b3e1-802334624fb4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24994,7 +24994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "96e5247c-a001-40ff-a181-fae2ea3c3679",
+                "id": "1c7fae5b-eb2f-43b9-8f45-7d9eb6b5c5dc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/supplier - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25010,7 +25010,7 @@
           }
         },
         {
-          "id": "a5c47c0b-9f1f-4f3b-b295-7c3cb7213940",
+          "id": "da98d837-c85e-43f4-8b4a-13eba93905c6",
           "name": "Update supplier",
           "request": {
             "name": "Update supplier",
@@ -25088,7 +25088,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fa301e0d-e17a-4cce-9131-8d789bce26ab",
+              "id": "8d83713f-c9c4-4194-b41d-7191a3e75da8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25169,7 +25169,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cf6833d1-9238-4284-9bba-c3c60e3eb4ea",
+                "id": "1a8d5719-1fe1-4edf-a022-96ef9bbf7b62",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/supplier/:supplierId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25185,7 +25185,7 @@
           }
         },
         {
-          "id": "3f4226e6-5637-4b1e-b2fc-b58850aee86a",
+          "id": "428340c7-ae83-429b-8483-aa05725d33f3",
           "name": "Delete supplier",
           "request": {
             "name": "Delete supplier",
@@ -25246,7 +25246,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "34d37de9-b7ee-4bff-b0c3-e4de0a518443",
+              "id": "27e1322b-9ef5-42a7-98a4-7c6cc1dd02e4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25304,7 +25304,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bda347ae-39c1-4e46-a38a-13846c2d41c0",
+                "id": "9d3e1dac-bc1d-49d5-a1d4-03a9ad5f9a54",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/supplier/:supplierId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -25320,7 +25320,7 @@
       "event": []
     },
     {
-      "id": "59f728a9-5385-4a36-9589-9922a5d6d974",
+      "id": "ffdd96c8-55ef-48c4-8db2-f437c30b9dc8",
       "name": "Sales channel",
       "description": {
         "content": "",
@@ -25328,7 +25328,7 @@
       },
       "item": [
         {
-          "id": "dbdd3002-290f-4b9f-9a29-a537d28e7f07",
+          "id": "6aa0a62d-36d9-4533-a571-3b3886f99f7c",
           "name": "Get sales channel list",
           "request": {
             "name": "Get sales channel list",
@@ -25382,7 +25382,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dd775990-b424-4067-b2db-003685d78093",
+              "id": "afe5ee17-7b45-4436-9b84-b67637f76416",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25450,7 +25450,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "aa546b72-f695-4546-a532-b01373c3422c",
+                "id": "9f51532a-958c-4a85-869d-771c0ebafb93",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/saleschannel/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25466,7 +25466,7 @@
           }
         },
         {
-          "id": "c002b7e6-6eb0-49f7-9486-e9721578ba4b",
+          "id": "01fd3192-d910-420b-89bc-18376c091d97",
           "name": "Get sales channel by ID",
           "request": {
             "name": "Get sales channel by ID",
@@ -25531,7 +25531,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8ec5115c-c7b7-49f4-b56e-3e2ec71ebd60",
+              "id": "6533cae5-bad5-442c-88e2-94ece1ec7dbe",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25599,7 +25599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "016bfb70-ea84-4c48-8fa5-4d0639189ad5",
+                "id": "2a0b8965-7c04-4e83-95aa-2033064615a8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/saleschannel/:salesChannelId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25615,7 +25615,7 @@
           }
         },
         {
-          "id": "3a57bc0d-c104-4b24-8ab8-c48bc47315a0",
+          "id": "f9fc9a58-af91-448f-96ee-ac355519126c",
           "name": "Get sales channel by product ID",
           "request": {
             "name": "Get sales channel by product ID",
@@ -25681,7 +25681,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "21ad1bdf-438b-4c77-adcb-494ffd931c8c",
+              "id": "a17101b2-bbb0-4c71-88d8-d82204777cf9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25750,7 +25750,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bd9c881a-764c-463b-9f97-fa86f1f3cc28",
+                "id": "00a4db53-f1c5-42c4-a987-d56f1b6f5d37",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/salespolicy - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25766,7 +25766,7 @@
           }
         },
         {
-          "id": "61de5677-0512-4b89-8dc6-4691438a441d",
+          "id": "b5587732-cfac-41d0-8018-12be957adaca",
           "name": "Associate product with sales channel",
           "request": {
             "name": "Associate product with sales channel",
@@ -25839,7 +25839,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bfe245e6-e4fb-41bf-9826-74a78bd1930a",
+              "id": "e3b591e4-7034-46c5-a389-580fcf72ad29",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25899,7 +25899,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f035e226-1d4f-4105-b2a9-2c356c4b5a4b",
+                "id": "ed2748b5-9894-4d5d-bd4c-49db0078ba3b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/salespolicy/:tradepolicyId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -25912,7 +25912,7 @@
           }
         },
         {
-          "id": "7ec6259a-76fb-4447-97a0-7b5607b2dd67",
+          "id": "c609ccfb-2a00-42e2-996f-8a964277cf0d",
           "name": "Remove product from sales channel",
           "request": {
             "name": "Remove product from sales channel",
@@ -25985,7 +25985,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f0d6b660-3561-404d-9bdf-7f618fdc6910",
+              "id": "4c3e58c5-e67c-4645-8831-ef11ef72f56b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26045,7 +26045,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fc874477-38e8-4d15-8c2b-37596d430a84",
+                "id": "44cdc6a6-9770-4466-8dce-b7342c52946a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/salespolicy/:tradepolicyId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -26058,7 +26058,7 @@
           }
         },
         {
-          "id": "fbcc5d5c-3af3-4882-86a5-e4f087a76e3e",
+          "id": "963a0944-92f1-4e64-bba0-933420b60dd8",
           "name": "List all SKUs in a sales channel",
           "request": {
             "name": "List all SKUs in a sales channel",
@@ -26149,7 +26149,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b84435bf-fd54-4366-8e07-0bcbc02725a4",
+              "id": "838d14f4-a535-47df-9a2e-dbf27305b609",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26254,7 +26254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b63834bf-819f-4863-b1f3-293486bdd6be",
+                "id": "69affb47-db2a-4245-a6f6-514946dd2570",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitidsbysaleschannel - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26273,7 +26273,7 @@
       "event": []
     },
     {
-      "id": "73b2500e-275b-4978-b3f0-392422239e7e",
+      "id": "69473d7d-0180-4d39-a1ba-586221b27079",
       "name": "Seller",
       "description": {
         "content": "",
@@ -26281,7 +26281,7 @@
       },
       "item": [
         {
-          "id": "1af609c0-537d-45da-8f3b-37229e64cf9e",
+          "id": "59a2710f-d522-47cc-a80a-bcee993a29e6",
           "name": "Get seller list",
           "request": {
             "name": "Get seller list",
@@ -26363,7 +26363,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ec1f5711-956d-4935-8b76-6ca63ceb1704",
+              "id": "3793cffc-e7d4-45fb-baff-aa670857668c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26459,7 +26459,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "99ca13f4-0fec-4cf8-9609-defc8a33703b",
+                "id": "a1294800-2117-4d42-b637-c6bbf0528892",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/seller/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26475,7 +26475,7 @@
           }
         },
         {
-          "id": "b5430deb-1044-43ce-b99e-7bd4713fa25c",
+          "id": "a2e428cd-6f49-4ce1-aa2e-86123cd8d54b",
           "name": "Get seller by ID",
           "request": {
             "name": "Get seller by ID",
@@ -26540,7 +26540,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "80bd28c9-af0a-4693-88c3-8cbad71db507",
+              "id": "0c736a11-fec3-4c79-9759-64318611cb3e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26608,7 +26608,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1b948a25-3b30-4aaa-980f-e8020d728fac",
+                "id": "115d75fe-e895-4b3d-83b3-265f596a7bac",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/seller/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26624,7 +26624,7 @@
           }
         },
         {
-          "id": "2be6ce0a-bc1b-498a-83fa-e5756f9dd475",
+          "id": "d9ec2eac-af86-4220-a386-16cec70df59b",
           "name": "Update seller",
           "request": {
             "name": "Update seller",
@@ -26690,7 +26690,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e5c89539-1780-4551-99e8-d9ffe0476604",
+              "id": "02fb44b0-abeb-445f-8db4-1a059ec45c19",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26770,7 +26770,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6ff6c7c5-36d3-400f-87a5-b0df14d1bef9",
+                "id": "5ddcedda-b600-44f8-84d7-d2bb0d8b0130",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/seller - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26786,7 +26786,7 @@
           }
         },
         {
-          "id": "853d6abb-f542-4a4d-9cce-8a085da8c119",
+          "id": "aa839f6c-2efe-49e1-960d-85956a750880",
           "name": "Create seller",
           "request": {
             "name": "Create seller",
@@ -26852,7 +26852,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "62295ad6-e168-46cd-b2f7-d63cc6ed870d",
+              "id": "09f80102-c9c7-4ca3-9638-8482b1929f02",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26932,7 +26932,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "68b8ad2a-8c9d-471d-8a07-7f553e82aac1",
+                "id": "962928a3-3d98-4dd9-8883-ace5e484e455",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/seller - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26948,7 +26948,7 @@
           }
         },
         {
-          "id": "2d8703ee-265e-488f-896b-912abc0da22e",
+          "id": "2a135ec3-a8bd-4a28-9dee-1df1203c6056",
           "name": "Get seller by ID",
           "request": {
             "name": "Get seller by ID",
@@ -27013,7 +27013,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a9c2f4db-0150-4abb-8daf-c0b822b0efd8",
+              "id": "18d7fcae-a676-4ae3-8304-570b64433173",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27081,7 +27081,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fc1a1270-5c10-4e2d-8272-4aa900385c72",
+                "id": "ccde03f0-777d-4bf4-a80e-fee3e861efc7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sellers/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27100,7 +27100,7 @@
       "event": []
     },
     {
-      "id": "e1387b66-11b8-48ee-82ce-e4aad3c73078",
+      "id": "500646d2-c3cb-4a93-acb3-692ead84ba54",
       "name": "SKU seller",
       "description": {
         "content": "",
@@ -27108,7 +27108,7 @@
       },
       "item": [
         {
-          "id": "19302f19-cdc4-465b-9454-47582a75eace",
+          "id": "01ca89f6-d7d7-45d4-9267-a9560ab65d20",
           "name": "Get details of a seller's SKU",
           "request": {
             "name": "Get details of a seller's SKU",
@@ -27184,7 +27184,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "33aba400-1323-409a-85c0-5d8412474596",
+              "id": "7f24f6a9-cb30-493a-a6d0-a5e96d11d21b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27253,7 +27253,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d7979c89-5018-4aad-93ad-d947c580bab0",
+                "id": "e1183c40-1994-4f1f-80f8-b226ba994084",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/skuseller/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27269,7 +27269,7 @@
           }
         },
         {
-          "id": "26db6438-d057-4176-93e9-f3ffbc327d7f",
+          "id": "cdf67eb7-4658-4282-afc3-fa57aaa6393a",
           "name": "Remove a seller's SKU binding",
           "request": {
             "name": "Remove a seller's SKU binding",
@@ -27342,7 +27342,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a39c7fd9-1151-4a5c-a5fb-d3c21ef5b40e",
+              "id": "04ce71a2-ca51-4b69-9704-537929c24d0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27402,7 +27402,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fb078d75-8e75-4ebb-841f-eaa870798d86",
+                "id": "9945b9d9-1253-4adf-b62c-8a5c9b3b72c7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/remove/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -27415,7 +27415,7 @@
           }
         },
         {
-          "id": "441a6992-51a5-4567-a621-ecec23a21815",
+          "id": "d5104bfb-9d65-443a-a6ef-1d60eb1e61da",
           "name": "Change notification with seller ID and seller SKU ID",
           "request": {
             "name": "Change notification with seller ID and seller SKU ID",
@@ -27488,7 +27488,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c10c780c-0b98-4b2e-96b9-b50983f98a1b",
+              "id": "746b8bb6-8211-4f2c-9114-31ad24208ee2",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -27548,7 +27548,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2d288684-ebc2-4f21-b4d7-b08be3e69258",
+                "id": "43c93489-e238-4488-9bbb-c90c9b7dfb01",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/changenotification/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27562,7 +27562,7 @@
           }
         },
         {
-          "id": "a1a73694-f355-4083-87fa-fe56e054ec10",
+          "id": "4340d372-bb3c-4c5b-8968-826ac527de79",
           "name": "Change notification with SKU ID",
           "request": {
             "name": "Change notification with SKU ID",
@@ -27628,7 +27628,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "674be70e-bff5-440f-aae8-092254b0fff0",
+              "id": "399a7788-3812-450b-84f5-81d97a9d4d24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27686,7 +27686,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ff7c8f46-4871-4d91-b61b-b24aec37658d",
+              "id": "7eef7e1a-f754-4e71-83ce-b36b94f0e077",
               "name": "Forbidden",
               "originalRequest": {
                 "url": {
@@ -27744,7 +27744,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "541904f5-7e19-4e76-a805-d355087f531a",
+              "id": "c07d9204-b7b4-4cb7-ab23-045fcbad3039",
               "name": "Not found",
               "originalRequest": {
                 "url": {
@@ -27812,7 +27812,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4a44d065-8bb4-4a67-82c7-559f8aa41883",
+              "id": "d6dd9522-24f1-4bb3-af5c-b4fd472a9c61",
               "name": "Too many requests",
               "originalRequest": {
                 "url": {
@@ -27871,7 +27871,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ad1ecddf-c06a-4e19-8ec2-a2195c39f06f",
+                "id": "933eeed3-d600-448a-84d4-17c33b827b42",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/changenotification/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -27887,7 +27887,7 @@
       "event": []
     },
     {
-      "id": "b237ae47-cc2a-4b87-9196-fcca2134831d",
+      "id": "a0b91be0-11a6-42c9-89c0-6fe666d575c5",
       "name": "SKU attribute",
       "description": {
         "content": "",
@@ -27895,7 +27895,7 @@
       },
       "item": [
         {
-          "id": "b186a6e6-bc9f-42aa-aafa-ff514f797c95",
+          "id": "67b21fa1-d6cb-4663-babd-92440560900c",
           "name": "Create SKU attribute",
           "request": {
             "name": "Create SKU attribute",
@@ -27974,7 +27974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bbd18ddf-f1a3-406c-8350-7471a9b084d7",
+              "id": "22b7f4a1-57c5-4c0b-af00-607d66c4c510",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28055,7 +28055,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b7af658c-44bf-4438-a8b7-499d43adc819",
+              "id": "e60c72db-0ee1-49fb-98a5-008cfc5c670e",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -28137,7 +28137,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eadfdd56-488e-4dd2-9112-af18186eb914",
+                "id": "20b6f8aa-7231-402f-a400-7970e17ccc94",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28153,7 +28153,7 @@
           }
         },
         {
-          "id": "4cb445e3-b3c4-4029-ba16-b6a28a05d148",
+          "id": "711113c1-29b1-4a4e-95fe-fceab7598a5c",
           "name": "Get all SKU attributes",
           "request": {
             "name": "Get all SKU attributes",
@@ -28219,7 +28219,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2b6bb46a-a9fb-403b-bc14-0bf1c56d9040",
+              "id": "31791277-b5a4-461f-9853-06c474cfd695",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28288,7 +28288,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5fc1dcb3-97b8-4b64-b17c-e061c0fefbb4",
+                "id": "ea0c1074-3a05-41dd-848e-858887c79345",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28304,7 +28304,7 @@
           }
         },
         {
-          "id": "887f06bc-c31b-4dc1-9d06-058f387715be",
+          "id": "4292feee-47c7-41da-9428-516f8b935c8e",
           "name": "Delete all SKU attributes",
           "request": {
             "name": "Delete all SKU attributes",
@@ -28366,7 +28366,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ec4420fc-0942-4015-b19f-b759755de54c",
+              "id": "c2877374-838a-4ca5-b9e7-c43fb4ddbf05",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28425,7 +28425,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f2c99e4b-87a3-4c56-8897-2c39477ee66d",
+                "id": "8e053fb9-b918-4d98-8046-b76f726a1bd9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -28438,7 +28438,7 @@
           }
         },
         {
-          "id": "974e8434-540b-4cb0-8400-ff95e425d404",
+          "id": "bd28022a-4f2c-412e-9f46-35a66e34b963",
           "name": "Get SKU attribute by ID",
           "request": {
             "name": "Get SKU attribute by ID",
@@ -28515,7 +28515,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "21f1300a-52d7-449f-9917-f5b199a2d867",
+              "id": "74f9745f-2c3f-4954-a877-287cdc46e017",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28585,7 +28585,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "16f2a088-4fbb-4cac-8a6f-dc4cc9a91f39",
+                "id": "58b7f2b3-7e16-41b8-a714-d094a981f1eb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28601,7 +28601,7 @@
           }
         },
         {
-          "id": "fae5f01f-9f91-4797-86a7-ba887607823e",
+          "id": "0536b0ad-fece-48c0-b0b6-1ac604368b86",
           "name": "Update SKU attribute",
           "request": {
             "name": "Update SKU attribute",
@@ -28691,7 +28691,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7ee3cf36-16f0-4840-8bbb-8304082840ab",
+              "id": "75272767-5cb0-49d3-84a5-71f4d99daf28",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28773,7 +28773,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "16f71622-aaa5-43bf-b61a-92bea96840e9",
+              "id": "8b7322a0-7123-498a-a7c8-1ba1b8519ded",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -28856,7 +28856,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8bbab6d4-b171-4b3a-acc0-5abdc466c7b8",
+                "id": "3e243288-79ba-4a32-b251-bc0c68b21854",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28872,7 +28872,7 @@
           }
         },
         {
-          "id": "1b7ad0b3-ebcb-4d14-ad50-4e1837963d6d",
+          "id": "6d41a2ed-4af5-4bc8-b7c1-5b20b49824b0",
           "name": "Delete SKU attribute",
           "request": {
             "name": "Delete SKU attribute",
@@ -28945,7 +28945,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "66e0ac4b-8eb8-4d46-98b2-675ac9510a05",
+              "id": "60c58207-265a-419e-ac1b-b1e184d88a41",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29005,7 +29005,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "480f2d41-2986-4e08-ad31-21ca9557c679",
+                "id": "26f2728f-9704-4429-a22e-a316cf381313",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -29021,7 +29021,7 @@
       "event": []
     },
     {
-      "id": "0fb65ea4-79db-4b84-b0cb-4da7d070a668",
+      "id": "64d4dca6-8f6b-4f8d-84ee-2b6259013e92",
       "name": "Multi-language",
       "description": {
         "content": "",
@@ -29029,7 +29029,7 @@
       },
       "item": [
         {
-          "id": "4bc3e13a-1fc1-46db-a7cb-d40722fe2e06",
+          "id": "e124bad7-9ed7-46ce-981c-5b9508cc3730",
           "name": "Get product translation by product ID",
           "request": {
             "name": "Get product translation by product ID",
@@ -29106,7 +29106,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a8941a01-0c97-4fcf-b0bf-664ae483f1c7",
+              "id": "de31091b-9790-407e-9573-4f7ce0e863a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29175,7 +29175,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ae64e636-560b-4259-adc3-bca7d472eb5b",
+              "id": "81c99540-a265-4e8a-b74d-9db72e4acd0a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29235,7 +29235,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "77d4f4c1-005b-47b6-b2d6-d709b916fbc1",
+                "id": "36e037d4-5a78-4b4c-bfe4-2f2195586fe6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -29251,7 +29251,7 @@
           }
         },
         {
-          "id": "9bf5f4ce-538a-4a5a-bfdd-6827357f9108",
+          "id": "696c51ba-cca0-4d84-bb02-d754b6e16331",
           "name": "Create or update product translation by product ID",
           "request": {
             "name": "Create or update product translation by product ID",
@@ -29326,7 +29326,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d4584d10-cd7c-48a2-a133-f4772203f9dc",
+              "id": "0df8d9e7-e264-4ea9-b44a-c6be4040006b",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -29397,7 +29397,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6c1c2e4f-e40f-473d-b68d-628ad436bcb7",
+              "id": "88723f63-cc7e-4512-9836-d5a0a94fd848",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -29468,7 +29468,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "751b164f-5433-4180-9516-8c338a4ecf22",
+              "id": "36f7eaec-f1b0-436d-a530-1194ca209217",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29539,7 +29539,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "30fd6f2d-ca7d-4edd-8149-609fb8fa858a",
+              "id": "42ce258e-1f7e-459e-9d40-f1d5429ef068",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -29611,7 +29611,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6fde2405-9800-480b-8458-4fcd19cb5f8a",
+                "id": "686f2cb0-da7b-475a-92d4-13aa44220854",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -29624,7 +29624,7 @@
           }
         },
         {
-          "id": "f2bc5eab-03e1-4c0d-917a-c1cf669a4e34",
+          "id": "68ad24d1-76ac-475b-bdd6-e680c40a418e",
           "name": "Get product specification translation by product ID",
           "request": {
             "name": "Get product specification translation by product ID",
@@ -29713,7 +29713,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3e33e258-c919-457a-a721-d712ec481e61",
+              "id": "d9ca3b2b-13f0-4377-94f9-e0911e15c0e0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29784,7 +29784,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4bb8d8cb-fbe0-411b-9aa8-31c4bd3d2592",
+              "id": "66036220-1f62-4cd1-bdf0-95851d8fab4d",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29846,7 +29846,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e09207c7-ecb3-4924-8bf8-466ae01995a2",
+                "id": "c11a95cf-eeaf-443b-9e8d-aa1644e5a43c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/products/:productId/specification/:specificationId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -29862,7 +29862,7 @@
           }
         },
         {
-          "id": "40d31223-9ff9-4725-aeac-40662c56b847",
+          "id": "d3bc021c-722e-4e4e-aaab-66fa698d23ad",
           "name": "Create or update product specification translation by product ID",
           "request": {
             "name": "Create or update product specification translation by product ID",
@@ -29949,7 +29949,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f4c768dc-1a17-4259-aeb5-c91005837f1e",
+              "id": "2149457b-5375-405f-a364-113606f224c6",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -30022,7 +30022,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2a125049-9c5a-45e2-a341-c4aca79d8b85",
+              "id": "d040f5e4-f208-43f0-847f-868fc6dbb761",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -30095,7 +30095,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7e27e3e9-1bad-46a1-ad20-2719503eb74f",
+              "id": "f1636bda-ebbe-488c-9ba4-b85cf6cbbf6a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30168,7 +30168,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7e85e45f-338b-4e1c-bcad-7d79a6304e6f",
+              "id": "9b8131de-3b89-4f51-b131-a58357272ace",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -30242,7 +30242,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "994d5677-8af1-4dbc-9a42-7e272b7a98df",
+                "id": "81ab339e-3853-41e1-9689-028d81a533c3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/products/:productId/specification/:specificationId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -30258,7 +30258,7 @@
       "event": []
     },
     {
-      "id": "960c3eb1-e223-4a54-a978-cd6cdd524b81",
+      "id": "ff7844b1-9280-4542-aa88-bdd3800672e0",
       "name": "Multi-language SKU",
       "description": {
         "content": "",
@@ -30266,7 +30266,7 @@
       },
       "item": [
         {
-          "id": "47f02fa9-48c6-4d90-b7ad-621a7e429848",
+          "id": "db4a97a9-bcec-4de2-9a76-b87e27ec92b2",
           "name": "Get SKU translation by SKU ID",
           "request": {
             "name": "Get SKU translation by SKU ID",
@@ -30343,7 +30343,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5448487d-b50e-4dd4-8c59-da9da20d6a87",
+              "id": "e1fc57ea-d35f-428b-b922-3bec7dbf5a4e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -30412,7 +30412,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "879727bf-b596-41e4-8b5c-833cecae625b",
+              "id": "9804f493-b8cf-4f9a-8d80-c1f5a9a79387",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30472,7 +30472,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5e577754-41c7-4493-934a-388bfa82e96c",
+                "id": "909ed991-8d6d-45a5-891a-a65266faa8d5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -30488,7 +30488,7 @@
           }
         },
         {
-          "id": "9693dd13-caf6-47c6-a5b5-e7274db62d89",
+          "id": "f769d2ee-6bb3-49e5-bcef-52637edd21a7",
           "name": "Create or update SKU translation by SKU ID",
           "request": {
             "name": "Create or update SKU translation by SKU ID",
@@ -30563,7 +30563,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8bd9d5f4-3eec-403a-aaee-bffd482bf3af",
+              "id": "3df73f2e-a618-4650-b537-9a32387e63f3",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -30634,7 +30634,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d7db3654-5e05-4d60-9e70-8383f1ec50fe",
+              "id": "82ddc3a3-44c2-466b-b171-4e3ca356e38d",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -30705,7 +30705,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c59886e0-26a4-4640-a97f-d58cf686cfb7",
+              "id": "0e5256ec-ac3e-48b2-af2e-bcc633c51b4b",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30776,7 +30776,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9123288b-e653-4770-a1b1-a62051a91904",
+              "id": "1692b817-14d8-4954-b1d6-a332310c0b3f",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -30848,7 +30848,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "726f99e1-9921-4e60-a5ef-b0bafe5a55a9",
+                "id": "a50693fc-9367-4fba-805a-65e6e0bb4e5b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -30861,7 +30861,7 @@
           }
         },
         {
-          "id": "a00c437f-7a16-4bb4-b102-919682be4a8b",
+          "id": "2fc5282d-ff5b-4997-bc4d-ab662b09c695",
           "name": "Get SKU attribute translation by SKU ID",
           "request": {
             "name": "Get SKU attribute translation by SKU ID",
@@ -30950,7 +30950,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "99d795ee-2a79-40a1-b991-78653e3599a3",
+              "id": "9f5438d2-e57b-4f96-8893-a572cf26813c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -31021,7 +31021,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b55ab24d-0714-4fee-8962-d7dfebc623e6",
+              "id": "6fa0cf51-a600-45a6-bf44-190fd5aab482",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31083,7 +31083,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cc30c915-6b6b-4688-aa1c-77e5e05fb69f",
+                "id": "83b6510f-fc72-4cbd-ad24-fa675fe0bf73",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -31099,7 +31099,7 @@
           }
         },
         {
-          "id": "df243714-c2b7-41d5-aecc-6b01244b2988",
+          "id": "7dc4784e-470f-4a7d-8da0-604d7413daf2",
           "name": "Create or update SKU attribute translation by SKU ID",
           "request": {
             "name": "Create or update SKU attribute translation by SKU ID",
@@ -31186,7 +31186,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c2319fd7-0d49-40b1-ad6e-c6a05b513d14",
+              "id": "2b0a6cbf-3419-45a9-acf1-abb124bc40ef",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -31259,7 +31259,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5a5e3829-064a-46a4-974b-915c88e22177",
+              "id": "b0817930-2dd3-40a4-991d-65347d72c6f1",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -31332,7 +31332,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a5342320-3c58-4405-927e-e2a7c1f3cbac",
+              "id": "f45902f0-28d3-4d24-917f-eb272555542e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31405,7 +31405,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "16d5cf0a-732c-4dec-a5a9-d3c791bef6bd",
+              "id": "4492bfa0-141c-43ed-aa5f-1aeaffe7bddf",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -31479,7 +31479,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ba08af7c-6311-4f2b-bcdf-3a57e000ceca",
+                "id": "4702fc23-e670-401b-85f1-4e6b403e03f4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -31492,7 +31492,7 @@
           }
         },
         {
-          "id": "7158b644-3b03-4bfb-93e1-b4acc62ba82b",
+          "id": "af570faf-4344-4c04-a548-37d6e15b93b1",
           "name": "Get SKU file translation by SKU ID",
           "request": {
             "name": "Get SKU file translation by SKU ID",
@@ -31581,7 +31581,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "73352ce1-b8cb-4064-9a4e-bd47dfae76de",
+              "id": "970cc6f3-000f-4f34-8801-c5f28ed8f2b2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -31652,7 +31652,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7cbd3bf4-3c28-4321-86b0-254db45e6978",
+              "id": "9ecb5e2c-4213-4a94-90a2-d387bf4c6887",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31714,7 +31714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3f2d71c2-9fc9-4f80-8d66-3a44c23d3135",
+                "id": "63f79bc7-b334-41d2-a652-481d7831f102",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -31730,7 +31730,7 @@
           }
         },
         {
-          "id": "4d0147d7-4c53-4b89-a4d8-87a04af06006",
+          "id": "68e3142e-b3d9-445e-be14-6502bb3c182d",
           "name": "Create or update SKU file translation by SKU ID",
           "request": {
             "name": "Create or update SKU file translation by SKU ID",
@@ -31817,7 +31817,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fd26fff3-8661-41eb-9fe8-13f610918874",
+              "id": "19d5a5ca-ae14-4b68-a18b-62613d1eaba4",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -31890,7 +31890,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e6b1a3ca-702f-4347-a09b-10af81feebdd",
+              "id": "82008a12-0944-49ac-9748-1936907ae032",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -31963,7 +31963,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cb5f4371-c1ba-412d-81f0-90f2d90b6b62",
+              "id": "2ebd9d99-7efe-48dc-93b6-c0752f72cb10",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32036,7 +32036,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "41b27836-2c0e-4d72-b8e6-30a77b618a10",
+              "id": "a4c4aa16-0ec9-4584-8308-2b2634239933",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -32110,7 +32110,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e26e595a-200c-460d-8def-0b66246b57f5",
+                "id": "776e4eb1-4b99-4331-b2a1-8279685a20ec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -32126,7 +32126,7 @@
       "event": []
     },
     {
-      "id": "083d585e-12e4-4921-bf0d-a5159d57cb54",
+      "id": "a955f0bd-313f-4a08-92cb-03a619bf8362",
       "name": "Multi-language specification",
       "description": {
         "content": "",
@@ -32134,7 +32134,7 @@
       },
       "item": [
         {
-          "id": "6ca6f18c-6bbc-4124-8ed6-466a3ade3bcd",
+          "id": "72b700d5-453c-455b-9285-726e1289b21c",
           "name": "Get specification group translation",
           "request": {
             "name": "Get specification group translation",
@@ -32211,7 +32211,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6512fa5e-74cf-4a92-a2fb-be7a32bd733d",
+              "id": "961d7469-2412-483d-b72a-dbb374cce613",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -32280,7 +32280,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dc5a477a-27f4-40e6-89e5-0f515522597b",
+              "id": "f95e9d5d-d7a5-42f0-8f6b-b67323b694da",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32340,7 +32340,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7a6d2616-612d-4374-81f2-44d8af9f5bfe",
+                "id": "1d016b91-c52b-4320-a73e-b2d60b46f151",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationgroup/:specificationGroupId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -32356,7 +32356,7 @@
           }
         },
         {
-          "id": "c3517981-da2b-4cb0-afeb-626b33345c41",
+          "id": "b09eabaf-6224-4209-8c91-b1ff28bfcf31",
           "name": "Create or update specification group translation",
           "request": {
             "name": "Create or update specification group translation",
@@ -32431,7 +32431,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a9f0c28c-08ab-4e3e-98ae-93dff4db71eb",
+              "id": "7640a35a-4ead-4a5d-aa9b-0efd5afe8d15",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -32502,7 +32502,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "04505f55-aa0b-4165-9601-fd7e65937e25",
+              "id": "a38f1f50-4445-4ef6-ab20-8dba26a68e37",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -32573,7 +32573,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ec98c179-4abf-4a53-a6bc-baab8ac8b5d4",
+              "id": "7e18cb1d-69e5-40e8-a551-10dd2ca9b1bc",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32644,7 +32644,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "39eb3179-e670-4a24-ba10-6decb3f7ee60",
+              "id": "5b2fbd4f-aa63-4473-8794-acc993a72541",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -32716,7 +32716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8708e202-513d-4755-aba3-091350803391",
+                "id": "a63e8b1c-97d5-4d3c-b4ec-60cac1ffa580",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationgroup/:specificationGroupId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -32729,7 +32729,7 @@
           }
         },
         {
-          "id": "cbc30c00-6901-40ac-bad2-de3ac7d5db5a",
+          "id": "a543b8cd-5afc-45c3-8958-8ed824e509f8",
           "name": "Get specification translation",
           "request": {
             "name": "Get specification translation",
@@ -32806,7 +32806,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6b8b667b-db29-43b9-914d-b5e7ff429fe3",
+              "id": "a6b88914-cd44-4ae7-b4c7-da175566b835",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -32875,7 +32875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "49391fd3-8b72-4403-bef2-6de125cb7db2",
+              "id": "b4ead1ff-a3db-4e42-a0f7-2bc0a9c2c8d6",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32935,7 +32935,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a7e5a2fe-a481-4eec-9fa1-f11b2eaed947",
+                "id": "7b5593eb-4203-433b-96f3-c536965499bb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -32951,7 +32951,7 @@
           }
         },
         {
-          "id": "208c6735-ff74-424d-9ade-79f08cf0c546",
+          "id": "de17d2f9-c3eb-4401-960f-c5006fca7a72",
           "name": "Create or update specification translation",
           "request": {
             "name": "Create or update specification translation",
@@ -33026,7 +33026,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d16f91a6-af9e-4f74-a13a-6f2b0a523bba",
+              "id": "795c4510-3126-4d67-9f4e-48c69730a511",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -33097,7 +33097,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "074d0b7e-7d98-4036-acd6-133a58b7d98f",
+              "id": "dd24edd7-c1d6-411a-89ed-9480ec99e235",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -33168,7 +33168,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "55b35c2b-9610-40f2-99f7-1a20ab47c2a4",
+              "id": "0c4ae616-4e0c-4d67-aba0-de18df982fa2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33239,7 +33239,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2cf8732d-74ad-4299-befc-4e487124ce4b",
+              "id": "40126567-dac2-495f-b01a-83e8969ae13b",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -33311,7 +33311,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6d4a3b4c-7740-4f60-9440-e0ce712c6f9d",
+                "id": "6f2484d5-5ac9-4f8b-9a6c-328f46d2953f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specification/:specificationId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -33324,7 +33324,7 @@
           }
         },
         {
-          "id": "aaa2174d-ac7f-43da-af98-340ed0d54bc1",
+          "id": "e2c5839a-e7c5-487f-8eaf-b5fdf2947180",
           "name": "Get specification value translation",
           "request": {
             "name": "Get specification value translation",
@@ -33401,7 +33401,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "39caf0a4-1481-4218-a1f3-361aa60965f2",
+              "id": "7c4f8cf8-80c5-4916-936c-a9c3bd786b0b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -33470,7 +33470,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "eb362f65-ba43-469b-b514-c83161c988ce",
+              "id": "7d7cec6f-58fd-4856-94dd-783933da37ff",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33530,7 +33530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ca03f61c-07ec-4c16-a391-60bca7de9772",
+                "id": "22ec90ed-01bd-4156-a2ab-a6db2a12cf3e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationvalue/:valueId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -33546,7 +33546,7 @@
           }
         },
         {
-          "id": "19044e58-fd0d-49d9-a8c0-f7acb7e6eb12",
+          "id": "a91d709b-99a5-4545-a930-0dccc9b4f458",
           "name": "Create or update specification value translation",
           "request": {
             "name": "Create or update specification value translation",
@@ -33621,7 +33621,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2e37244c-8771-4521-b580-72c8cd810ac6",
+              "id": "3e87db3b-e6cf-4a4d-b507-472433aa7c33",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -33692,7 +33692,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c17832be-971d-48f2-95ec-2cef6ca78ce8",
+              "id": "76c07bc2-40a5-437a-80e1-435ef944190f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -33763,7 +33763,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "84eb7f51-97aa-4e96-9f15-bcf20a7ec6cd",
+              "id": "d74d04ec-e6c1-4fe7-8fdb-9eeaa5f3fafd",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33834,7 +33834,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f63c8e3a-783f-4f57-b49c-66402942b363",
+              "id": "36092c8c-3b67-4ec8-9100-19ed3df5fdcc",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -33906,7 +33906,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2561226a-2731-4b6d-8866-82d78f26d976",
+                "id": "0fdc47d1-4b9a-4b4d-b8f4-6d107f65a0a4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationvalue/:valueId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -33922,7 +33922,7 @@
       "event": []
     },
     {
-      "id": "ede453e8-06c6-4c4d-858f-672d3525abd3",
+      "id": "4cf42d65-6659-4e85-a202-5ad75a5b13ef",
       "name": "Multi-language category",
       "description": {
         "content": "",
@@ -33930,7 +33930,7 @@
       },
       "item": [
         {
-          "id": "c4ec2087-dda0-4f93-a6c9-80829d828a14",
+          "id": "c7228a23-8683-4585-a416-8a96b840b8a7",
           "name": "Get category translation",
           "request": {
             "name": "Get category translation",
@@ -34007,7 +34007,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b9e95268-3e2b-4255-88f0-9c10229521b1",
+              "id": "fc414f16-3f98-4a64-97bf-1c3804cc364c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -34076,7 +34076,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d8cee33c-1ac7-4653-9860-f49a21ca1bc6",
+              "id": "885ebb7f-2412-4880-add6-9ea189679625",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34136,7 +34136,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "15a52144-17ac-4086-9ff1-e67298d3a697",
+                "id": "b468ceb2-56f0-49f9-8966-18eac4490776",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/category/:categoryId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -34152,7 +34152,7 @@
           }
         },
         {
-          "id": "e93b84d4-e60f-459d-bda8-711d6bcf0a0a",
+          "id": "8e2e0cda-bd15-44ec-bf41-a81b8b67623c",
           "name": "Create or update category translation",
           "request": {
             "name": "Create or update category translation",
@@ -34227,7 +34227,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e5647776-265c-476d-be32-6bb9779565b0",
+              "id": "f191939c-44ff-44a3-a750-56891b628a4d",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -34298,7 +34298,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "979fe475-d8a3-4903-9a48-4ff6d6e60a2e",
+              "id": "156673d7-3c15-4672-89eb-774a1b113c0c",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -34369,7 +34369,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0d8edcb0-6383-4ceb-9b08-69f718705f5c",
+              "id": "405112f5-a429-4dcc-87ee-b2de67c1b1fb",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34440,7 +34440,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "24ef6714-d386-4a88-93e0-22b1de14095d",
+              "id": "d448561c-c29e-45ec-ace9-98dc98b2d7e1",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -34512,7 +34512,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "44d5c2f6-0c3c-40bd-ab8d-dd7c260e65d3",
+                "id": "3e5b3951-d38a-4bf1-9761-4db8bac22bef",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/category/:categoryId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -34528,7 +34528,7 @@
       "event": []
     },
     {
-      "id": "ed8e5d05-1bfb-48ab-a995-530adc34a540",
+      "id": "bb994507-5541-48b0-b78c-d0b92e81100b",
       "name": "Multi-language brand",
       "description": {
         "content": "",
@@ -34536,7 +34536,7 @@
       },
       "item": [
         {
-          "id": "aa8001be-fbd1-46f9-920e-7ff353420e3e",
+          "id": "b106f507-6af2-47ed-8442-d69ad937b33c",
           "name": "Get brand translation",
           "request": {
             "name": "Get brand translation",
@@ -34613,7 +34613,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5cf74015-90fe-43a6-a74b-0be344f8276b",
+              "id": "71fe1f83-9c51-4f8b-8b49-d6ff2fb0df59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -34682,7 +34682,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d5068750-00af-4e84-8e05-8dbd3c106982",
+              "id": "8a2acb5a-417d-4701-9706-ad8f2e1d538c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34742,7 +34742,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3ab28f12-96ac-492f-9ea9-cdefb7d6c787",
+                "id": "2a48c04a-b14c-40de-a1f6-cdd28d5bf802",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/brand/:brandId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -34758,7 +34758,7 @@
           }
         },
         {
-          "id": "ee9ad34d-4f1e-4a60-abb5-ba082ab5b75c",
+          "id": "c5160b89-511f-4c03-9449-acc490124332",
           "name": "Create or update brand translation",
           "request": {
             "name": "Create or update brand translation",
@@ -34833,7 +34833,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3b10f4db-b400-476b-a015-3ccaf036559f",
+              "id": "681e2141-1877-4a09-9602-4760535863fb",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -34904,7 +34904,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "537d1ef2-9a06-4982-9375-42654bb1116a",
+              "id": "371117d0-5c69-4891-807b-90b9e16d9c9f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -34975,7 +34975,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0509c31b-3e8e-486f-835b-7b1de8f0d053",
+              "id": "44195073-804c-4e0f-88c3-a44e1c0fdf85",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35046,7 +35046,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "03db09e6-4a00-4f2f-a21a-e4d51524bd91",
+              "id": "7afba795-74a7-414c-a7a9-92b542cc5496",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -35118,7 +35118,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "896f7788-d2bc-44f7-b2a8-56c648c68b53",
+                "id": "a8b0d0e7-651f-4b88-80a7-3a0888c794ec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/brand/:brandId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -35134,7 +35134,7 @@
       "event": []
     },
     {
-      "id": "0acbf5a5-d1ec-4416-ab57-32942d88bd9d",
+      "id": "45320f2d-4447-4632-839f-b42f7d14a061",
       "name": "Multi-language attachment and service",
       "description": {
         "content": "",
@@ -35142,7 +35142,7 @@
       },
       "item": [
         {
-          "id": "f8b98163-4f47-4386-a11a-a5608f9b71a8",
+          "id": "d5116e73-57b6-41ac-8b37-475e8dc4fc38",
           "name": "Get attachment translation",
           "request": {
             "name": "Get attachment translation",
@@ -35219,7 +35219,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "005a6693-ef73-4c53-bb09-2cad0493e6e9",
+              "id": "031f2651-c7b8-4d7a-8e3c-0eecf7935177",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -35288,7 +35288,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "82538e49-bc49-4839-b0dd-dcbd3ebe5739",
+              "id": "de3d7042-023f-457d-b724-4310ca73d9b2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35348,7 +35348,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d3cab42f-5d68-40f9-8651-72dbe09fd79c",
+                "id": "bdc2a131-e206-4afb-b107-c7585172f393",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachment/:attachmentId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -35364,7 +35364,7 @@
           }
         },
         {
-          "id": "48091c8a-e627-4e16-a573-1354ac445b06",
+          "id": "a9527ef9-be9e-4e78-a15c-583f97858cfa",
           "name": "Create or update attachment translation",
           "request": {
             "name": "Create or update attachment translation",
@@ -35439,7 +35439,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7c8920da-9b17-4f8f-b42a-89af2903484b",
+              "id": "ba9eaf95-d4c9-42fc-b286-557559d91ef0",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -35510,7 +35510,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "eafd30d6-968b-4f9a-a36c-7a15de4e74b6",
+              "id": "20e16402-4749-466d-b0d9-6c3484939e96",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -35581,7 +35581,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "132afbcd-e4d7-4f11-9afb-bff8a01e40f2",
+              "id": "9634fbe6-97c8-42ef-9f94-4e06303cd3e7",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35652,7 +35652,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fd4eda20-2599-457b-8e55-6ff34a4948fb",
+              "id": "58b7fce4-e53e-4eb1-8695-d454cbb3999e",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -35724,7 +35724,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2a9994dc-8f96-4b01-987c-8a58c898b872",
+                "id": "6dcaa604-2302-41dd-bb80-767d5a8a3c95",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/attachment/:attachmentId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -35737,7 +35737,7 @@
           }
         },
         {
-          "id": "5412a51d-30a9-41f4-8414-8d5bdea5dd98",
+          "id": "0ac63326-2e7e-4f93-80d4-56d65ced6e14",
           "name": "Get SKU service type translation",
           "request": {
             "name": "Get SKU service type translation",
@@ -35814,7 +35814,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ea27d719-72d6-41e0-8799-ce6c34f052c5",
+              "id": "81115cbd-3733-4dfa-aaa2-bbd054cffdc9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -35883,7 +35883,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1bbcad73-e5da-41f8-99fd-698a1d037a40",
+              "id": "cb3a7e8b-1b54-4fb1-8cc7-fd95e0645133",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35943,7 +35943,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "96419c92-f527-4860-92e9-c4d830495bb2",
+                "id": "c72c1b5a-9c72-40c1-b5af-7773cbaf1845",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -35959,7 +35959,7 @@
           }
         },
         {
-          "id": "d58ac0ac-db8e-4797-978a-592d7eaa055a",
+          "id": "9b505634-3639-4b73-8377-bcc3d1964cbb",
           "name": "Create or update SKU service type translation",
           "request": {
             "name": "Create or update SKU service type translation",
@@ -36034,7 +36034,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f1ab5dc0-6ec1-4c9a-bfc2-99428a63e21f",
+              "id": "d86d63b5-80c2-4e45-a9ec-1ea4dfc346e9",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -36105,7 +36105,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d59fcc7a-5489-47ad-a765-2e51006a6b03",
+              "id": "48edc131-ab98-4559-b6be-3de9caa590ca",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -36176,7 +36176,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d5ada780-3025-444d-9554-ec4849eafbea",
+              "id": "e0f7a245-9bcf-4d0a-af8c-18db4d65d9d3",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36247,7 +36247,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9ad1ad35-44ff-4afb-af29-bb1f23c1c4d4",
+              "id": "bb0352a7-4aa4-4aba-b1f7-523c20004fa4",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -36319,7 +36319,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6655c8de-1f67-4f95-8640-cb6a5354ba16",
+                "id": "58f2376d-234f-4122-a19f-e47cc41f08ac",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -36332,7 +36332,7 @@
           }
         },
         {
-          "id": "89a8aad0-4944-4406-962a-a1e83070ccc8",
+          "id": "e7eab673-66a2-4b67-8173-856a51def097",
           "name": "Get SKU service translation",
           "request": {
             "name": "Get SKU service translation",
@@ -36409,7 +36409,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2be52a8e-dcda-487a-9303-b847712ff710",
+              "id": "adad71e1-e902-4d83-bc05-3f3105536ba2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -36478,7 +36478,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5ad1ea6f-b072-42df-b872-b3e838771ead",
+              "id": "a2c5059a-5f89-4d69-9dfa-a4db424eaa4a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36538,7 +36538,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "38cffb39-9b2c-4070-8c38-559cc799783d",
+                "id": "1a4d4698-0ee0-4dc5-b5cb-612b0f5b92f1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservice/:skuserviceId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -36554,7 +36554,7 @@
           }
         },
         {
-          "id": "a1ced1ee-d86d-4949-b0a2-3d345f90faa6",
+          "id": "dc905279-6b36-4e25-9422-10e7085b7eec",
           "name": "Create or update SKU service translation",
           "request": {
             "name": "Create or update SKU service translation",
@@ -36629,7 +36629,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "88449550-99c6-43bf-8ba5-071f7ac97013",
+              "id": "b8cece8d-c839-47cc-8338-8b40a28b3837",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -36700,7 +36700,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "affd698f-861e-4eab-9673-97fb1a9cc31a",
+              "id": "0a396661-5751-4639-87e0-185d35f488ce",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -36771,7 +36771,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5f8a8a2e-8d4c-4eea-9926-a73fa7423d49",
+              "id": "0f75d5bb-cb04-4ee7-8403-79f5a6a060b0",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36842,7 +36842,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6260bcd7-5cbd-4542-9f71-063974414df6",
+              "id": "7c59222c-b425-4637-a7da-5f9504626dc3",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -36914,7 +36914,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "71d037c5-1383-499c-9879-690c40596e65",
+                "id": "ab101540-1803-45d5-bafa-d00ced77d78c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservice/:skuserviceId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -36927,7 +36927,7 @@
           }
         },
         {
-          "id": "e38a181e-fe24-4aa7-ad3f-9409d2aa0e9b",
+          "id": "240cf025-2c7d-4e25-892d-dc210f08e033",
           "name": "Get SKU service value translation",
           "request": {
             "name": "Get SKU service value translation",
@@ -37004,7 +37004,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d852b233-eeb5-4084-8a79-253fbb99d1db",
+              "id": "4936f2a2-d4d9-4f77-86b9-8e5169d1e35f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -37073,7 +37073,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c1bcdedd-732f-41bc-ab51-ec820a4e0a3f",
+              "id": "3225b13f-b06f-4b97-923c-8852696f5bd1",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37133,7 +37133,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cf4b74a3-cf57-4ca3-ac8b-e36b75418e0b",
+                "id": "840bd09b-ad71-4474-a4f9-5d7b1237e74a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -37149,7 +37149,7 @@
           }
         },
         {
-          "id": "78c791c1-beee-42d8-a7a7-16f646f390a7",
+          "id": "9ff48fdf-77d2-4940-a654-088c3ba8c2e6",
           "name": "Create or update SKU service value translation",
           "request": {
             "name": "Create or update SKU service value translation",
@@ -37224,7 +37224,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "76fce57f-5a7a-4e23-9948-330bb2579f0d",
+              "id": "8ff1c758-9346-4e28-86c6-c63173beecd8",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -37295,7 +37295,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b7e4a04c-634e-4183-8787-29607d6ef748",
+              "id": "5d9b7420-4430-4a56-bbdc-94c5cfdc743a",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -37366,7 +37366,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "20d4599b-aec6-43ac-833e-ff37eecad063",
+              "id": "a0f2f1af-69d0-4764-8408-a5bbb5eb4393",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37437,7 +37437,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b3922c2e-16b5-4b7f-9e81-92c8c1c49c3c",
+              "id": "32620e64-0dfe-449a-9103-7b935facd314",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -37509,7 +37509,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "189a485b-a10b-4bc1-94a7-67f041b6887c",
+                "id": "227293d8-5b4d-4e5c-aa69-61420454f67b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -37525,7 +37525,7 @@
       "event": []
     },
     {
-      "id": "fbf0651d-2383-430e-8b9e-833095eab3b5",
+      "id": "c8761d78-5d82-4741-89bb-648ac9db2669",
       "name": "Multi-language collection",
       "description": {
         "content": "",
@@ -37533,7 +37533,7 @@
       },
       "item": [
         {
-          "id": "39a82a1d-48e2-4a62-b012-79620d00e02f",
+          "id": "8609a879-1f29-4d87-99ea-c8f31154e192",
           "name": "Get collection translation",
           "request": {
             "name": "Get collection translation",
@@ -37610,7 +37610,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "770666c8-82e6-4f5c-af1c-2cbc05f3de95",
+              "id": "6d5adb4f-6e16-4510-8c6f-029025e7a482",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -37679,7 +37679,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a406f09e-b3b3-4b25-b3e8-73b97608e6cb",
+              "id": "0f7c6de5-edb4-4082-a635-54add8496a39",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37739,7 +37739,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "35a0f8e8-02fa-4168-bc81-52d108b1acff",
+                "id": "c21ca36a-4ce4-45de-85e0-58c8cfacd51c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -37755,7 +37755,7 @@
           }
         },
         {
-          "id": "867b6adb-710d-467f-9ba5-8ce26bd78248",
+          "id": "c42d2e77-9ae3-4398-be32-c6f00d3efda4",
           "name": "Create or update collection translation",
           "request": {
             "name": "Create or update collection translation",
@@ -37830,7 +37830,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9e759069-fb6f-4b84-8d9e-d3216da5a425",
+              "id": "ce621e97-25b6-406c-89b4-01b164bed293",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -37901,7 +37901,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "06e2115c-bdd7-46e7-996c-b03776c51be5",
+              "id": "bf76136a-cec2-4eba-819d-7c8756ea28e2",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -37972,7 +37972,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b9300d3c-594f-4a93-ac27-47936821b438",
+              "id": "4cd3a44b-fcf2-415a-a56b-551aae902c6d",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -38043,7 +38043,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0d21e161-563b-4dfd-8d9f-abe3580b90d8",
+              "id": "04388cca-e5d3-4410-959b-07e263b04afb",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -38115,7 +38115,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "661e77ae-97aa-48f9-ac1a-499439eb00db",
+                "id": "af8be566-a1f6-4df0-8303-7858f4becf09",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/collection/:collectionId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -38131,7 +38131,7 @@
       "event": []
     },
     {
-      "id": "81dd555c-468e-4cb3-bab3-3a2bf7d64737",
+      "id": "85c52047-6f59-4ce1-b505-4fd621f3f407",
       "name": "Product indexing",
       "description": {
         "content": "",
@@ -38139,7 +38139,7 @@
       },
       "item": [
         {
-          "id": "da599ecc-8c94-4465-bce9-c0110761f4b7",
+          "id": "6f95c9ea-39a8-4674-a923-5d23573281fb",
           "name": "Get product indexed information",
           "request": {
             "name": "Get product indexed information",
@@ -38205,7 +38205,7 @@
               "_": {
                 "postman_previewlanguage": "xml"
               },
-              "id": "3fb91e1f-5cff-456f-8b48-56417c895446",
+              "id": "c366462a-c78e-410f-b9fe-0fc14007f71d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38274,7 +38274,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "69344a2d-bc90-4f2a-b85f-b42a77bb1bd3",
+                "id": "596968fa-7b65-47bd-b997-fee2e6dd106c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/GetIndexedInfo/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38291,7 +38291,7 @@
       "event": []
     },
     {
-      "id": "61625277-4c8f-4d99-b907-8c09a739d9b8",
+      "id": "711335a2-8f94-4267-84c9-1a7361ae3f36",
       "name": "Commercial conditions",
       "description": {
         "content": "",
@@ -38299,7 +38299,7 @@
       },
       "item": [
         {
-          "id": "abb9b287-ff24-4a92-946b-fccc250e3dff",
+          "id": "44a34ac4-9f90-4efe-89af-db3e141a0472",
           "name": "Get all commercial conditions",
           "request": {
             "name": "Get all commercial conditions",
@@ -38353,7 +38353,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "70ffc267-e4df-46c2-8e17-899f602b9eed",
+              "id": "67ae0872-f344-449e-8309-a0431b9582df",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38421,7 +38421,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e00bd8b3-f980-4d8e-b80e-88795fd430f9",
+                "id": "971e047e-61b1-47cd-ad1f-a212a6ef25a2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/commercialcondition/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38437,7 +38437,7 @@
           }
         },
         {
-          "id": "0c68a077-66e3-41cb-ba38-fb42034f039d",
+          "id": "397aa842-b12a-416b-b0b9-0a568475c6a7",
           "name": "Get commercial condition",
           "request": {
             "name": "Get commercial condition",
@@ -38502,7 +38502,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "134b3afc-3c0b-4480-8bee-7bf9c12df1b1",
+              "id": "9c202528-8f68-40da-b52b-13af843843d4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38570,7 +38570,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "42503647-bad2-4b5f-96b6-c7842ff9aed1",
+                "id": "0a47ec5a-75be-4bc2-bed9-da4c2a498d2a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/commercialcondition/:commercialConditionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38589,7 +38589,7 @@
       "event": []
     },
     {
-      "id": "9beba852-5bee-4b56-a324-56eb491be455",
+      "id": "dd618e8c-73e4-4376-b141-185a99e3c3e5",
       "name": "Gift list",
       "description": {
         "content": "",
@@ -38597,7 +38597,7 @@
       },
       "item": [
         {
-          "id": "cbfb1f3f-4afa-4660-93d8-461c11b3977c",
+          "id": "04948284-4c50-4265-b22d-7cac405a663f",
           "name": "Get gift list",
           "request": {
             "name": "Get gift list",
@@ -38663,7 +38663,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1c018422-0e6e-4259-9117-9f0f12529c19",
+              "id": "f6817e6b-0509-4f45-8773-70d52820a40d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38732,7 +38732,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1588d2af-24d7-4335-b501-6dfbe3a4db96",
+                "id": "4989de1c-6db9-40a4-9ac0-ed0d53d1a15e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/addon/pvt/giftlist/get/:listId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38790,7 +38790,7 @@
     }
   ],
   "info": {
-    "_postman_id": "82e5b7cf-e13e-4881-8ff3-a854ee80fa7b",
+    "_postman_id": "61081289-d1ab-41ac-930b-5782b19058c6",
     "name": "Catalog API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Catalog API.json
+++ b/PostmanCollections/VTEX - Catalog API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "c52ef862-3313-49a8-bdd4-8cbaf3a548cd"
+    "postman_id": "6a4d6e50-11af-4db4-b939-ac4ad681926d"
   },
   "item": [
     {
-      "id": "818841cc-b308-452b-af5e-d5f967dcb4a2",
+      "id": "972bdbef-e20f-47d9-866e-f02febb65eb3",
       "name": "SKU service",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "bb6da97a-da86-4b5e-9ff3-c7968f86fc60",
+          "id": "15ada9c2-86cc-488e-9c43-68ce234037f4",
           "name": "Get SKU service",
           "request": {
             "name": "Get SKU service",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "91d5c924-186d-4632-8ffd-016eaf4a61a5",
+              "id": "00270efc-9835-4960-bb53-c7324bd37d5b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -145,7 +145,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3ffcd87c-ae56-4745-9ee7-f6b6d134e8fc",
+                "id": "3e785840-c9a9-4f24-bd79-5c7aa1875ab2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -161,7 +161,7 @@
           }
         },
         {
-          "id": "1e250baf-6783-4dde-aaac-73313b09c390",
+          "id": "d7ed45ab-78c7-4e16-838a-9cbfd17cd71f",
           "name": "Update SKU service",
           "request": {
             "name": "Update SKU service",
@@ -239,7 +239,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "49441368-72a3-4b39-b283-45d77774cebf",
+              "id": "d1d172dc-13c6-46b7-955c-fb9d48cead37",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -320,7 +320,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6dc65992-4064-4794-99b1-8357692d1e6f",
+                "id": "0ff6ff18-e2b5-4270-bf7e-5ad266c75701",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -336,7 +336,7 @@
           }
         },
         {
-          "id": "bff5d151-907b-4514-87df-8d8041378598",
+          "id": "1826b775-b92f-4ef1-aa2a-8fb13c2c57cd",
           "name": "Dissociate SKU service",
           "request": {
             "name": "Dissociate SKU service",
@@ -397,7 +397,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6627c007-9455-4e41-b9af-c201a9400853",
+              "id": "7aa9ad97-304a-451d-bf74-fadb1ee4e565",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -455,7 +455,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "adc3606f-f901-438e-9617-da43a81003b3",
+                "id": "5f5c564c-29d3-44de-a11a-c7ff8fd1672f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservice/:skuServiceId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -468,7 +468,7 @@
           }
         },
         {
-          "id": "47cb15aa-bb4d-4012-b6e0-500e327066dd",
+          "id": "3dddd4c0-5d51-45cd-b522-17561e89022c",
           "name": "Associate SKU service",
           "request": {
             "name": "Associate SKU service",
@@ -534,7 +534,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3c9ae0fe-0a68-4691-b3bc-100ac8db4610",
+              "id": "05f51648-843c-4118-a4f6-e7010fb2a555",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -614,7 +614,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ac01b3a6-2488-44c8-9cee-d159fcb3f028",
+                "id": "5bec9ed9-1ab1-4c48-8c04-6d1486578a5e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservice - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -633,7 +633,7 @@
       "event": []
     },
     {
-      "id": "bf9a39e6-cebb-4f7d-8da5-27de043d1be5",
+      "id": "da9ddcbb-dbd1-4db9-937d-aa160dc91258",
       "name": "SKU service attachment",
       "description": {
         "content": "",
@@ -641,7 +641,7 @@
       },
       "item": [
         {
-          "id": "1e68c855-96e1-49a6-9884-06ff0acaf108",
+          "id": "d7d3ef28-6723-4cc1-bcf3-06c9e1daa782",
           "name": "Associate SKU service attachment",
           "request": {
             "name": "Associate SKU service attachment",
@@ -707,7 +707,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3950070a-527b-44cc-ac7d-57da31b2706e",
+              "id": "7117b87e-0dea-4e06-aefb-3cffc7667c4b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -787,7 +787,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "21e67ed9-ad94-4c33-806c-df5f53877d24",
+                "id": "1e1a7223-dc91-46aa-ad59-354799bcf9b5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicetypeattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -803,7 +803,7 @@
           }
         },
         {
-          "id": "57950da0-efe0-4f1c-837b-ccdeb861f59d",
+          "id": "32f42b3f-fa32-4ad2-b4ed-a4ada3a0abd5",
           "name": "Dissociate attachment by attachment ID or SKU service type ID",
           "request": {
             "name": "Dissociate attachment by attachment ID or SKU service type ID",
@@ -871,7 +871,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8779886c-cd22-4f1b-87b3-6a8b2f452178",
+              "id": "8f44febc-d419-4bb3-b26e-b2e30cb8a41b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -947,7 +947,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2d9d224a-e8a6-4c59-8ad0-1bdd8b64f3f4",
+                "id": "3d5d3dd0-9921-41c8-b319-cbee45e27dab",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetypeattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -960,7 +960,7 @@
           }
         },
         {
-          "id": "214fc53c-ddbe-4fd8-8a1b-578f1a94e7e8",
+          "id": "b74f4d29-b640-495b-9e2e-79153da92ab1",
           "name": "Dissociate attachment from SKU service type",
           "request": {
             "name": "Dissociate attachment from SKU service type",
@@ -1021,7 +1021,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "92072173-9884-4e7b-924e-204644ee5702",
+              "id": "76e38706-25e6-4320-8009-911343e3433e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1079,7 +1079,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a4286f98-0baa-4700-8c0a-ac8660625fa1",
+                "id": "eb3a9441-d6d4-4118-868f-7dadc37e04a4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetypeattachment/:skuServiceTypeAttachmentId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1095,7 +1095,7 @@
       "event": []
     },
     {
-      "id": "3efcde43-3efb-4430-a590-cd09fce1d91b",
+      "id": "695821da-f48b-4ffc-b3b4-b0c6c844cf75",
       "name": "SKU service value",
       "description": {
         "content": "",
@@ -1103,7 +1103,7 @@
       },
       "item": [
         {
-          "id": "f823ff76-9222-4c79-93f5-c1c3417358ed",
+          "id": "274e319f-bd99-4256-8416-649c282e7273",
           "name": "Create SKU service value",
           "request": {
             "name": "Create SKU service value",
@@ -1169,7 +1169,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2caf14bd-718f-405a-9d64-49bb1816f364",
+              "id": "f9259caa-2d8a-491f-9cf1-e27d6d292c24",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1249,7 +1249,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b5b2aa0a-e012-4f6e-89af-26cfea9b603a",
+                "id": "6b0a3296-24a4-47f2-8b55-32031b959077",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicevalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1265,7 +1265,7 @@
           }
         },
         {
-          "id": "c50259c4-f098-463f-bd15-e634068f51f0",
+          "id": "2f9e6610-fd25-449d-aef6-455d20448f90",
           "name": "Get SKU service value",
           "request": {
             "name": "Get SKU service value",
@@ -1330,7 +1330,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "212dadcd-9a6c-418a-a4e7-41a662801cf2",
+              "id": "9f70f2ee-d152-4660-818f-6fec7679cf66",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1398,7 +1398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6befd8e3-4c15-4815-b97f-29e7a31bc26e",
+                "id": "1c8e4f47-5361-4cd1-838c-f88785dee193",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1414,7 +1414,7 @@
           }
         },
         {
-          "id": "1c075521-abe4-40f2-bcfc-bc5909ffaf7f",
+          "id": "7e248e4f-0c74-4ed9-b826-0a1663ad8125",
           "name": "Update SKU service value",
           "request": {
             "name": "Update SKU service value",
@@ -1492,7 +1492,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e1506d75-0f09-4d02-97fb-c5786be1b995",
+              "id": "bf28dee9-0fd4-4622-9350-94c90a2f1a8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1573,7 +1573,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7bf5980b-00c4-4e23-84d3-e267ffcde214",
+                "id": "d5050534-e2ce-4460-949d-ee8afdf01e19",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1589,7 +1589,7 @@
           }
         },
         {
-          "id": "3c6f5bdb-96d7-4d3c-8003-081183511c83",
+          "id": "acc115ea-1e2c-42f1-8e5d-c7de3a48ad1f",
           "name": "Delete SKU service value",
           "request": {
             "name": "Delete SKU service value",
@@ -1650,7 +1650,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a7cbdb8b-9637-4d2e-8c86-11cf9bf5fa15",
+              "id": "ac828036-86d0-4c1b-a749-d4b13d1dc718",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1708,7 +1708,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be4d1edb-167e-4dec-a996-b766d2a4190a",
+                "id": "d0fbc391-71b0-4ca8-b1c4-6170c81a3797",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1724,7 +1724,7 @@
       "event": []
     },
     {
-      "id": "bca60ae4-f516-43e5-8eb4-5ac707667056",
+      "id": "86c7e9cd-badc-4466-aa69-f793c7cd4cd5",
       "name": "SKU service type",
       "description": {
         "content": "",
@@ -1732,7 +1732,7 @@
       },
       "item": [
         {
-          "id": "57d5eb86-3580-48a8-a2d8-8f62beaab120",
+          "id": "159df798-4904-4732-991d-a23d7ac07546",
           "name": "Create SKU service type",
           "request": {
             "name": "Create SKU service type",
@@ -1798,7 +1798,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f75b3a3f-9c9e-44dd-9e41-842ef19ac90b",
+              "id": "289c8652-964e-4da3-8c87-fa510034858b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1878,7 +1878,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "de3fe976-fc63-482f-ae03-44f8159aeb3d",
+                "id": "4f4d2fec-4c2d-4a29-8b39-e75ff6518d42",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuservicetype - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1894,7 +1894,7 @@
           }
         },
         {
-          "id": "e34a3839-7a75-413f-8708-23364f6fb9a0",
+          "id": "80451c22-7324-45cb-8087-9bb1df4dda9e",
           "name": "Get SKU service type",
           "request": {
             "name": "Get SKU service type",
@@ -1959,7 +1959,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5a5ba468-4ac2-4ca9-a86f-ad8de358c946",
+              "id": "2c876f7e-7c45-4486-bcb9-7d937e6c1224",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2027,7 +2027,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9f582fe8-d6a2-4f30-938b-af829d388274",
+                "id": "7ba5bb0b-1569-45ef-a84e-42c4ea901aac",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2043,7 +2043,7 @@
           }
         },
         {
-          "id": "d3fba5d2-08a1-4a1f-936d-6f41d0b27bcd",
+          "id": "f06748a8-85f5-4e72-aa22-94cb21f3d037",
           "name": "Update SKU service type",
           "request": {
             "name": "Update SKU service type",
@@ -2121,7 +2121,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "951814b2-1cdb-4535-a2f1-0fc83295e186",
+              "id": "5b29ffe7-ad6b-42c6-a708-739779097ea6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2202,7 +2202,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5a096649-9bc8-47cf-985c-f39f3877505d",
+                "id": "0476cb22-e227-4701-a3db-87807b58954a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2218,7 +2218,7 @@
           }
         },
         {
-          "id": "632980f8-7d3c-44b7-a961-555f1020dd07",
+          "id": "d489e835-1b01-425f-b73c-2b3b5822d39f",
           "name": "Delete SKU service type",
           "request": {
             "name": "Delete SKU service type",
@@ -2279,7 +2279,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e4271cfa-37e9-40e2-8197-4baaccb5eeda",
+              "id": "138aefc9-995c-46a5-abcd-09686f68bee5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2337,7 +2337,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e74f68f8-73c1-4c39-a24b-72e2d94b63c2",
+                "id": "87e73617-0bf1-4396-b456-8d52df5a048d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2353,7 +2353,7 @@
       "event": []
     },
     {
-      "id": "c7e9a74f-6ed9-4ed6-8da4-b813cbd2249d",
+      "id": "f47ca651-a45b-4777-b0cf-2547442d7ebc",
       "name": "Category",
       "description": {
         "content": "",
@@ -2361,7 +2361,7 @@
       },
       "item": [
         {
-          "id": "4900b59d-c094-4369-a03a-25830576f7cb",
+          "id": "81b92c66-08b9-4d51-8804-cd26a91efb2b",
           "name": "Get category tree",
           "request": {
             "name": "Get category tree",
@@ -2427,7 +2427,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7ede4248-a116-4282-9b24-0d2baa4d0393",
+              "id": "42134506-9e9c-4e96-a2c9-a14fbafb82d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2496,7 +2496,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c24d492a-5632-49c6-b7ac-49c605139524",
+                "id": "71a19237-fe56-454f-ba9f-633151dd408c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/category/tree/:categoryLevels - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2512,7 +2512,7 @@
           }
         },
         {
-          "id": "1ce5dfec-c372-4ae2-b8bc-c4537cf64823",
+          "id": "7df87abe-04e8-4f82-ad02-2a89fcef4f84",
           "name": "Get category by ID",
           "request": {
             "name": "Get category by ID",
@@ -2587,7 +2587,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "33c32415-d7dc-4733-a9fa-1367b7246cbe",
+              "id": "4401f074-efd3-4333-9725-bdef6c45cbb0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2665,7 +2665,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f9627e9d-2eee-4674-b63f-69777c927c2c",
+                "id": "4857c261-bdc4-4cf2-805b-20472fb256bd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2681,7 +2681,7 @@
           }
         },
         {
-          "id": "ce294a8b-c2af-4ccc-9681-471ec22ca35d",
+          "id": "aabafa59-df9d-4ccd-93c7-7ae1f625cffa",
           "name": "Update category",
           "request": {
             "name": "Update category",
@@ -2759,7 +2759,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2156b83c-1f7b-4a6d-b116-f53e5f158967",
+              "id": "7b64cc0a-9fe6-44ef-a420-f73f203bb44f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -2840,7 +2840,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f0671468-493b-4ce4-b8b0-4fd6071fdb06",
+                "id": "2fdc8d2c-bb85-4b9c-b681-9b74b95cf1af",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2856,7 +2856,7 @@
           }
         },
         {
-          "id": "578bf4db-da90-45c7-a813-f3345b92661d",
+          "id": "88bcec68-ad5b-472c-bad1-1b7eaef92f4b",
           "name": "Create category",
           "request": {
             "name": "Create category",
@@ -2922,7 +2922,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "80095d67-809d-485a-af99-459fe68cb2c5",
+              "id": "be4413b1-3782-4ac8-b454-0c087689141c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3002,7 +3002,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "729df149-ba71-44e6-985f-f342ba4c546e",
+                "id": "1949a818-6bd4-46bd-89f8-b1b947062c71",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/category - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3021,7 +3021,7 @@
       "event": []
     },
     {
-      "id": "b42585a5-b930-4a2c-9fe4-1f01c228b74e",
+      "id": "d375c6d9-4e61-4092-852c-f13094c191ca",
       "name": "Brand",
       "description": {
         "content": "",
@@ -3029,7 +3029,7 @@
       },
       "item": [
         {
-          "id": "55555b36-acbc-4554-a016-98648b702474",
+          "id": "bf576e8f-ad7d-4129-9bd7-c8a12f0ee956",
           "name": "Get brand list",
           "request": {
             "name": "Get brand list",
@@ -3083,7 +3083,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "388bc95b-07eb-4455-906b-5ea62c5f9e7e",
+              "id": "a04a8c30-c9f0-4b9a-acfd-165513f83d73",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3151,7 +3151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4df65e1e-163a-4ace-a643-14e6723b9e85",
+                "id": "244a2d41-89c5-4b60-ad1c-0359e80237a0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3167,7 +3167,7 @@
           }
         },
         {
-          "id": "6491a581-b1cd-47b7-af5d-5220c5abdfc1",
+          "id": "ae560a93-5ae5-406e-9501-be30ea8c3d0c",
           "name": "Get paginated brand list",
           "request": {
             "name": "Get paginated brand list",
@@ -3240,7 +3240,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5bbe396d-effe-4412-b3e9-e497d76ee843",
+              "id": "05c85812-fc4c-49be-98af-eea69ae5e623",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3327,7 +3327,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "70181621-9379-4488-9964-6d97e4709b4b",
+                "id": "50c13f3f-def2-4749-b101-f0ef605fee1f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/pagedlist - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3343,7 +3343,7 @@
           }
         },
         {
-          "id": "bed62999-50ba-4be3-8c7e-48bbfc1e2114",
+          "id": "36ab7487-e2f4-44ce-953f-ca97f3156135",
           "name": "Get brand by ID",
           "request": {
             "name": "Get brand by ID",
@@ -3408,7 +3408,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b3b6073b-7120-41d2-88f8-558b2cf76d9d",
+              "id": "85a1bf2a-6466-4720-9bdf-3487ec67728b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3476,7 +3476,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7cce100b-cf27-4267-aae6-7b6c50cd011c",
+                "id": "369c3715-4dd2-4323-a3e0-bc087a26d1e7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3492,7 +3492,7 @@
           }
         },
         {
-          "id": "c4e714a1-a883-4310-8f88-9715478de5a9",
+          "id": "d84ecc34-a675-4332-a53b-e166fc845ef2",
           "name": "Create brand",
           "request": {
             "name": "Create brand",
@@ -3558,7 +3558,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c0dd014c-d9e8-402b-bab5-4025adb2a98c",
+              "id": "43e2dadd-c506-454c-a1df-6dc73c99ac59",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3638,7 +3638,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5c7dac3c-303a-41d2-8ef3-027c5482ff06",
+                "id": "0b84bc7e-8394-4fe0-8a18-929ff255bb44",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/brand - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3654,7 +3654,7 @@
           }
         },
         {
-          "id": "1bad9652-1c1d-4f83-ba57-07a0948fd711",
+          "id": "22c69621-df47-456c-94b1-a3f51450f3d1",
           "name": "Get brand and context",
           "request": {
             "name": "Get brand and context",
@@ -3719,7 +3719,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6ca8d3dd-80e4-4b94-8def-3827b6538e3b",
+              "id": "61124873-85e3-4ac5-9663-a8afd6db211a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3787,7 +3787,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "00f619d8-5f1f-438a-8101-0eb25edc634f",
+                "id": "50baf75e-1635-4065-836f-025ddcefb191",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3803,7 +3803,7 @@
           }
         },
         {
-          "id": "a16f8fab-7f51-47d0-b3ec-07a5692cb7da",
+          "id": "1d65efca-82a9-495f-85cf-03bb8460bc55",
           "name": "Update brand",
           "request": {
             "name": "Update brand",
@@ -3881,7 +3881,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "388bf5f9-08ce-46ff-ba93-f04c8df681a7",
+              "id": "6c765ac4-db48-4c59-9454-51f484317563",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -3962,7 +3962,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8997ec77-2c4e-469e-880d-39e31e81fd7d",
+                "id": "e8ff28dd-9d78-4953-b4f8-8653c5d9b981",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3978,7 +3978,7 @@
           }
         },
         {
-          "id": "93f7a481-b2fe-4ce4-ba86-7211f2443846",
+          "id": "ff19e59f-771c-457a-8dcc-63e5bbd177b4",
           "name": "Delete brand",
           "request": {
             "name": "Delete brand",
@@ -4039,7 +4039,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "611ee4c0-460e-4a6a-a950-6406dd102c8b",
+              "id": "98ece09b-1a30-4ac3-949c-0ec16d698619",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4097,7 +4097,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e9532346-0ee5-4536-b58c-e4e56d205c48",
+                "id": "ffef5d60-cf12-42c9-9a6f-1147555c1468",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4113,7 +4113,7 @@
       "event": []
     },
     {
-      "id": "38d4d2b9-c8fe-4bf3-b980-1590a2daa11f",
+      "id": "3f78446c-6ba4-4c64-8800-2a05cc9935c7",
       "name": "Attachment",
       "description": {
         "content": "",
@@ -4121,7 +4121,7 @@
       },
       "item": [
         {
-          "id": "7d712869-928c-4de1-9897-3a77b4ceb5b0",
+          "id": "7914120f-cc0d-4e2a-b246-7f2a8e15951c",
           "name": "Get attachment by ID",
           "request": {
             "name": "Get attachment by ID",
@@ -4186,7 +4186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6eba3a3f-d681-4161-92b3-69460116f44b",
+              "id": "3c752ee2-a47e-462d-851b-48eda7f81ce3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4254,7 +4254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0d581800-e99b-4783-b682-4df9aabbd00a",
+                "id": "e74b46ce-a45a-4bc3-8062-63d1120fef29",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4270,7 +4270,7 @@
           }
         },
         {
-          "id": "9148e9e8-62eb-4ae0-bc8c-2ef77da1fbdf",
+          "id": "aeb58952-9b18-4c13-a545-f6ddd4bc1b61",
           "name": "Update attachment",
           "request": {
             "name": "Update attachment",
@@ -4348,7 +4348,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "50740ec3-dcde-49fc-9648-dc698e3ec969",
+              "id": "5d08cc4a-cb77-4974-a5ed-892709851f46",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4429,7 +4429,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c66355e9-b7fd-421d-a409-8f4b13894139",
+                "id": "74a410ef-a152-417a-bc2f-4d890def156c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4445,7 +4445,7 @@
           }
         },
         {
-          "id": "6a8cd327-134e-46da-827d-17a412086045",
+          "id": "7c8007ce-6ea0-4bf1-a711-b630b5466492",
           "name": "Delete attachment",
           "request": {
             "name": "Delete attachment",
@@ -4506,7 +4506,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "69ca6252-4727-4342-829c-f3b3b6efc8a9",
+              "id": "7dcf9a7a-1ca6-465d-aa15-af6f8ecf06e4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4564,7 +4564,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "32f77770-1185-4cff-8eae-6a941928ca38",
+                "id": "bc68df28-d6ce-40c5-a64d-39da8dbc3554",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/attachment/:attachmentid - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -4577,7 +4577,7 @@
           }
         },
         {
-          "id": "7dd86249-4209-4fa0-a76a-2c7b36694568",
+          "id": "54101c7d-c5ac-4013-b491-3f25a89f87c8",
           "name": "Create attachment",
           "request": {
             "name": "Create attachment",
@@ -4643,7 +4643,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7090f39a-6a3d-4b17-bd50-26e51df8095f",
+              "id": "5c2842ee-eff7-4e34-856d-3ef7c818c596",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4723,7 +4723,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ccc5d33c-e7c3-48ed-8e1e-65016c930861",
+                "id": "5415cdd5-5341-4157-a01a-9c8b8b53c7e9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/attachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4739,7 +4739,7 @@
           }
         },
         {
-          "id": "55528aa9-2878-4e33-a7cd-c0f7b1f6cd79",
+          "id": "59a96906-a313-4b5e-b505-91be1146a704",
           "name": "Get all attachments",
           "request": {
             "name": "Get all attachments",
@@ -4792,7 +4792,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3fc32bab-ddb5-497f-8fe7-b4784e2737b2",
+              "id": "e5a6c947-5585-4b99-898b-0538313fbf33",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -4859,7 +4859,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4deb16ac-b276-4335-a710-ad4a5de02f57",
+                "id": "9ba44a5e-7081-4586-9848-987f0c573918",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachments - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4878,7 +4878,7 @@
       "event": []
     },
     {
-      "id": "e5451b31-8925-4e86-be70-241b475c01b4",
+      "id": "43c56663-a85e-4561-944d-e6d9fa2b515d",
       "name": "Product",
       "description": {
         "content": "",
@@ -4886,7 +4886,7 @@
       },
       "item": [
         {
-          "id": "c07dca32-bf2b-4d1f-8603-7015df5bcbf8",
+          "id": "12199b3c-768a-4cb8-ad44-49e0a35d9c35",
           "name": "Get product and SKU IDs",
           "request": {
             "name": "Get product and SKU IDs",
@@ -4968,7 +4968,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "787d5afe-b612-470a-bf5d-f5b806235f4d",
+              "id": "7024ae0e-687e-43eb-a3d5-ad44f2ef474e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5064,7 +5064,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "386c4544-2d52-4ead-91bb-4782fc185334",
+                "id": "124e4b79-4fd3-4cec-8838-7e72129f2b75",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/GetProductAndSkuIds - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5080,7 +5080,7 @@
           }
         },
         {
-          "id": "04c2f0e7-1ef5-401b-9102-699341179d1a",
+          "id": "ce9f6d8d-365a-45db-9751-00ddb24ccb08",
           "name": "Get product by ID",
           "request": {
             "name": "Get product by ID",
@@ -5145,7 +5145,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "73b00ecf-0339-4369-b00b-51358ccc4c70",
+              "id": "f3194abe-276b-4e32-be3c-794d843afd02",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5213,7 +5213,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2cf61545-ef57-4035-b38a-bfe816c46891",
+                "id": "cecdfccb-dae9-4e19-9ee5-f5e0b51bab74",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5229,7 +5229,7 @@
           }
         },
         {
-          "id": "dafc2159-e249-482b-bd80-d22d70230c8b",
+          "id": "0bf4efac-8886-46ba-a407-0bf14e6a4dad",
           "name": "Update product",
           "request": {
             "name": "Update product",
@@ -5307,7 +5307,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b548cc6d-d8bd-41b5-8aa1-c68b7c763308",
+              "id": "d1f83641-cad4-4e53-8dea-0299c9a738e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5388,7 +5388,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e6c7a539-59b4-4ea0-9194-df36543ea632",
+                "id": "b1417c6b-757a-4553-9719-5283c0f56094",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5404,7 +5404,7 @@
           }
         },
         {
-          "id": "97ec7384-678f-4f7d-8285-781207a65f4c",
+          "id": "439d0c21-c371-41c7-b86c-f68ad9fced23",
           "name": "Get product and its general context",
           "request": {
             "name": "Get product and its general context",
@@ -5470,7 +5470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0b0362bc-f6c0-4890-a9ab-94161c18eed6",
+              "id": "d98a2bc5-0216-41e6-8a29-a0845b1639fa",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5539,7 +5539,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "039b08c0-b190-438a-9789-72b24e317d17",
+                "id": "4ee717c9-dadb-4e97-88a5-23feba229ea2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/productget/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5555,7 +5555,7 @@
           }
         },
         {
-          "id": "b7382e37-ee9a-4f11-bd36-d4f9fcf4fc84",
+          "id": "febaed50-f9b7-4c81-9822-6aea2ed4c80d",
           "name": "Get product by reference ID",
           "request": {
             "name": "Get product by reference ID",
@@ -5621,7 +5621,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9e38c997-08d9-47d2-9419-e20ae5574b95",
+              "id": "e2db7662-406e-4eec-b570-bee655cbd796",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5690,7 +5690,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "42773bf2-7470-4a07-8e72-4b07b36891ea",
+                "id": "646f8efa-ef7c-47d7-9da3-663d65ba1e1e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/productgetbyrefid/:refId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5706,7 +5706,7 @@
           }
         },
         {
-          "id": "a75d02e7-28a0-4f60-b700-b3695aa92990",
+          "id": "5d58a063-8d18-44ef-97f8-d146f420a3e0",
           "name": "Get product's SKUs by product ID",
           "request": {
             "name": "Get product's SKUs by product ID",
@@ -5772,7 +5772,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8d82e574-68d0-4c67-82e2-7a980688d565",
+              "id": "b8768477-cb82-49aa-9eb2-751515b08640",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5841,7 +5841,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b09c9cad-cf63-4b81-bf6c-f59eedf1aca6",
+                "id": "b5b7926d-255e-464b-b24d-6a0c71b1885f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/products/variations/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5857,7 +5857,7 @@
           }
         },
         {
-          "id": "29585852-2db0-4d03-8df3-fdd25ab84b1f",
+          "id": "614c61df-4bbb-43b7-b3ea-1a0d8f2bad7f",
           "name": "Get product review rate by product ID",
           "request": {
             "name": "Get product review rate by product ID",
@@ -5923,7 +5923,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5f628763-c76f-437f-acdb-cf30f76a0d22",
+              "id": "14244cdf-6889-4aa9-b4de-c5a10d921a14",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -5992,7 +5992,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d1b46dbe-8d0b-4646-9497-8272bf4743aa",
+                "id": "598da966-ef57-4ab7-a1ce-b31ab0e3176d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/addon/pvt/review/GetProductRate/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6008,7 +6008,7 @@
           }
         },
         {
-          "id": "34b1975e-cff7-41e8-8747-b43c55a6eb22",
+          "id": "c31eb4a0-e7f6-4cfd-a536-fcc1d8fb8014",
           "name": "Create product with category and brand",
           "request": {
             "name": "Create product with category and brand",
@@ -6074,7 +6074,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "41526d66-d0cc-49e2-abd6-bcbca5a11541",
+              "id": "770b143e-3ec7-4260-b26c-92b438a1d7d0",
               "name": "New category and brand",
               "originalRequest": {
                 "url": {
@@ -6153,7 +6153,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "712f5758-bb48-4bbe-9ffd-149649e4a886",
+              "id": "cf359626-254e-470d-8105-9409f4b03de3",
               "name": "Associating it to an existing category and brand",
               "originalRequest": {
                 "url": {
@@ -6233,7 +6233,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7162afff-2ccc-43a3-84e1-49812642ade6",
+                "id": "6d9beeb6-a2d0-411b-8d80-619bffec8a9e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6252,7 +6252,7 @@
       "event": []
     },
     {
-      "id": "9217edda-5ed6-4476-9751-6afc975f9c3e",
+      "id": "9517f497-082b-4a62-888a-4f06c91aeb76",
       "name": "Product specification",
       "description": {
         "content": "",
@@ -6260,7 +6260,7 @@
       },
       "item": [
         {
-          "id": "2fcd5b69-668a-4287-8fe3-a52977806a40",
+          "id": "81ab212b-b675-41ac-aeb6-9f200a22b6ba",
           "name": "Get product specifications by product ID",
           "request": {
             "name": "Get product specifications by product ID",
@@ -6326,7 +6326,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "86ec938b-7f5d-436d-b047-38b52a4ee241",
+              "id": "77929d5b-d8a2-4a69-a75f-7026d8dd11a7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6395,7 +6395,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "09b8e2aa-5378-4c97-a7d2-476923671dff",
+                "id": "d67cb487-9527-4294-8c16-6ccd6ffdc627",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6411,7 +6411,7 @@
           }
         },
         {
-          "id": "ac67d58d-c3e5-4bc8-be28-3d728bc81cfb",
+          "id": "7383c50f-2b2c-4b07-8922-a944db36cf36",
           "name": "Update product specification by product ID",
           "request": {
             "name": "Update product specification by product ID",
@@ -6486,7 +6486,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a30b7e54-431b-4ce9-ae1c-a276427812f7",
+              "id": "f8143f7e-0f63-40f0-87bc-2a66778938fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6558,7 +6558,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b003a631-c70e-4629-b23d-05429c585015",
+                "id": "1bc7f09b-72ba-47b9-906a-796422375691",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/products/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -6571,7 +6571,7 @@
           }
         },
         {
-          "id": "e42b7607-bb8b-47ce-97c6-a63e38cc777f",
+          "id": "98899b49-99aa-448c-ab60-d861901793f7",
           "name": "Get product specifications and their information by product ID",
           "request": {
             "name": "Get product specifications and their information by product ID",
@@ -6637,7 +6637,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6ee97b83-d309-4ba0-ab49-cf42539aca16",
+              "id": "b0e0f506-14a5-4393-855a-a0b9949b2f63",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6706,7 +6706,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "29538a6a-3e38-415a-946c-f736903e21a5",
+                "id": "08bfc778-e19d-40cf-bfc9-b1c41d5118d1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6722,7 +6722,7 @@
           }
         },
         {
-          "id": "a35276e7-a3a7-4880-b6da-e558dd615236",
+          "id": "8a81e632-535a-44f1-82d2-28a3f728f272",
           "name": "Associate product specification",
           "request": {
             "name": "Associate product specification",
@@ -6801,7 +6801,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "617d6a36-c8db-4ff1-96dd-a4693e482997",
+              "id": "05580eb2-ca2f-4439-a794-2dde24370994",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -6883,7 +6883,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fd954854-87e0-4e00-8e12-6649bccd7515",
+                "id": "6532e213-b6e7-4640-98d3-4dbb1be4de00",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6899,7 +6899,7 @@
           }
         },
         {
-          "id": "a6499734-4d0c-49f7-8816-a9bbeb9ee1e4",
+          "id": "7f85708b-aef5-4a1b-972b-790db7dbb0d6",
           "name": "Delete all product specifications by product ID",
           "request": {
             "name": "Delete all product specifications by product ID",
@@ -6961,7 +6961,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d2fe85dd-2a13-4d83-b86e-589f1c5fd2c6",
+              "id": "5fca5d9c-d7af-4736-8b8a-25c65d0aade5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7020,7 +7020,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "efd5eeb3-eaee-4ed3-80a4-121482529549",
+                "id": "123b84b6-1fd3-45ca-82c8-9b02750c73fa",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7033,7 +7033,7 @@
           }
         },
         {
-          "id": "9d81df5d-f518-4d0d-afad-bfcaf3661e1f",
+          "id": "e0650cc4-fdc2-4bfa-a810-b1ae4ceac0e4",
           "name": "Delete a product specification",
           "request": {
             "name": "Delete a product specification",
@@ -7110,7 +7110,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4d5fc92a-e3f5-46bf-9b35-c276ac7864f0",
+              "id": "c4c2da43-42db-4c98-8ced-6f94c2a2ef97",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7169,7 +7169,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0fc3ad83-a90f-4152-acc6-dcf8179015c6",
+              "id": "ec474e18-548a-479c-a4af-197ade1e1e42",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -7239,7 +7239,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bf8c325d-de19-40c7-82af-3fabfa8a824b",
+                "id": "9dcd2701-63d7-4179-9c69-407ad06b9a55",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7252,7 +7252,7 @@
           }
         },
         {
-          "id": "1756be4f-a9c3-4b19-874d-6bec6a75deca",
+          "id": "7c0242c8-e8eb-4a5e-bd39-ef4ea358766c",
           "name": "Associate product specification using specification name and group name",
           "request": {
             "name": "Associate product specification using specification name and group name",
@@ -7331,7 +7331,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "46774e70-19d1-437c-96d8-800de65c7cc3",
+              "id": "d2545680-73e8-4945-a045-50211fe32dee",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7413,7 +7413,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "471fb5cf-a8f7-4cd1-8d04-b2d431c6434c",
+                "id": "f4a49c6d-5193-4921-b23c-280833f7b9f1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7432,7 +7432,7 @@
       "event": []
     },
     {
-      "id": "dcbd2af4-8f58-4483-b379-4e852f576c9d",
+      "id": "8ea06a57-ed5a-4630-b450-6c3e102019e9",
       "name": "Similar category",
       "description": {
         "content": "",
@@ -7440,7 +7440,7 @@
       },
       "item": [
         {
-          "id": "11d3a63f-bc4c-4ca8-aaa8-6cf4b7b8d280",
+          "id": "8bb210ae-7eaa-4e7a-ae1f-6f79f75fe07b",
           "name": "Get similar categories",
           "request": {
             "name": "Get similar categories",
@@ -7506,7 +7506,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e3f20286-5451-4c68-aa6c-321daacd34b6",
+              "id": "fecfe480-15e4-4ff3-a4f4-a062532f9873",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7575,7 +7575,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "921bcbf6-0851-4196-9879-b3d485c0be52",
+                "id": "6a73e7cf-e836-4eee-b993-1717a7dff6ec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/similarcategory - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7591,7 +7591,7 @@
           }
         },
         {
-          "id": "c2c8631a-22d6-48f7-bea2-e5ab489c1b2a",
+          "id": "0cdf1f40-e573-465e-8aea-298fec11be00",
           "name": "Add similar category",
           "request": {
             "name": "Add similar category",
@@ -7668,7 +7668,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f894d383-5647-42ba-a889-154d52c4d758",
+              "id": "febd87dc-2e46-4952-b76b-312b084f7661",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7738,7 +7738,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7bd331b6-1f9d-451e-b0a4-446f2ae55dc4",
+                "id": "4469d46e-5e9d-4ba8-8aa5-3b8459a0ac61",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/similarcategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7754,7 +7754,7 @@
           }
         },
         {
-          "id": "2cb6e53f-c79a-4a8f-b912-64faf51d3245",
+          "id": "1f86ac7e-f21a-45ae-8e16-25f313e646ad",
           "name": "Delete similar category",
           "request": {
             "name": "Delete similar category",
@@ -7827,7 +7827,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0b0d4364-765d-41b1-a15b-f7aa661e6189",
+              "id": "90587a2a-513c-4ebb-a300-a3585dbcd47d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -7887,7 +7887,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "13133fa9-63bc-41bc-8a53-7c79092d1f8c",
+                "id": "0e26f261-906e-4ed3-9a33-eb489ad24e02",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/similarcategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -7903,7 +7903,7 @@
       "event": []
     },
     {
-      "id": "6e9fd629-694e-4ece-8c99-d9818992af04",
+      "id": "147f5fd8-03de-4554-bac3-aaa39f43e461",
       "name": "SKU",
       "description": {
         "content": "",
@@ -7911,7 +7911,7 @@
       },
       "item": [
         {
-          "id": "77b60378-5b23-4242-a680-41c13e32be7f",
+          "id": "54a78cc0-fde6-4c3c-b925-a9d0900b61a4",
           "name": "List all SKU IDs",
           "request": {
             "name": "List all SKU IDs",
@@ -7984,7 +7984,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "40cc5f79-1d37-414b-a0d4-32f299f53061",
+              "id": "89e2eb05-2371-4efa-ab0c-9ea7e833a9b8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8071,7 +8071,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b6308ec5-ae0f-4042-86cf-3b25fc22b3d5",
+                "id": "a6738371-a209-4332-87da-e2fb6b74ddbc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitids - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8087,7 +8087,7 @@
           }
         },
         {
-          "id": "ed8c8c87-4415-4848-8c53-74ef682ccb5b",
+          "id": "e136a140-db24-4ad3-ac85-7e8972910c39",
           "name": "Get SKU and context",
           "request": {
             "name": "Get SKU and context",
@@ -8163,7 +8163,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c383b082-ea5f-4b98-af4a-846e8159683c",
+              "id": "f3fd2130-ebe6-4fc4-b02a-7c22d3ac858f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8242,7 +8242,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dadc1848-468a-466d-8caa-835747464baa",
+                "id": "0144f066-3c68-4d7e-8c73-2afe1677ce47",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyid/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8258,7 +8258,7 @@
           }
         },
         {
-          "id": "6def2f03-6238-4c5f-997c-c8b83f799712",
+          "id": "964391f6-bb2c-4494-aa7d-ab8b360b7462",
           "name": "Get SKU by reference ID",
           "request": {
             "name": "Get SKU by reference ID",
@@ -8321,7 +8321,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4f68c66c-48de-4d36-87f7-b643073e155b",
+              "id": "90f8727c-a4b8-4b8d-9094-34f5cb9ade9c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8398,7 +8398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0fbf7866-5356-433a-be29-3e2b3df4ac81",
+                "id": "5b18125c-d78e-4e74-9d74-f64735b1b876",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8414,7 +8414,7 @@
           }
         },
         {
-          "id": "a5f88c63-f592-4a7c-9bbf-88b513878fb3",
+          "id": "66d9665e-4949-48b5-80dc-17b51f9ba742",
           "name": "Create SKU",
           "request": {
             "name": "Create SKU",
@@ -8480,7 +8480,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "75db2cf0-76ce-4a05-9e16-f73889d5fdc8",
+              "id": "08c675c1-48c6-4a00-b62f-530fa12744d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8560,7 +8560,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fc8cc895-bb35-4d7f-afc2-3ad3065d5393",
+                "id": "ee537a3e-6725-45c6-a888-9e6a6cfddb30",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8576,7 +8576,7 @@
           }
         },
         {
-          "id": "aff5b9c6-da13-4fa8-a065-76919dbc276f",
+          "id": "cb126f2e-f7a6-4441-8ae0-8b82667052ab",
           "name": "Get SKU ID by reference ID",
           "request": {
             "name": "Get SKU ID by reference ID",
@@ -8642,7 +8642,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c937f59d-0157-4ffe-b2c0-d1946a6901c0",
+              "id": "a4cc8f62-c918-45c9-89c5-60a68463182c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8711,7 +8711,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7f54465c-c726-4df8-a415-db8c0f0b38ce",
+                "id": "e5db9af7-3819-4b50-95e5-aa8afaa74297",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitidbyrefid/:refId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8727,7 +8727,7 @@
           }
         },
         {
-          "id": "4f8f866a-bff8-48c7-ab21-f5eae3fb6142",
+          "id": "f9aecf0c-5ea1-4993-b1e3-5f324e026913",
           "name": "Get SKU by alternate ID",
           "request": {
             "name": "Get SKU by alternate ID",
@@ -8793,7 +8793,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f1d99c19-a956-4b7a-85cf-de86cf996936",
+              "id": "94318e29-8bba-45b1-a021-f652487e94fc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -8862,7 +8862,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9d3c4d19-96e8-4357-8319-603dc3ab861a",
+                "id": "36fc8420-2639-4f5d-a8a9-82fac001c065",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyalternateId/:alternateId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8878,7 +8878,7 @@
           }
         },
         {
-          "id": "78929ec2-c201-49d4-a7d5-6f3b2c6ec9db",
+          "id": "85f53da0-ae16-43ee-a137-b3d95478c971",
           "name": "Get SKU list by product ID",
           "request": {
             "name": "Get SKU list by product ID",
@@ -8944,7 +8944,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "58282a07-ebf1-4ba6-a6cf-11303ecfb890",
+              "id": "7b7dd3d3-59f1-403c-ae78-504c068b9908",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9013,7 +9013,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "52077f01-0f0c-4d8f-b03d-7004e8a67843",
+                "id": "0a7c75ca-dc76-419d-92bb-05db8d2e64ca",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitByProductId/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9029,7 +9029,7 @@
           }
         },
         {
-          "id": "c330d414-5cbe-4d99-a8f5-abfcb48cca70",
+          "id": "37b2c0e4-1ace-4d7c-a2d4-654cd337d2ce",
           "name": "Retrieve SKU ID list by reference ID list",
           "request": {
             "name": "Retrieve SKU ID list by reference ID list",
@@ -9096,7 +9096,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7d216a56-c313-4cae-88a1-afebdb179358",
+              "id": "adebd45e-afb4-4bd3-80eb-301391ba34d6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9176,7 +9176,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "660c8fd9-0d28-41c4-bc63-ad6291d6bdec",
+              "id": "c7a53af9-5f33-446c-82d7-a6b4aae5f712",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -9247,7 +9247,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d37a70ac-7f1d-4753-afd7-39867d35cbb6",
+                "id": "db3875be-0f65-4013-a4b5-0d1fa420b352",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pub/sku/stockkeepingunitidsbyrefids - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9263,7 +9263,7 @@
           }
         },
         {
-          "id": "3cccf164-02b8-43e6-b83c-1c9071160655",
+          "id": "bae9d953-728a-4ffa-93cf-99ae9f93e4b3",
           "name": "Get SKU",
           "request": {
             "name": "Get SKU",
@@ -9328,7 +9328,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f959c135-0f41-4d95-b548-f25c29c51f88",
+              "id": "75e7deb7-a929-4d05-b65a-d8688c7d7d0a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9396,7 +9396,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "322c12d9-3af3-4662-8e1b-bbc112af903d",
+                "id": "b6a6511a-9533-489f-ba6c-686426b84e78",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9412,7 +9412,7 @@
           }
         },
         {
-          "id": "bf4ea349-c168-4c12-bc1b-486f8f55f964",
+          "id": "c3b08d9e-182a-4cce-adb7-317da57f9dfe",
           "name": "Update SKU",
           "request": {
             "name": "Update SKU",
@@ -9490,7 +9490,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f9df8f6b-09e0-490e-99b9-677262270485",
+              "id": "53bc3686-c01e-4998-9482-33cda3ccca66",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9571,7 +9571,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "22a46a04-19c9-4c32-ab85-ef9a22b49e3d",
+                "id": "e92c678a-d57c-4bbd-b747-b62cd74dc809",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9590,7 +9590,7 @@
       "event": []
     },
     {
-      "id": "96d31809-9dc5-4b9b-bba4-4b178da7ea21",
+      "id": "c62aa47d-0fcd-4367-80a0-c1ca988f5ad0",
       "name": "SKU EAN",
       "description": {
         "content": "",
@@ -9598,7 +9598,7 @@
       },
       "item": [
         {
-          "id": "c30a9ada-02a7-41d4-97db-b49086fa37a4",
+          "id": "70ff7784-cd1e-4310-96bf-b6dfa5fa619d",
           "name": "Get SKU by EAN",
           "request": {
             "name": "Get SKU by EAN",
@@ -9664,7 +9664,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2371ff33-1754-48b6-9b4d-78d1c24a24cd",
+              "id": "59138e11-3674-4f72-8420-8716647a66ef",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9733,7 +9733,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5917e4d7-6114-45c7-aac2-936b947b9542",
+                "id": "dd906a60-e3bc-4d27-82a3-1126d3ff42f5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitbyean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9749,7 +9749,7 @@
           }
         },
         {
-          "id": "d20909fb-93ba-47d5-94c0-ec6ddf1fd753",
+          "id": "37ff0cd1-5550-4fe6-9917-63e33020de87",
           "name": "Get EAN by SKU ID",
           "request": {
             "name": "Get EAN by SKU ID",
@@ -9815,7 +9815,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "295cd8a5-97bb-4f2f-b2f3-fe8fcdc03328",
+              "id": "77f049da-eafa-4ec6-b8f3-76ed2607cc30",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -9884,7 +9884,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d20eed27-edc3-4c66-9f9d-4fe052af83c5",
+                "id": "c8af4bac-70ac-4dd1-8885-155391e22f39",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9900,7 +9900,7 @@
           }
         },
         {
-          "id": "6d68ff35-046f-4c02-a356-3698ad0d4779",
+          "id": "210cb0fb-d898-45f8-a8ce-944787a6a923",
           "name": "Delete all SKU EAN values",
           "request": {
             "name": "Delete all SKU EAN values",
@@ -9962,7 +9962,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0732a1aa-b8d5-446b-88a1-1a211afb6fd5",
+              "id": "ad0eee47-c30c-42e9-af77-004a24bf79b0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10021,7 +10021,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "337919d7-a2ce-4a3a-bcd9-e86031d310c6",
+                "id": "cb0e907c-53bc-40e6-bb4a-842ea943787f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10034,7 +10034,7 @@
           }
         },
         {
-          "id": "b180cc41-2a03-4fd3-9127-7b41355e7130",
+          "id": "677128fc-23a6-4a52-a064-06b8237a85d2",
           "name": "Create SKU EAN",
           "request": {
             "name": "Create SKU EAN",
@@ -10107,7 +10107,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8e42c156-f2f0-44a5-a32e-6f1bd13a69f9",
+              "id": "900333c7-2192-4928-ac95-e9c438abd5b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10167,7 +10167,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cadd84bc-1f10-44ae-bd66-76ee0285e079",
+                "id": "1f2b80d1-9c3f-47c4-ac21-9c05ed15662a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/ean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10180,7 +10180,7 @@
           }
         },
         {
-          "id": "c3fd930b-c0b3-4ddc-a7ad-d97ff3576018",
+          "id": "98012f62-563b-4d94-b948-528ba859e521",
           "name": "Delete SKU EAN",
           "request": {
             "name": "Delete SKU EAN",
@@ -10253,7 +10253,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c2e595ac-c05b-4254-9525-90ac44ffedc2",
+              "id": "92a096e7-62a8-445e-b976-b8473480dd8b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10313,7 +10313,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a31a3906-7c73-4281-82bb-a0df1c7a2632",
+                "id": "583575a8-78d1-4882-8d23-f9ff1f380ff0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/ean/:ean - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10329,7 +10329,7 @@
       "event": []
     },
     {
-      "id": "34565fd9-45a1-4abf-8ed5-ab46dedd4541",
+      "id": "c67e7886-078c-4a37-9497-0ee894f40571",
       "name": "SKU file",
       "description": {
         "content": "",
@@ -10337,7 +10337,7 @@
       },
       "item": [
         {
-          "id": "93c4933a-0661-46e8-8b4f-1657d345ba7b",
+          "id": "5bf89f64-57e6-47a7-a287-ca113d3cc50f",
           "name": "Get SKU files",
           "request": {
             "name": "Get SKU files",
@@ -10403,7 +10403,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "31b9a23f-6597-424d-94ac-ba21822d5cce",
+              "id": "36905c1c-0779-4ce6-bfd6-be0ce45ea948",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10472,7 +10472,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5d2dc0ba-abee-4b49-9208-eb69f0160b15",
+                "id": "7cc27cff-4907-4169-9db3-af6b23fa7ea9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10488,7 +10488,7 @@
           }
         },
         {
-          "id": "0eed0892-5cf1-4c2f-94c3-6e1840c9559c",
+          "id": "0fc6e377-786f-43b1-a747-c4bcbea8614a",
           "name": "Create SKU file",
           "request": {
             "name": "Create SKU file",
@@ -10567,7 +10567,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "31824b0d-f5c1-4e8b-85eb-a6752088eab9",
+              "id": "8bb6160b-3a66-4a30-ba3d-69634ffd54c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10649,7 +10649,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5c094407-1403-40ba-a628-27f239cad4b6",
+                "id": "eaa97613-9ce5-412d-ac5d-42fd61bb51d3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10665,7 +10665,7 @@
           }
         },
         {
-          "id": "7b0951fe-12c0-422c-b663-d9526fbcb4b1",
+          "id": "dbab20a8-b68c-4a54-be1e-2ecab6346069",
           "name": "Delete all SKU files",
           "request": {
             "name": "Delete all SKU files",
@@ -10727,7 +10727,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5815ef13-f594-4ea6-b979-80beb9ec5ca3",
+              "id": "b469d9c7-11bc-4e2f-be20-58b97ca6704b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10786,7 +10786,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "06edc074-b3bd-46a8-898c-8a22d04854e6",
+                "id": "355afb62-320c-4d7d-a304-b3bfbd18194f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -10799,7 +10799,7 @@
           }
         },
         {
-          "id": "bb4ac3f5-5ffc-4209-abeb-8e0bd85087db",
+          "id": "7f9aa914-618c-4f2f-a7db-479cb30af42c",
           "name": "Update SKU file",
           "request": {
             "name": "Update SKU file",
@@ -10889,7 +10889,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "60950919-80eb-4246-82f1-6e1fdcb81794",
+              "id": "bfd30df3-0924-4754-bd76-a4b8823f5b94",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -10972,7 +10972,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d25fbc37-25e9-47cd-b3a0-c671584c4f98",
+                "id": "873de2d9-ce53-4da9-9a2d-9f51724604db",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -10988,7 +10988,7 @@
           }
         },
         {
-          "id": "e3d31505-1c8c-477e-9ea3-d4e4566f82bd",
+          "id": "38c9c6a7-292d-4fd0-8f09-dc43e4a77e5b",
           "name": "Delete SKU image file",
           "request": {
             "name": "Delete SKU image file",
@@ -11061,7 +11061,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8ccf11f6-c093-460f-b9b0-655d28087afb",
+              "id": "c08eb20f-a084-432f-8c5a-7871730d16e1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11121,7 +11121,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "03d36610-7f26-40c3-ab2a-97ea3d920a7b",
+                "id": "df4e5a0f-8167-4a90-ab06-aff9395aa564",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11134,7 +11134,7 @@
           }
         },
         {
-          "id": "207b8b89-a67a-4dbc-a9f9-582a7577dc9c",
+          "id": "fb84bee2-5af5-42a9-b568-34b20592ff44",
           "name": "Reorder SKU files",
           "request": {
             "name": "Reorder SKU files",
@@ -11210,7 +11210,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bd13e368-833b-486d-8e1b-5b56dae6a1b5",
+              "id": "b5c280eb-b975-465e-b9b7-4849b7baf08e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11282,7 +11282,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8d7f797b-80df-42cf-81ca-7da1b77f3a79",
+              "id": "d4f24fe7-6b27-49a3-b875-d562a945eaf5",
               "name": "Bad request. All files are required.",
               "originalRequest": {
                 "url": {
@@ -11355,7 +11355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e7ee5569-8c6d-451e-8b0c-056ccdcc9248",
+                "id": "07a70874-65d4-40e3-ab87-c0b820216abe",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/reorder - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11368,7 +11368,7 @@
           }
         },
         {
-          "id": "d86c3edb-5c8f-488e-af35-69d9289f3d65",
+          "id": "e5536395-f446-4144-a26b-01bb3bcb735e",
           "name": "Copy files from an SKU to another SKU",
           "request": {
             "name": "Copy files from an SKU to another SKU",
@@ -11446,7 +11446,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6c92737b-2bf6-44e9-8e25-76aab577686b",
+              "id": "90db0392-2af5-4251-a699-d7955de49de3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11517,7 +11517,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "10e61a35-3d25-4053-8f01-a1e817031db2",
+                "id": "25b17198-0075-40a0-87ca-31cb6b620989",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/copy/:skuIdfrom/:skuIdto/file - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -11533,7 +11533,7 @@
           }
         },
         {
-          "id": "669de16a-41e1-4f12-aa3f-c95243e9a1c1",
+          "id": "7547cf4c-4a08-479a-9142-ef09c2f26753",
           "name": "Disassociate SKU file",
           "request": {
             "name": "Disassociate SKU file",
@@ -11607,7 +11607,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "321842b6-0405-43c5-8649-2552e8269cbd",
+              "id": "480b9ace-6b61-4298-bda3-d4a67c044cc4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11668,7 +11668,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a4a3007c-bf70-4062-b5a1-085ffbfea7ad",
+                "id": "17dae7ca-00fc-4dfd-85e8-a66adaec2b85",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/disassociate/:skuId/file/:skuFileId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -11684,7 +11684,7 @@
       "event": []
     },
     {
-      "id": "8ef4d76a-825f-480c-9173-2c800774c5ce",
+      "id": "7c42997f-f3b5-4273-865c-e92cb00e8de4",
       "name": "SKU kit",
       "description": {
         "content": "",
@@ -11692,7 +11692,7 @@
       },
       "item": [
         {
-          "id": "3faf81d9-fa94-4502-b2ca-dc4184afb852",
+          "id": "8c7040cc-ba1b-4ea8-b27e-cd3d26035cf8",
           "name": "Get SKU kit by SKU ID or parent SKU ID",
           "request": {
             "name": "Get SKU kit by SKU ID or parent SKU ID",
@@ -11764,7 +11764,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9e96887f-385a-4665-99bf-1cb5b79719c0",
+              "id": "b9e4f593-14aa-4180-98cc-1f57bc3f6d45",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -11850,7 +11850,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7b9c0801-435b-42be-964d-07034e95a3f5",
+                "id": "a1835b5a-1495-43da-933e-d5aa152ff3c0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -11866,7 +11866,7 @@
           }
         },
         {
-          "id": "17b57962-6e3a-412f-846c-81a4c049a441",
+          "id": "997c2c46-773f-4a7b-a1b0-27bd99186589",
           "name": "Create SKU kit",
           "request": {
             "name": "Create SKU kit",
@@ -11932,7 +11932,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "51f9a282-6932-408e-ae56-b4f76830f6f8",
+              "id": "b0e12fd4-03b0-43c0-bffe-14243cb06ef7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12012,7 +12012,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "89aeea27-d5fe-4efd-b1e9-12fd3a7ed0bb",
+                "id": "18f20402-a31a-4c1c-91c8-ce84dd18006b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12028,7 +12028,7 @@
           }
         },
         {
-          "id": "c33ff0da-35d1-4944-8da9-f13a49cd6d83",
+          "id": "cdd80fc1-5df6-4e3f-9cff-8cbd30138047",
           "name": "Delete SKU kit by SKU ID or parent SKU ID",
           "request": {
             "name": "Delete SKU kit by SKU ID or parent SKU ID",
@@ -12096,7 +12096,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7d0ff1e9-8353-4d38-b239-7de6508e3941",
+              "id": "44be84c2-987c-4c68-be5e-f7695d546e8f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12172,7 +12172,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "802143c1-53e1-4a21-9ff9-06bca61aa393",
+                "id": "059afd34-f1cc-4405-bb93-f8986a7da752",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunitkit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -12185,7 +12185,7 @@
           }
         },
         {
-          "id": "a8073a59-233d-47dd-9981-46c4db99a449",
+          "id": "e1ef9fdf-f2e7-4fa9-bb2d-e88bd53af1ae",
           "name": "Get SKU kit",
           "request": {
             "name": "Get SKU kit",
@@ -12250,7 +12250,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "17a897f4-2056-4e00-be6e-86cd31a632dd",
+              "id": "fac0e4ed-6dfd-4901-84e1-de77d0bf21c6",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12318,7 +12318,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cb9faf0d-b5bf-4dfd-82c5-820bcb9f7a5f",
+                "id": "006cfaae-1337-4187-a5fc-d0259d1c6721",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunitkit/:kitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12334,7 +12334,7 @@
           }
         },
         {
-          "id": "e7fbc430-3874-4cb9-ac34-896557d67b74",
+          "id": "001e7b56-6708-48b4-95bd-cd6b722bd1c9",
           "name": "Delete SKU kit by kit ID",
           "request": {
             "name": "Delete SKU kit by kit ID",
@@ -12395,7 +12395,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ba524ac4-f54e-4852-9d32-935197d62c7e",
+              "id": "4bcc9dd6-30af-41b0-a19d-27a0cf478731",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12453,7 +12453,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "34bd78b4-180c-442d-b1ad-94b13d634328",
+                "id": "53b00c40-ca6d-4b35-9c79-a1518fa15ac5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunitkit/:kitId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -12469,7 +12469,7 @@
       "event": []
     },
     {
-      "id": "36d0feaa-c83c-43a0-96e3-62d39ada9fee",
+      "id": "383293e0-881c-4950-a75b-4183641d2371",
       "name": "SKU specification",
       "description": {
         "content": "",
@@ -12477,7 +12477,7 @@
       },
       "item": [
         {
-          "id": "09367b56-5ada-49e9-9d17-d730187f6ea6",
+          "id": "260d1068-9b5a-481d-a365-97d6636857a4",
           "name": "Get SKU specifications",
           "request": {
             "name": "Get SKU specifications",
@@ -12543,7 +12543,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f99ebf8c-2b77-4450-9447-46cce8f58fc0",
+              "id": "919f4b25-55d0-4047-8bc8-e837eb7ac7b3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12612,7 +12612,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "75a1772c-e658-41f7-b943-bd4c4ed3662e",
+                "id": "d58d41e3-2bd1-433a-8c9a-4b53ed54bf87",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12628,7 +12628,7 @@
           }
         },
         {
-          "id": "03106adf-9998-424e-98bd-81e2a71f98a7",
+          "id": "1338bbb2-90cf-4f56-af39-9ea3a69da6e3",
           "name": "Associate SKU specification",
           "request": {
             "name": "Associate SKU specification",
@@ -12707,7 +12707,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "50527983-40fa-4c50-bfa9-52f5d50e9cfd",
+              "id": "1fcb8bf8-c632-4f2b-854a-e46b037233e4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12789,7 +12789,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "11f94472-7da9-49fe-8010-f862edaef310",
+                "id": "18018a9f-56ac-4ff4-af99-7fdf0b24395a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12805,7 +12805,7 @@
           }
         },
         {
-          "id": "4a71d012-0f58-445a-9d81-4463d5d4994a",
+          "id": "bb03bcd0-3c1c-4e96-b1cc-77ab29ab5000",
           "name": "Update SKU specification",
           "request": {
             "name": "Update SKU specification",
@@ -12884,7 +12884,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2d2cb00d-7629-45f0-9749-710d2ad99601",
+              "id": "bf926385-1644-4a57-a7a3-2c113cd8421c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -12966,7 +12966,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "59c81fd4-256d-4b7c-b319-c040cf24f3d3",
+                "id": "0d774795-988b-4e44-befe-d40ef5aeb9c4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -12982,7 +12982,7 @@
           }
         },
         {
-          "id": "dd902187-4e6a-49ad-99c3-f868ea153a2a",
+          "id": "65b590ef-70d6-442a-89a0-7314dd3c1793",
           "name": "Delete all SKU specifications",
           "request": {
             "name": "Delete all SKU specifications",
@@ -13044,7 +13044,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0ebc5dac-e919-4199-9495-dcbc48b7986b",
+              "id": "dccd9a28-4994-496e-80ad-842600087af4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13103,7 +13103,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8d5b2a35-515b-4eb1-a3d3-616bb2dca9ee",
+                "id": "dea3b5b4-0081-4487-b8f1-323777c2a1cb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13116,7 +13116,7 @@
           }
         },
         {
-          "id": "b8513319-86fa-4865-abc1-9131442d14c9",
+          "id": "ee90741c-880f-4ca3-9a66-1af8235142c0",
           "name": "Delete SKU specification",
           "request": {
             "name": "Delete SKU specification",
@@ -13189,7 +13189,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d4cba6df-822d-4b94-8548-463532af71b1",
+              "id": "54e1722a-c6c4-4f95-a46a-ff1b4458faf2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13249,7 +13249,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "06c99c88-ea17-4e24-8c2a-4cd6ec7548ef",
+                "id": "5541d69b-e017-41a5-9011-d5c84b095d5d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13262,7 +13262,7 @@
           }
         },
         {
-          "id": "c492e9f6-2d54-4326-a235-91a2a61c3049",
+          "id": "7ae479cc-c59e-4b24-b9ad-b21c8f910b4e",
           "name": "Associate SKU specification using specification name and group name",
           "request": {
             "name": "Associate SKU specification using specification name and group name",
@@ -13341,7 +13341,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e4592d80-50c8-4fa0-af58-5fe7adf1f602",
+              "id": "31e38d40-5eed-4293-a325-618c5c45cba3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13423,7 +13423,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2b5a9736-b421-4351-bc3c-254e4afbd9c4",
+                "id": "ba581e53-656a-4ee5-a6aa-5a5fdf75a7a9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13442,7 +13442,7 @@
       "event": []
     },
     {
-      "id": "c4239818-cfec-48bf-920c-e0729a80d754",
+      "id": "72dafbf2-fcf1-415f-9d17-50c845bb012b",
       "name": "SKU attachment",
       "description": {
         "content": "",
@@ -13450,7 +13450,7 @@
       },
       "item": [
         {
-          "id": "52ea5cc6-66be-4225-8294-79f8c2adfed8",
+          "id": "3c90df5d-f889-45e1-8d14-ae512f95d6b1",
           "name": "Associate SKU attachment",
           "request": {
             "name": "Associate SKU attachment",
@@ -13516,7 +13516,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a08a6771-bfee-48dc-930d-237036db8658",
+              "id": "4f8a2302-7fee-436d-abbb-cad00bba54bc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13596,7 +13596,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "aba18ac5-a7fc-408e-9d92-15f2aacaa86a",
+                "id": "57527395-f477-4aae-afe3-bcbd1a667fe5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skuattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13612,7 +13612,7 @@
           }
         },
         {
-          "id": "255e78bc-4c1f-40aa-b8d6-991d075d1307",
+          "id": "2fa8d29c-57c6-4f20-b5a2-b81ec73c398b",
           "name": "Dissociate attachments and SKUs",
           "request": {
             "name": "Dissociate attachments and SKUs",
@@ -13680,7 +13680,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6935a690-7b06-41a1-a64e-fd7a57826d46",
+              "id": "81fc5558-4f78-4ab7-bfc1-c992b5505f1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13756,7 +13756,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7c5b5c0c-9337-4d23-aa08-d71e5b69a345",
+                "id": "5cce6b73-2f19-4f6c-a100-d52422f1586c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuattachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -13769,7 +13769,7 @@
           }
         },
         {
-          "id": "aff866f6-823f-4c45-ba84-b0f6bc4b9ac8",
+          "id": "eff33135-1ee4-432f-9f8b-b02c0ebf9676",
           "name": "Get SKU attachments by SKU ID",
           "request": {
             "name": "Get SKU attachments by SKU ID",
@@ -13835,7 +13835,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "16eed353-2edd-4095-9a8a-3a82e4249205",
+              "id": "a18b0439-6dee-4d37-8cef-aa36383eaec7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -13904,7 +13904,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8b196c84-a99f-4377-9668-aecda79c3410",
+                "id": "5cfb18e9-e1f8-4dca-9ffc-178c22b941b5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attachment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -13920,7 +13920,7 @@
           }
         },
         {
-          "id": "d64217c3-aab1-4de5-b79f-611b60376201",
+          "id": "43d07a9a-40e9-4dd4-a8af-023896c307c0",
           "name": "Delete SKU attachment by attachment association ID",
           "request": {
             "name": "Delete SKU attachment by attachment association ID",
@@ -13981,7 +13981,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "69c86f16-7ba4-4ff9-8eba-9ad5ba52db84",
+              "id": "8d5f2aa1-24ab-4744-807c-f908f8f1c183",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14039,7 +14039,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4bbe441d-47c3-4409-87ec-70d7d1175c66",
+                "id": "3693a8d3-44bf-49dd-b099-f31a68aa0ceb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skuattachment/:skuAttachmentAssociationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -14052,7 +14052,7 @@
           }
         },
         {
-          "id": "3f440ee5-fd15-4a71-90b2-f0bd6a57dcd2",
+          "id": "2bc4de71-82f7-4029-bc57-784ee9b5855a",
           "name": "Associate attachments to an SKU",
           "request": {
             "name": "Associate attachments to an SKU",
@@ -14115,7 +14115,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5cf91839-da5e-4477-af66-7eaac1778f32",
+              "id": "9a200010-2191-4fc8-9b91-07fa1e5a4cdc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14186,7 +14186,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "42405045-fc44-4710-9537-35e7c8335a9d",
+                "id": "ce9bbb72-dea4-4237-ba5c-91a55efb9174",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/sku/associateattachments - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -14202,7 +14202,7 @@
       "event": []
     },
     {
-      "id": "31ceb65d-33ba-4049-9d92-6a3b8a304f81",
+      "id": "924f2a93-9e3a-4964-b945-71177cd93c26",
       "name": "SKU complement",
       "description": {
         "content": "",
@@ -14210,7 +14210,7 @@
       },
       "item": [
         {
-          "id": "133ff2ed-76d8-4df4-9914-8e998bf11c84",
+          "id": "5937f83d-318e-492f-a92c-6a513d9583ac",
           "name": "Get SKU complement by SKU ID",
           "request": {
             "name": "Get SKU complement by SKU ID",
@@ -14276,7 +14276,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "38b2f675-2a53-4762-924c-8663dc00b2c6",
+              "id": "44dd91cb-8356-44a8-98df-5cbae5818a1c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14345,7 +14345,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b6481cca-52f3-48db-8ce5-967dce014441",
+                "id": "934ac958-a530-47b1-93f4-700a7ec19313",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/complement - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14361,7 +14361,7 @@
           }
         },
         {
-          "id": "184df095-d8fc-4d8a-9dff-33875cea9f64",
+          "id": "eb9bddf8-e90d-4742-8b68-a3ffc5a64083",
           "name": "Get SKU complements by complement type ID",
           "request": {
             "name": "Get SKU complements by complement type ID",
@@ -14438,7 +14438,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "673a3b85-fd0a-416e-a070-23d8e28990e2",
+              "id": "549da15e-23ae-47cc-920b-99d0b056466c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14508,7 +14508,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "02739d47-036e-4273-80f6-d2c775fb810c",
+                "id": "91e232d1-c881-4891-a632-70853020e07b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/complement/:complementTypeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14524,7 +14524,7 @@
           }
         },
         {
-          "id": "672a4483-d7d7-4f48-b872-7765ab250ace",
+          "id": "232bb594-0403-4701-b9de-5e2aabaca751",
           "name": "Get SKU complements by type",
           "request": {
             "name": "Get SKU complements by type",
@@ -14601,7 +14601,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d27a6023-5f7d-4a3c-95a2-d8708a73f127",
+              "id": "8cd48bb3-e6a8-4fd2-9e78-d08db1643354",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14671,7 +14671,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e85d45f4-91ce-4eb3-982b-308369527dd7",
+                "id": "291592c5-5808-4ffa-9cbe-f02c403092d8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/complements/:parentSkuId/:type - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14687,7 +14687,7 @@
           }
         },
         {
-          "id": "beb7acc3-25dd-410f-a7ee-39db3be653af",
+          "id": "9f87a2cd-6878-4a61-be54-7d6e01ea0c37",
           "name": "Create SKU complement",
           "request": {
             "name": "Create SKU complement",
@@ -14753,7 +14753,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d114ce25-fc02-49c4-9636-bacd4b29ec80",
+              "id": "a1e40576-d023-48f9-b517-2c2773cea4a1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14833,7 +14833,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8430ab6c-142e-43fc-b54f-ce7ad71ba842",
+                "id": "1c2a297e-dcb9-417c-ad62-75f60c02d434",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/skucomplement - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14849,7 +14849,7 @@
           }
         },
         {
-          "id": "1df75690-486e-4798-8f98-76818c323053",
+          "id": "61492bdc-ecd0-4c7a-97f0-7266e9d551dd",
           "name": "Get SKU complement by SKU complement ID",
           "request": {
             "name": "Get SKU complement by SKU complement ID",
@@ -14914,7 +14914,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c562adaa-a875-4e96-83fd-fca930cb4925",
+              "id": "3a9c76ab-d57d-4af9-a818-623bbac6ebf9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -14982,7 +14982,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "faadbf36-eb59-4d0e-8e50-13bb2d2831b7",
+                "id": "bd782e4d-b71b-428d-bb1c-14ca3092a115",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skucomplement/:skuComplementId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -14998,7 +14998,7 @@
           }
         },
         {
-          "id": "587f611a-481f-4018-8f8b-e93c73687956",
+          "id": "537d5003-5872-4214-aa75-6ff82c153521",
           "name": "Delete SKU complement by SKU complement ID",
           "request": {
             "name": "Delete SKU complement by SKU complement ID",
@@ -15059,7 +15059,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5ceb3725-5299-4567-868b-c9c60d014b40",
+              "id": "59c161b0-eecf-46ee-ae06-c8fe8d5817d7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15117,7 +15117,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ac10930d-997c-4edb-9fad-24376a3e7760",
+                "id": "8261b3e2-2e3c-4074-ae41-e6915dbcbb38",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/skucomplement/:skuComplementId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15133,7 +15133,7 @@
       "event": []
     },
     {
-      "id": "01bcb641-48e6-40f0-b72b-a4da072c6f02",
+      "id": "d9263f74-634b-4f55-aeef-01f81b7a51e2",
       "name": "Non-structured specification",
       "description": {
         "content": "",
@@ -15141,7 +15141,7 @@
       },
       "item": [
         {
-          "id": "3bfef8b2-71f0-4985-923e-50882957ef0c",
+          "id": "1f9144f4-20da-4372-9eba-ad1cf2c18430",
           "name": "Get non-structured specification by ID",
           "request": {
             "name": "Get non-structured specification by ID",
@@ -15207,7 +15207,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "23611d80-db71-4fac-aa84-24a72f4b5bc9",
+              "id": "f485d53f-e601-4625-af87-93256a47a886",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15276,7 +15276,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ac8fb034-040d-4b48-9029-7454599dd489",
+                "id": "418d953e-987e-44f1-a425-08d65521883e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/nonstructured/:Id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15292,7 +15292,7 @@
           }
         },
         {
-          "id": "6fcc4128-8bf5-4825-8b95-eb235ecf913d",
+          "id": "cb9c0dc4-d19f-4b4c-a789-c6c08bdaf5a7",
           "name": "Delete non-structured specification",
           "request": {
             "name": "Delete non-structured specification",
@@ -15354,7 +15354,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2171af2e-c0a1-43bb-b8f7-5cf911c4cdab",
+              "id": "20580757-d23e-40f6-ba3b-215970392356",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15413,7 +15413,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dd2c4c69-0fdd-400c-80c9-e4fe4229bffc",
+                "id": "34fa88fe-fc8b-4be7-8c88-0f76fe0c58d2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/specification/nonstructured/:Id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15426,7 +15426,7 @@
           }
         },
         {
-          "id": "3240953d-cb5b-4e7b-8685-269c1dfb8a51",
+          "id": "50fee0b7-ca6a-4d67-b626-c5aab1d8c50b",
           "name": "Get non-structured specification by SKU ID",
           "request": {
             "name": "Get non-structured specification by SKU ID",
@@ -15490,7 +15490,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8f96b16b-1195-40c8-8ceb-0f952bc39351",
+              "id": "86b22302-e323-4431-bbc0-014c4c76df35",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15568,7 +15568,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f0fd04ca-de3f-4837-96aa-b0e1d359efe4",
+                "id": "f323281a-63f8-4ece-818a-76079e6ef53f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/nonstructured - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15584,7 +15584,7 @@
           }
         },
         {
-          "id": "c3351f11-da26-4fc2-a357-678d381be445",
+          "id": "8e2ec1a7-11bd-4959-a627-05cbd3937851",
           "name": "Delete non-structured specification by SKU ID",
           "request": {
             "name": "Delete non-structured specification by SKU ID",
@@ -15644,7 +15644,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c2e6ced9-d4fc-43b1-b319-dc513ce89ed4",
+              "id": "de16c066-c2eb-42b6-a343-747e92bd2a9b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15712,7 +15712,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8657962f-a0ee-471e-ba4b-fd27123f8c77",
+                "id": "6b60f3ff-4516-4150-8a96-e70b39ef353f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/specification/nonstructured - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -15728,7 +15728,7 @@
       "event": []
     },
     {
-      "id": "53bb7a11-3953-47ef-92f8-4748bd680562",
+      "id": "93dd2973-82d8-41ae-aa83-28a9bd2190f5",
       "name": "Specification field",
       "description": {
         "content": "",
@@ -15736,7 +15736,7 @@
       },
       "item": [
         {
-          "id": "704d9482-7984-4fd8-9357-be3f7c92f323",
+          "id": "4d2541b9-3854-479c-8e5e-85c3af8c9599",
           "name": "Get specification field",
           "request": {
             "name": "Get specification field",
@@ -15802,7 +15802,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4d945817-dcc9-4605-ae90-3eaa397402ef",
+              "id": "085e220e-4a94-4759-8864-54c5b36ac877",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -15871,7 +15871,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d441f3ff-a30b-4379-8a0f-6cd4c1ecb07c",
+                "id": "af9c821a-3daf-4607-b9e9-d7ac754b88aa",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/fieldGet/:fieldId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -15887,7 +15887,7 @@
           }
         },
         {
-          "id": "bbb4d9bb-0194-49f5-96d9-cc93b1b6c358",
+          "id": "4008127f-f833-4972-a74a-bf043d9cb514",
           "name": "Create specification field",
           "request": {
             "name": "Create specification field",
@@ -15954,7 +15954,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c7ab2339-f400-4f57-9ed3-73258967b13b",
+              "id": "232b099c-73cb-456c-872d-8faaffb33cb4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16035,7 +16035,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c74074ba-10a2-476a-968a-7453e824c9ff",
+                "id": "3209f694-a782-4f29-9c29-ecf2643a71a2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/specification/field - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16051,7 +16051,7 @@
           }
         },
         {
-          "id": "34ce23f2-8958-4e1f-b221-ab35e0978756",
+          "id": "7e875683-d858-4397-95ea-87feac079269",
           "name": "Update specification field",
           "request": {
             "name": "Update specification field",
@@ -16118,7 +16118,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1ff0af52-5a63-4656-8222-5957af57029a",
+              "id": "c0061195-9066-464f-9534-9793d6fe9c6c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16199,7 +16199,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4d918de6-9f93-4ff7-bb95-7d3be0e31942",
+                "id": "30733728-2a63-4997-8138-aedad956af76",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/specification/field - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16218,7 +16218,7 @@
       "event": []
     },
     {
-      "id": "5946e1ba-2a17-41b9-8f30-04c1dac0f57a",
+      "id": "515566a3-0c8d-40c3-bc3a-9a3507e6b795",
       "name": "Specification group",
       "description": {
         "content": "",
@@ -16226,7 +16226,7 @@
       },
       "item": [
         {
-          "id": "3d0c625f-2945-48a1-a854-5de0e7b5c97b",
+          "id": "a641e033-69eb-4a45-a586-c9a7b2578937",
           "name": "List specification group by category",
           "request": {
             "name": "List specification group by category",
@@ -16292,7 +16292,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "65b704dc-6add-444b-a6b3-8fd51ac9752d",
+              "id": "cf526399-f39c-44d4-b14a-b51893cdc075",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16361,7 +16361,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "81e0eb71-a90c-4f04-b9d8-6c93235933e4",
+                "id": "0694e17e-1d22-41ad-bf97-5832c3ef9ad3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/specification/groupbycategory/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16377,7 +16377,7 @@
           }
         },
         {
-          "id": "7a6ee109-636c-4eb0-96b7-ee9a59ba92da",
+          "id": "5f8165a4-453a-4e90-a4db-f85cbdb11655",
           "name": "Get specification group",
           "request": {
             "name": "Get specification group",
@@ -16443,7 +16443,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4e478884-7384-47d0-bfcd-f50d3539c337",
+              "id": "6be50c7d-9a7b-47f4-affd-1ace4ee73a5d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16512,7 +16512,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c93b3db2-8fc1-4964-8a27-f1e1693d09c2",
+                "id": "58ab0c21-371c-4213-9988-72998f3a58a1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/groupGet/:groupId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16528,7 +16528,7 @@
           }
         },
         {
-          "id": "aaaf777d-f582-46f9-b6bc-9d16354665e3",
+          "id": "5be2dcda-8c23-4790-9691-9696d2b80b28",
           "name": "Create specification group",
           "request": {
             "name": "Create specification group",
@@ -16594,7 +16594,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1d47367e-e20d-486f-a4a6-69f6624158de",
+              "id": "dcf9dbf0-4675-448e-a2d2-586de3876c4d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16674,7 +16674,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3e706043-ed3a-4592-b764-c01e1e814002",
+                "id": "a2d881a0-9de3-41a3-8583-43b20d33b129",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specificationgroup - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16690,7 +16690,7 @@
           }
         },
         {
-          "id": "d264ed1f-ed5e-4f70-b389-669c6362af4e",
+          "id": "c85b088b-c492-44bb-964f-f30f5493671e",
           "name": "Update specification group",
           "request": {
             "name": "Update specification group",
@@ -16768,7 +16768,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dab1ae41-2fd2-42bf-8022-fdff022c777f",
+              "id": "0b80e020-02f0-4b88-9443-0c12aa2cdef0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -16849,7 +16849,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f45b54be-b014-4fb2-8ece-02cebef42157",
+                "id": "1fe50780-9cc5-404c-b67a-b99cacba9a46",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationgroup/:groupId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -16868,7 +16868,7 @@
       "event": []
     },
     {
-      "id": "7d332f1e-ed85-4149-a745-f0ae57e9a8df",
+      "id": "34d04d8c-c1d8-44fc-b749-cdd311025b23",
       "name": "Specification value",
       "description": {
         "content": "",
@@ -16876,7 +16876,7 @@
       },
       "item": [
         {
-          "id": "4d9b0a27-6e8f-416b-b6b6-ef8900f3c2f7",
+          "id": "505b596d-0bac-492b-b91c-e26a39212b2b",
           "name": "Get specification value",
           "request": {
             "name": "Get specification value",
@@ -16941,7 +16941,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "efc383c1-f15a-4729-86aa-3c20c6a775e5",
+              "id": "1fb98902-cd98-42b8-aa6a-78f861c08100",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17009,7 +17009,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5c27bf2b-d5a6-439e-8961-7d60e8546b2f",
+                "id": "0a676311-2bdf-4924-8c83-14954a8932ad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationvalue/:specificationValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17025,7 +17025,7 @@
           }
         },
         {
-          "id": "c0c0538d-716c-4a2a-994c-0041382ac5c5",
+          "id": "206de1c8-8e91-442b-85dc-88a1dfb7fda0",
           "name": "Update specification value",
           "request": {
             "name": "Update specification value",
@@ -17103,7 +17103,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6e72852a-896c-449f-81e2-28fb8ab72757",
+              "id": "1262fc1a-3a92-4348-9f46-f9ff278bc834",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17184,7 +17184,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "07f1da00-e9ce-4403-a290-08cb353e6f88",
+                "id": "e1527db9-1458-47f3-8ec3-f1258708a017",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationvalue/:specificationValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17200,7 +17200,7 @@
           }
         },
         {
-          "id": "da566a07-c077-4c4c-960c-1c4cf29e0174",
+          "id": "56a48217-0218-42cf-b245-b95951d49ff7",
           "name": "Create specification value",
           "request": {
             "name": "Create specification value",
@@ -17266,7 +17266,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "15ca1313-ff37-4ced-aa2b-6ed766f3772b",
+              "id": "c43d84f8-53fa-4ceb-87e4-93d84083bf04",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17346,7 +17346,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "89125d07-9922-4d31-9ff8-6fecb9ee4cd5",
+                "id": "f92d86d2-2184-4ce1-8102-cef015fdc897",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17365,7 +17365,7 @@
       "event": []
     },
     {
-      "id": "f8a75440-52c8-4c8b-a46f-2337e5114b7b",
+      "id": "1ebb5239-28d4-461b-b851-3928efc73291",
       "name": "Specification field value",
       "description": {
         "content": "",
@@ -17373,7 +17373,7 @@
       },
       "item": [
         {
-          "id": "30b0226a-eae4-40e9-97f0-22cb258f8c9a",
+          "id": "b791b98e-5c6a-4f4f-a591-b118aa1617b2",
           "name": "Get specification field value",
           "request": {
             "name": "Get specification field value",
@@ -17439,7 +17439,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6452de84-d7d9-44da-bc04-28295c6bbe74",
+              "id": "3ca418a4-730c-4210-89c6-17e7883d76af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17508,7 +17508,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a3568527-f4e0-4c77-8f8f-edfa308559f7",
+                "id": "c5a37d0a-5921-4c6f-a9e6-38fea5bd7ce4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/specification/fieldValue/:fieldValueId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17524,7 +17524,7 @@
           }
         },
         {
-          "id": "39be46d2-35a1-4a6d-9fd6-454804033fe9",
+          "id": "61763ecc-813f-416d-b627-8f9ade669bfe",
           "name": "Get specification values by specification field ID",
           "request": {
             "name": "Get specification values by specification field ID",
@@ -17590,7 +17590,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "09ee0389-855f-4f73-a47b-12b9af404095",
+              "id": "5a25b596-85d5-45bf-a74f-fb7ad53c234a",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17659,7 +17659,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e1b48dd6-1f52-48a7-94f2-e07525f91955",
+                "id": "31de4b07-9925-40ce-a867-e1e7f4648cbe",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/fieldvalue/:fieldId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17675,7 +17675,7 @@
           }
         },
         {
-          "id": "2065aee0-98f6-4bcf-97ed-dae807ea72d6",
+          "id": "d12f7c09-b749-415a-8eff-ba08f28521d5",
           "name": "Create specification field value",
           "request": {
             "name": "Create specification field value",
@@ -17742,7 +17742,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6f00ae8d-7552-4b96-845e-f77d95521a4d",
+              "id": "4d1ed4b3-5dd6-40f7-b5cd-4c7d5c1f81d1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17823,7 +17823,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "74b2c372-759a-4223-855b-5cea7143d75a",
+                "id": "f2407139-b662-48cb-ae30-c17a40fce346",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/specification/fieldValue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -17839,7 +17839,7 @@
           }
         },
         {
-          "id": "1740871a-1e8a-4e7a-b0c6-0c768059719e",
+          "id": "dc93d0fe-4ccd-4d6e-bd2d-582cab78ebbd",
           "name": "Update specification field value",
           "request": {
             "name": "Update specification field value",
@@ -17906,7 +17906,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "90d91093-7c48-4dfe-9f6c-22d19c38dced",
+              "id": "45ecd768-37c2-4f49-a248-b62aab859d8d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -17987,7 +17987,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "dfb6fa67-7a44-4cdc-ab3a-aff72c337123",
+                "id": "4ebd0131-bcb9-4512-9608-c9a60fbf3a1e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/specification/fieldValue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18006,7 +18006,7 @@
       "event": []
     },
     {
-      "id": "9235fd35-e789-4079-9172-bbda70273307",
+      "id": "3b3b9a2c-730f-4777-9804-bc508cc276cb",
       "name": "Category specification",
       "description": {
         "content": "",
@@ -18014,7 +18014,7 @@
       },
       "item": [
         {
-          "id": "d3e9bec2-b485-41e9-a761-d4b3ebb5cc51",
+          "id": "1b3b710b-4a36-42ee-838f-31a5d3e69723",
           "name": "Get specifications by category ID",
           "request": {
             "name": "Get specifications by category ID",
@@ -18081,7 +18081,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b8724a88-08fe-4b82-a9d5-797243161172",
+              "id": "3b388074-0e52-4e2b-a5c4-ef33437d7e4c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18151,7 +18151,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f7206f51-346f-45bd-9bc2-580ec38b65e8",
+                "id": "e20b6fe6-b77a-4941-a39f-b002574c8339",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/field/listByCategoryId/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18167,7 +18167,7 @@
           }
         },
         {
-          "id": "664958ae-e613-4a23-b6d2-b167b61306d8",
+          "id": "a69d59cc-e19b-4119-b3e7-7f32a20958cf",
           "name": "Get specifications tree by category ID",
           "request": {
             "name": "Get specifications tree by category ID",
@@ -18234,7 +18234,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c6bdbe0d-8a47-45c3-bc8d-fe00a2319043",
+              "id": "7d02e71c-7503-44fd-84a4-64d28a81fa74",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18304,7 +18304,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "12def0b4-62df-41fe-be2b-b966433c51ba",
+                "id": "b578cf28-6871-4f06-a4ac-3b092328adaf",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/specification/field/listTreeByCategoryId/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18323,7 +18323,7 @@
       "event": []
     },
     {
-      "id": "a03839ed-228e-4cf7-970c-282d978c7422",
+      "id": "0594252b-2bfd-487f-9983-639164967fbb",
       "name": "Specification",
       "description": {
         "content": "",
@@ -18331,7 +18331,7 @@
       },
       "item": [
         {
-          "id": "368fb5f1-68b5-4a57-8f57-2f3a4acf6e12",
+          "id": "4b08f73f-decf-4782-9e32-fa4945499229",
           "name": "Get specification by specification ID",
           "request": {
             "name": "Get specification by specification ID",
@@ -18396,7 +18396,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7632fb4e-b833-41db-841b-a9249849df42",
+              "id": "9664ae58-71e4-4857-b32b-83e2365d6941",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18464,7 +18464,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3fe164d4-fc8a-4f69-990d-2f11111c7fba",
+                "id": "5eeef717-e5bf-459d-af4f-0db96810c4bd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18480,7 +18480,7 @@
           }
         },
         {
-          "id": "84d8c457-ae56-427c-ad58-2d1e1e490235",
+          "id": "e521cdf7-42a4-4382-b05d-f2a5b58249d6",
           "name": "Update specification",
           "request": {
             "name": "Update specification",
@@ -18558,7 +18558,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "aee84202-bcbe-4429-8ca8-2497a42783c2",
+              "id": "ce255043-4d98-485e-9ec1-cce5a40e06e7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18639,7 +18639,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3c5bec26-2974-4bf7-a10b-938ebbdba622",
+                "id": "a335acb2-3297-4332-bf4c-21e9f6939272",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specification/:specificationId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18655,7 +18655,7 @@
           }
         },
         {
-          "id": "3a992182-11ec-4706-9724-6a7cb11e6151",
+          "id": "d2226a38-b506-42f2-a030-368643402970",
           "name": "Create specification",
           "request": {
             "name": "Create specification",
@@ -18721,7 +18721,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "911cf8f8-6c4c-40d9-93f7-f7f9f5e8da0b",
+              "id": "7a762662-d3fe-477f-986c-6a011d9c25ca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18801,7 +18801,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e8c70f97-10c6-4691-9c63-ff2d658654e2",
+                "id": "38119a52-2b9b-44e3-9b0e-2c113e508035",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/specification - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -18820,7 +18820,7 @@
       "event": []
     },
     {
-      "id": "0cc76301-fbe8-4217-bc13-b09921971fd8",
+      "id": "ba7f1fd4-e003-4c5f-a95d-f43bf1347417",
       "name": "Subcollection",
       "description": {
         "content": "",
@@ -18828,7 +18828,7 @@
       },
       "item": [
         {
-          "id": "386e3eb9-1091-40b2-a637-8a82eb60b46c",
+          "id": "5b620634-85f4-4e1f-bea5-c55e1d795746",
           "name": "Add SKU to subcollection",
           "request": {
             "name": "Add SKU to subcollection",
@@ -18907,7 +18907,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6a2ec963-2d5b-46f9-b434-da5e367d8993",
+              "id": "f32ed562-783a-4c99-8ce2-1ee27e8a9442",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -18989,7 +18989,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "20cd1d9e-6544-478d-8303-3c66ca9914ac",
+                "id": "e2bd80e8-d3a0-46de-88aa-b71dda6160c4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/stockkeepingunit - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19005,7 +19005,7 @@
           }
         },
         {
-          "id": "757f8589-7c27-482e-955a-56daac2dd221",
+          "id": "76cae780-a9ab-45bc-81c7-a3e91a80defe",
           "name": "Delete SKU from subcollection",
           "request": {
             "name": "Delete SKU from subcollection",
@@ -19078,7 +19078,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "98268bfd-61ad-49c2-bbe8-f26fab3fc33d",
+              "id": "0b00a770-fb5a-402c-9128-1dc2c8f61236",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19138,7 +19138,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "035fbd71-8b39-49b7-b688-4a4558f786c8",
+                "id": "f9bcbaea-0b4d-4009-8340-9182c3c5f9e1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/stockkeepingunit/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19151,7 +19151,7 @@
           }
         },
         {
-          "id": "a39e6178-1564-4b37-a634-5b46a2c949a0",
+          "id": "8c89f77f-0acf-47fa-9948-07bf22d3a7b9",
           "name": "Associate category to subcollection",
           "request": {
             "name": "Associate category to subcollection",
@@ -19230,7 +19230,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "39d96a1c-91ff-4163-b902-df08831ef864",
+              "id": "0fc9bd5f-54a1-4984-87de-c75a4be9bdf7",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19312,7 +19312,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "be67442f-e91c-48ac-b792-d2416f514e22",
+                "id": "684f1588-425a-4a4a-84f7-b8acd0e84ecd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/category - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19328,7 +19328,7 @@
           }
         },
         {
-          "id": "2c34aeda-2ed0-4f02-ad2d-5f9b45eb30aa",
+          "id": "3bc6a949-3ee3-4bf7-b317-d5c24440987b",
           "name": "Delete category from subcollection",
           "request": {
             "name": "Delete category from subcollection",
@@ -19401,7 +19401,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "02c80864-38c7-4b8f-a89b-276e8ad28da3",
+              "id": "996f9a9a-5629-442b-bbdb-b2efd9fe3e47",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19461,7 +19461,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "19cca660-77e8-4188-8dfb-6a07e9718e07",
+                "id": "af693d1e-4b96-4b62-9556-b85a6fb04f99",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/category/:categoryId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19474,7 +19474,7 @@
           }
         },
         {
-          "id": "ecbcfc7e-db6a-4ab4-9e67-04ba88439de6",
+          "id": "a9274a64-a6f2-469c-98cc-b5279b0ee111",
           "name": "Associate brand to subcollection",
           "request": {
             "name": "Associate brand to subcollection",
@@ -19553,7 +19553,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "667374c9-bc27-4322-be10-39ac28edc55a",
+              "id": "a3027620-1d60-4f1f-a392-39ea651d00d9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19635,7 +19635,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4392d32f-43b9-4360-b7a3-c0f4b1f4b97b",
+                "id": "c14e331e-af69-4499-bd7b-b5f3b2eef74d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/brand - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19651,7 +19651,7 @@
           }
         },
         {
-          "id": "9a1d2754-ce97-4c0e-95f1-9a048b59b30a",
+          "id": "62e774b2-7a0c-4773-becd-a6b5a9be23a5",
           "name": "Delete brand from subcollection",
           "request": {
             "name": "Delete brand from subcollection",
@@ -19724,7 +19724,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "53b9c848-03d8-4a18-a221-a970c8bb8fd4",
+              "id": "767afb89-4bc4-4867-9f46-fbfed49b4694",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19784,7 +19784,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a315044e-1fbc-4dd5-bde7-0dbcd3da14cf",
+                "id": "8c8d04c9-edc7-4699-8041-e3277f8bed34",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/brand/:brandId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -19797,7 +19797,7 @@
           }
         },
         {
-          "id": "883d29fa-6997-407e-9a59-3e3866f2bf00",
+          "id": "3fc8b46c-ce87-4d59-a0e6-96df5964e471",
           "name": "Get subcollection by collection ID",
           "request": {
             "name": "Get subcollection by collection ID",
@@ -19863,7 +19863,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a8fbd7ea-b3ba-48f7-872b-721bc5db4edf",
+              "id": "6f4e0dec-9024-4e95-a15c-d4247dbf4212",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -19932,7 +19932,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "926233ad-d965-4e0d-91ad-91031698787a",
+                "id": "b0dc71ce-096f-459f-a43e-5e9a811508d3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/subcollection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -19948,7 +19948,7 @@
           }
         },
         {
-          "id": "35c0567b-3154-4861-8b1c-822dcc493401",
+          "id": "c3b9bf7e-3b79-4743-9631-09a0db84a152",
           "name": "Get subcollection by subcollection ID",
           "request": {
             "name": "Get subcollection by subcollection ID",
@@ -20013,7 +20013,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bf3d4a9b-85ed-4324-b74c-a3dc0a241642",
+              "id": "cbfef596-f73b-4326-8cf7-5575c3b19fa2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20081,7 +20081,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9ae932ad-0eda-4063-ad1d-5d5da1fdb19d",
+                "id": "6b0d39d2-0f32-481f-877f-127b0a6f84de",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20097,7 +20097,7 @@
           }
         },
         {
-          "id": "c2717607-8dc1-4e81-8cd0-0c7e0ebbe876",
+          "id": "f6aa826a-bf45-4bdf-9b2e-47bef64fbf4a",
           "name": "Update subcollection",
           "request": {
             "name": "Update subcollection",
@@ -20175,7 +20175,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1dd9faf4-5999-4714-a164-4d85eec8087c",
+              "id": "810d8c6f-67e1-4845-9ccd-599e31150c90",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20256,7 +20256,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "03338557-c910-461b-aa1d-464476ba8fef",
+                "id": "839b5a4d-20e0-4c14-80bd-e531ff553841",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20272,7 +20272,7 @@
           }
         },
         {
-          "id": "b6408cf9-cf6e-4f07-8a39-6838cc896ccd",
+          "id": "c1911ccf-f500-4f5c-b2a8-0794a788caa6",
           "name": "Delete subcollection",
           "request": {
             "name": "Delete subcollection",
@@ -20333,7 +20333,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c246137d-91e2-4d6c-ae0b-4149b617ed3e",
+              "id": "994d9cf8-9a47-4754-bf85-6b6b3c782511",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20391,7 +20391,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b4643e89-e383-49a7-9602-b5269cf6659b",
+                "id": "d25a7cde-dee4-48a6-98da-b3a2fb29d962",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -20404,7 +20404,7 @@
           }
         },
         {
-          "id": "c8bb8a5c-47f5-47a1-b4b5-eb3e779b802c",
+          "id": "cd42345c-b30b-46b8-8c0b-8e338c6b952b",
           "name": "Create subcollection",
           "request": {
             "name": "Create subcollection",
@@ -20470,7 +20470,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3cc123ab-85f7-434f-8825-e857c3d0315f",
+              "id": "04654609-1bca-4b03-b70f-98e3f0eba776",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20550,7 +20550,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bd189a3d-36c2-44c3-b942-e1966cc5a33d",
+                "id": "64494465-e393-4ffc-bd8a-3e2793690703",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20566,7 +20566,7 @@
           }
         },
         {
-          "id": "66587c06-66de-456e-a252-d1836abc7361",
+          "id": "cea32ec2-4a67-42d0-a45d-4be06cce0ed0",
           "name": "Reposition SKU on the subcollection",
           "request": {
             "name": "Reposition SKU on the subcollection",
@@ -20641,7 +20641,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2c2d274f-5e48-4a53-9ceb-7978bd58ef52",
+              "id": "07772487-8ae5-4fd6-aa3c-f9c22f1680bd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20713,7 +20713,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "214fac39-c06c-4e09-b31d-2995da842271",
+                "id": "a4e14c09-a484-4863-984d-6a32c7042598",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/position - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -20726,7 +20726,7 @@
           }
         },
         {
-          "id": "10842a33-d604-4d37-afcb-19e36507bada",
+          "id": "bc380a3d-8b3c-465c-a66c-79c3819522e3",
           "name": "Get specification values by subcollection ID",
           "request": {
             "name": "Get specification values by subcollection ID",
@@ -20792,7 +20792,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a156f87c-41d1-4048-910f-349fe3a8b9d3",
+              "id": "6f7cb503-986b-4f39-b1ed-56d8184481a0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -20861,7 +20861,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "57c59ca6-6020-4f14-8c5d-232fdf0f72b3",
+                "id": "c01f3e9d-391c-448f-9760-77824094fb19",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -20877,7 +20877,7 @@
           }
         },
         {
-          "id": "33e02333-b454-4646-8eb8-5a8ab20a9413",
+          "id": "cfcbcbd3-d0d4-4c4f-93f8-00da4f54db9a",
           "name": "Use specification value in subcollection by ID",
           "request": {
             "name": "Use specification value in subcollection by ID",
@@ -20956,7 +20956,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "cd57738c-8673-4bf8-943b-daa62f61874a",
+              "id": "871bf758-4940-438d-b3e9-e25ef16108ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21038,7 +21038,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "cf6ca99e-f55f-451d-8313-01f4498640b5",
+                "id": "c7c105e2-81b7-4572-a1e0-ffed7037f734",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21054,7 +21054,7 @@
           }
         },
         {
-          "id": "43d551d8-eb7f-4aa9-bf2c-9410290bbca5",
+          "id": "a933a4c8-c843-4e14-9485-ecbd5339c769",
           "name": "Delete specification value from subcollection by ID",
           "request": {
             "name": "Delete specification value from subcollection by ID",
@@ -21116,7 +21116,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "01a4744c-e093-4208-9bec-5c14b59b95a8",
+              "id": "c34bccc0-be00-478a-930a-9f1982066b16",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21175,7 +21175,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e5893ecc-f152-42cd-b7ee-ed56c67d8eae",
+                "id": "c05f9679-d4da-4767-81b2-de0de2cc21f8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/subcollection/:subCollectionId/specificationvalue - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -21191,7 +21191,7 @@
       "event": []
     },
     {
-      "id": "c7b14cce-06c5-4636-b455-c4ba51244401",
+      "id": "cbd77fa0-d2e2-4545-90a5-ed5b678a2991",
       "name": "Assortment",
       "description": {
         "content": "",
@@ -21199,7 +21199,7 @@
       },
       "item": [
         {
-          "id": "b3398221-c8a8-4e9b-87ff-c5a67dcb1231",
+          "id": "9dbd8d21-6474-42d9-8fca-95e63c260692",
           "name": "Create product assortment",
           "request": {
             "name": "Create product assortment",
@@ -21265,7 +21265,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6d6d972c-11e4-4022-b937-2abac4992360",
+              "id": "93b3e80f-0605-44af-8ba6-7cb73635cc75",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -21344,7 +21344,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5eec0ed3-abc5-4a6e-af5e-7ed7b4e6697c",
+              "id": "41d3e33b-2eec-4ad9-86f0-b8eab48e648a",
               "name": "Unprocessable Entity",
               "originalRequest": {
                 "url": {
@@ -21424,7 +21424,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "039f4607-7a84-48b2-b22c-c9caf8b768fc",
+                "id": "8f7454e7-a767-4095-8300-805d41fba59e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21440,7 +21440,7 @@
           }
         },
         {
-          "id": "b8cbdffb-f20c-4b58-a569-cbdc1e4ee740",
+          "id": "ae0d192e-fe51-4e88-9ec8-51a1cc70dec5",
           "name": "Get all product assortments",
           "request": {
             "name": "Get all product assortments",
@@ -21521,7 +21521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b95c175d-d827-4ab1-9fa3-6efb6aeded56",
+              "id": "0ec784fe-f83c-4554-ac26-618b338d5983",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21616,7 +21616,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "44c29f48-881d-4541-b11a-167b3c6916b2",
+                "id": "5f8014e0-7d59-43ee-8fa1-421f84ecddd4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/assortment - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21632,7 +21632,7 @@
           }
         },
         {
-          "id": "96149073-6a88-4dc1-8e74-2e435b826e6e",
+          "id": "9ab46347-ab46-463e-984f-fe15df6f107a",
           "name": "Get product assortment by ID",
           "request": {
             "name": "Get product assortment by ID",
@@ -21688,7 +21688,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a83ae541-6d6f-41ad-97ac-b2f6f3fbf9fb",
+              "id": "03c1f39b-c1a2-42d8-ab2e-9528d14b0466",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21746,7 +21746,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9c1896bd-f749-4199-aa2f-6a3813c8d546",
+              "id": "d754606d-22a6-4079-a79f-f1c473a68d27",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -21805,7 +21805,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3eeb3859-5f9d-4f83-869d-8a9d4cb6c0c5",
+                "id": "964c7de7-5f1d-453f-8142-a75bf098df7b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -21821,7 +21821,7 @@
           }
         },
         {
-          "id": "b15d1dc0-393e-43a7-b5c7-2e22eb1ef3e6",
+          "id": "5f45daf4-050a-49a0-9e26-c60032140889",
           "name": "Update product assortment",
           "request": {
             "name": "Update product assortment",
@@ -21899,7 +21899,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e6a868f6-1c23-496b-8822-7d1db98422d8",
+              "id": "d2e2ed3d-20cd-4996-a415-e428188b2f69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -21979,7 +21979,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "aae05f45-ffe7-461d-bbb3-76e1bb03a854",
+              "id": "ef4f7857-bed8-4aba-a1a3-b4350d382bd3",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22059,7 +22059,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "692ab6a9-22fc-44d5-a792-6f07a8deed88",
+              "id": "17eb18ee-85f1-4959-88f0-f00d019c7db6",
               "name": "Unprocessable Entity",
               "originalRequest": {
                 "url": {
@@ -22140,7 +22140,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e1d046aa-fe00-4a58-8050-15a886c8a1db",
+                "id": "b90cedae-ec92-40b3-ad83-9e65b198bc9f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22156,7 +22156,7 @@
           }
         },
         {
-          "id": "48573753-fe54-4ac7-80a8-23e2ca4be83f",
+          "id": "05ac42cb-6bd5-46ee-873f-2f58a946438b",
           "name": "Delete product assortment",
           "request": {
             "name": "Delete product assortment",
@@ -22212,7 +22212,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b7a7df7c-adef-417e-bdd2-7cd414e5c4f2",
+              "id": "bb849b93-288f-4775-803d-a04167169e21",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22270,7 +22270,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9b69108a-1d47-4b76-b5a6-5b3dd822a732",
+              "id": "6370d2d0-08f2-47b7-927a-4f22e2e7f5a3",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -22328,7 +22328,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7674844b-0c76-440c-8c18-76600cb40e17",
+              "id": "835c1afe-cd85-463c-a876-1e1b48253fc9",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22387,7 +22387,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4f5943c7-4102-4295-9f4c-67b95c756a81",
+                "id": "45b6e613-5d1c-40f4-881a-77d26b0270ed",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22403,7 +22403,7 @@
           }
         },
         {
-          "id": "2893d71e-45f6-4840-a910-2045ccc17691",
+          "id": "681bfccb-03f5-49e0-b043-64a7919c54f7",
           "name": "Add included collection to product assortment",
           "request": {
             "name": "Add included collection to product assortment",
@@ -22471,7 +22471,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "301f6934-5a11-4bd8-a071-5fed57d05c3c",
+              "id": "55d1767b-c1db-4cd6-bd75-3886cd1d1ce4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22531,7 +22531,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d3c102b9-09a9-497a-9c2f-a7068853d1d1",
+              "id": "c77a50cf-f1aa-461c-bcdd-fecb16bdf98e",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -22592,7 +22592,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9dd055a8-5815-4f0c-9d1b-dc52a2973baf",
+                "id": "3e3eb5d0-70eb-4a5b-a584-1671138e00de",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment/:productAssortmentID/included-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22608,7 +22608,7 @@
           }
         },
         {
-          "id": "24558e67-e72b-4411-96bc-c4999a7aa61b",
+          "id": "cfd5d2ca-a0d7-4d56-ab95-6f5f8ddee47b",
           "name": "Remove included collection from product assortment",
           "request": {
             "name": "Remove included collection from product assortment",
@@ -22676,7 +22676,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "42416cab-d255-4a6d-a36a-78cd06660022",
+              "id": "7c45ff5d-fb46-4d11-9a02-80401e87ccc0",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22736,7 +22736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1f2c9716-97c3-4630-b45c-21ce5e6c17f8",
+              "id": "384b7886-1151-414b-9eae-8daf5d860918",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -22797,7 +22797,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ede00c4c-484c-4c80-b590-96726243151e",
+                "id": "cd6e18a3-5e80-4732-84a7-f5cf5628fafc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID/included-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -22813,7 +22813,7 @@
           }
         },
         {
-          "id": "5e860898-55fb-447b-b3fe-7d9c4dd42e08",
+          "id": "ea358583-e363-48e6-8e93-422e43524ba6",
           "name": "Add excluded collection to product assortment",
           "request": {
             "name": "Add excluded collection to product assortment",
@@ -22881,7 +22881,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e44fd8c6-85e8-4d0d-88c8-1d5c689a9850",
+              "id": "dade3ba3-1420-4934-af6e-fa2afa93fc34",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -22941,7 +22941,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2b780c97-059f-4fd5-9f76-92e86b6bcb81",
+              "id": "6c13bc7d-ee93-463b-bdf8-ce987b438500",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -23002,7 +23002,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "37ba10b9-9e54-4166-931d-52f57026fb0d",
+                "id": "a9e554df-bf15-455f-9358-5c5e12f3e285",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/assortment/:productAssortmentID/excluded-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23018,7 +23018,7 @@
           }
         },
         {
-          "id": "aa33994d-cb6b-4a78-b17c-a870710aa2bf",
+          "id": "1b73ef62-7ad8-4f1d-b743-e8b501c45923",
           "name": "Remove excluded collection from product assortment",
           "request": {
             "name": "Remove excluded collection from product assortment",
@@ -23086,7 +23086,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f3bd57d8-e24c-46a4-a0c6-5e182d3998c6",
+              "id": "0c1ec01c-a987-40c5-97f9-d2b156df630c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23146,7 +23146,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dc76242e-f038-4e08-ac54-c47b3823eb0f",
+              "id": "3c42455f-b778-46e3-bb94-a6e2da0283e0",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -23207,7 +23207,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3359fa25-8bc5-4b02-bdb4-c44a8bd63be9",
+                "id": "a8273724-f9da-4aa4-9b88-763e6945c4fc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/assortment/:productAssortmentID/excluded-collections/:collectionID - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23226,7 +23226,7 @@
       "event": []
     },
     {
-      "id": "3f8410b1-1ad6-4547-9fca-7079a4c4d2b3",
+      "id": "1f5d39c6-0bbd-42c1-85f3-959e43bc7110",
       "name": "Collection",
       "description": {
         "content": "",
@@ -23234,7 +23234,7 @@
       },
       "item": [
         {
-          "id": "6aff6d21-c7d9-44a9-a47c-d2d857837896",
+          "id": "b89b4d90-a705-48eb-a3d8-3f37102d3424",
           "name": "Get all inactive collections",
           "request": {
             "name": "Get all inactive collections",
@@ -23288,7 +23288,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "27066b97-b6db-4bb9-b804-e5ac97ce8ed9",
+              "id": "e248d90a-a47a-4dad-a886-52c36e247e35",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23356,7 +23356,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c28a3a99-5b91-4b98-a575-981ce3d0ddaa",
+                "id": "d10f9bd3-6eb0-4716-b5e8-ab61e055180e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/inactive - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23372,7 +23372,7 @@
           }
         },
         {
-          "id": "8e113300-590e-4985-b948-3d90d57a77e3",
+          "id": "507726b4-4738-4a03-94b1-da270779f4eb",
           "name": "Create collection",
           "request": {
             "name": "Create collection",
@@ -23424,7 +23424,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": 21711792,\n  \"Type\": true\n}",
+              "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": -18504615.878519416,\n  \"Type\": -93214454.76493557\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -23438,7 +23438,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c25c16dc-8fa8-42b7-8bc2-31ab9a66ff21",
+              "id": "5745f425-5fb2-4e8b-a519-db1918b09627",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23493,7 +23493,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": 21711792,\n  \"Type\": true\n}",
+                  "raw": "{\n  \"Name\": \"Halloween costumes\",\n  \"Description\": \"HomeHalloween\",\n  \"Searchable\": false,\n  \"Highlight\": false,\n  \"DateFrom\": \"2025-11-26T15:23:00\",\n  \"DateTo\": \"2069-11-26T15:23:00\",\n  \"TotalProducts\": -18504615.878519416,\n  \"Type\": -93214454.76493557\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -23518,7 +23518,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7dfa4e26-f33a-4e6e-bf39-8967dd203030",
+                "id": "5eb16098-e552-42c6-a05c-7c66d9e93150",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23534,7 +23534,7 @@
           }
         },
         {
-          "id": "2b8b85a3-ec1a-4f6c-8e5e-2d149274a05a",
+          "id": "ac3d80dd-2fcd-46b6-80f2-e58b931f3024",
           "name": "Import collection file example",
           "request": {
             "name": "Import collection file example",
@@ -23580,7 +23580,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d230bf39-f14a-41a5-82e4-611d882a7a80",
+              "id": "54ac06ff-0e5b-4f95-acf7-1bbe2a24749d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23640,7 +23640,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "228d2d08-7ac7-456c-97d9-2f55b94acb22",
+                "id": "15aca668-ae05-40e8-9a43-d0373aca0164",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/stockkeepingunit/importfileexample - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -23654,7 +23654,7 @@
           }
         },
         {
-          "id": "9444fd1d-ba99-446d-81d0-741d15c69ca9",
+          "id": "b58d9b8d-6471-4b06-a019-4f8d64691088",
           "name": "Add products to collection by imported file",
           "request": {
             "name": "Add products to collection by imported file",
@@ -23734,7 +23734,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1d53035d-b3b5-495c-9eae-161280b2908a",
+              "id": "79d7f818-5d7f-4ade-9721-41e18e868cca",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23811,7 +23811,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "df7bfad6-fe08-4d1b-a0ad-bcb9889a475a",
+                "id": "5984e6f2-c1b6-4fa9-ba9b-407df3bca6b9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/stockkeepingunit/importinsert - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -23824,7 +23824,7 @@
           }
         },
         {
-          "id": "d7da64eb-73f1-4f2d-9880-534ad457c840",
+          "id": "321b22ee-2585-44c2-87c6-7d1295998dc1",
           "name": "Remove products from collection by imported file",
           "request": {
             "name": "Remove products from collection by imported file",
@@ -23904,7 +23904,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2893f379-a0f7-459e-a19e-9456c2e8876f",
+              "id": "cb9e6602-3529-4662-bd6a-788e42609a79",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -23981,7 +23981,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "898dde7d-cc9a-4e84-80f1-cc779ce7f3c4",
+                "id": "4a423371-b043-4f73-bb62-9bcc13c6e924",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/collection/:collectionId/stockkeepingunit/importexclude - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -23994,7 +23994,7 @@
           }
         },
         {
-          "id": "9f3d2115-dd4d-423e-b52b-08381af8a1f2",
+          "id": "4974c91f-b353-4f84-8d04-ce3fa8128dfe",
           "name": "Get products from a collection",
           "request": {
             "name": "Get products from a collection",
@@ -24178,7 +24178,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7b5ab2df-23cc-4fc2-a103-6ae78afebca7",
+              "id": "8021bf31-5ca8-470c-986b-c75c18e0b77b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24365,7 +24365,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "262c2938-9b2f-491a-8934-b40ab4395816",
+                "id": "3ff9cc93-8efa-45cd-aabc-f8d0a2382fcb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24381,7 +24381,7 @@
           }
         },
         {
-          "id": "af99f40a-5568-4247-999c-d97042af8745",
+          "id": "6f5f2315-00bf-4553-9fe3-fd5d25bee857",
           "name": "Get collection by ID",
           "request": {
             "name": "Get collection by ID",
@@ -24446,7 +24446,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9742e3e7-7329-43ff-9eac-3c184cc18c08",
+              "id": "ecf76140-6717-4991-b44e-74bd31cbd718",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24514,7 +24514,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "80a08337-b7ef-4cd5-b119-b43cacd9f9cf",
+                "id": "be8078e7-f270-4cd2-a202-9902b0ebc3cb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24530,7 +24530,7 @@
           }
         },
         {
-          "id": "7aff83a6-bb72-4f18-aba5-245b132e7fb8",
+          "id": "e754836b-0b85-44e4-848e-c7fa948a5581",
           "name": "Update collection",
           "request": {
             "name": "Update collection",
@@ -24608,7 +24608,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "63aa8e21-bd8e-4d96-a59c-8089eec58d34",
+              "id": "ed3fa146-99ae-4282-9720-7d887468b4cd",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24689,7 +24689,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "947c0e59-324f-4db5-825a-3e872167b376",
+                "id": "0d397c08-0d4d-4153-9018-f67e91e4b40b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -24705,7 +24705,7 @@
           }
         },
         {
-          "id": "b5e15b78-e45f-4355-9c37-818a8f21db09",
+          "id": "c91d3f71-d277-4c5b-81cd-b201272926e6",
           "name": "Delete collection",
           "request": {
             "name": "Delete collection",
@@ -24766,7 +24766,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "92dd1045-db22-4047-b79c-65a08b306193",
+              "id": "e6704970-d1d8-4a99-808a-337206a617ae",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24824,7 +24824,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f63797e7-d4ee-443e-b6cc-1cc94429fd35",
+                "id": "37ab6135-fdf5-4e32-b441-8b3f408ec6c2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/collection/:collectionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -24840,7 +24840,7 @@
       "event": []
     },
     {
-      "id": "8021052f-186e-42b4-85f8-6dfeb27217d0",
+      "id": "4b1ea72f-6e06-4bf3-815b-6f52d15397bc",
       "name": "Supplier",
       "description": {
         "content": "",
@@ -24848,7 +24848,7 @@
       },
       "item": [
         {
-          "id": "3c54cc4b-0dd4-449c-8b5e-fd21aed756db",
+          "id": "d6f82be5-1285-493a-a323-2757fa035fff",
           "name": "Create supplier",
           "request": {
             "name": "Create supplier",
@@ -24914,7 +24914,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5f451ae5-f9b2-4c3d-9942-c8a2c5b2d8e2",
+              "id": "b804da7a-aafd-4962-8034-9b6577704234",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -24994,7 +24994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b38012b8-10ff-4fc5-916e-72206884f242",
+                "id": "d5465cea-1d43-491d-85c7-028c5c395b68",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/supplier - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25010,7 +25010,7 @@
           }
         },
         {
-          "id": "f4fd6612-be22-479f-ac66-b9fa24470aef",
+          "id": "b822bc9a-e3df-45a9-b8fb-c8daf01b1687",
           "name": "Update supplier",
           "request": {
             "name": "Update supplier",
@@ -25088,7 +25088,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a951baba-d322-43bd-a583-eb532d0f47f1",
+              "id": "bc7b1324-2c7b-4caf-8e29-1f4b31c61e69",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25169,7 +25169,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9469bf0f-fa44-4898-88b1-340214f8881a",
+                "id": "bfbc9d7f-4786-4570-ab1a-c417dd164528",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/supplier/:supplierId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25185,7 +25185,7 @@
           }
         },
         {
-          "id": "4960303d-015a-41fd-9132-639b85f8ac34",
+          "id": "f503579a-bc24-48bb-beb6-7895bebf94e9",
           "name": "Delete supplier",
           "request": {
             "name": "Delete supplier",
@@ -25246,7 +25246,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e674cff4-5aac-497b-9efa-427a71e24699",
+              "id": "4aabfe93-630d-4355-8418-6da4881c6dd8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25304,7 +25304,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3d9c42e5-8b00-41c7-b05f-87151d1bcaf2",
+                "id": "7c505ac8-3837-4a77-8dff-ea78d603c162",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/supplier/:supplierId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -25320,7 +25320,7 @@
       "event": []
     },
     {
-      "id": "e15d9447-22f4-431c-98cb-190a47099f39",
+      "id": "ba06b7b0-cf4f-45ef-b515-13050a01f02c",
       "name": "Sales channel",
       "description": {
         "content": "",
@@ -25328,7 +25328,7 @@
       },
       "item": [
         {
-          "id": "ef518a00-e40a-4235-b930-77b464aba273",
+          "id": "41d03f15-ec07-4293-8799-4b6ffd35db61",
           "name": "Get sales channel list",
           "request": {
             "name": "Get sales channel list",
@@ -25382,7 +25382,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "56cf3e82-b5e4-4747-990d-1aea645de0c5",
+              "id": "28fa3a34-c16d-4573-a59f-bc1ede0f1488",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25450,7 +25450,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eb47fa96-6359-461d-8670-f77434f8d303",
+                "id": "23676faa-ea34-4dc4-b7fd-20156bf5bb0b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/saleschannel/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25466,7 +25466,7 @@
           }
         },
         {
-          "id": "77289e22-c418-4cb2-b099-89100394c65d",
+          "id": "e0ea1774-363b-4629-b6a8-a18d92ccff18",
           "name": "Get sales channel by ID",
           "request": {
             "name": "Get sales channel by ID",
@@ -25531,7 +25531,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8771eff7-3d82-4e0a-afaf-053b017c3267",
+              "id": "073dcb08-92e8-42a2-8c97-b74e49536222",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25599,7 +25599,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1e32ad12-e8be-47f3-ac92-68ff66594b01",
+                "id": "3a9c198d-ff46-4e80-b6f5-32f07e8f1e3e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pub/saleschannel/:salesChannelId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25615,7 +25615,7 @@
           }
         },
         {
-          "id": "ef17f688-acc9-47f2-81c4-cc55e9562e2f",
+          "id": "e991356c-8e1e-4da1-a153-bfbd7426cdde",
           "name": "Get sales channel by product ID",
           "request": {
             "name": "Get sales channel by product ID",
@@ -25681,7 +25681,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "22b0cd15-fc74-4722-8276-25d1eb360694",
+              "id": "fa6ead6d-ff50-4a08-98bd-b9ddb99c57b9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25750,7 +25750,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bdee3773-f113-4208-95b7-50daa9705d08",
+                "id": "1b773ae7-d2fc-4fda-9807-3b00bcd2a391",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/salespolicy - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -25766,7 +25766,7 @@
           }
         },
         {
-          "id": "61641911-72b2-40a8-ad0c-46f3a0847c25",
+          "id": "46100b16-63a5-43f1-8a90-cc34c006fb3a",
           "name": "Associate product with sales channel",
           "request": {
             "name": "Associate product with sales channel",
@@ -25839,7 +25839,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4bf058e7-1dbf-4f89-b58c-a6a5b6807f2f",
+              "id": "d0660c16-2c70-455a-82b8-f3450d997562",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -25899,7 +25899,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "392573a6-e0c8-4f3a-aa68-a3f1d292571a",
+                "id": "47498d11-1d66-4d68-a130-5c7e2583f6ac",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/product/:productId/salespolicy/:tradepolicyId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -25912,7 +25912,7 @@
           }
         },
         {
-          "id": "ac3a0fed-39e9-4aa7-b42c-4e450aebad5d",
+          "id": "3041a5d3-dc14-4d25-81d3-51032ec716d8",
           "name": "Remove product from sales channel",
           "request": {
             "name": "Remove product from sales channel",
@@ -25985,7 +25985,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "18639800-20c8-4437-8642-f3d255c70cb4",
+              "id": "878f3e8b-82fe-4887-bc6a-be8b31ad409c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26045,7 +26045,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5acdf3e2-c3db-40df-9047-8a8323f25515",
+                "id": "d031b0fd-6eb4-4ee9-8d6f-00a323e6043b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/product/:productId/salespolicy/:tradepolicyId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -26058,7 +26058,7 @@
           }
         },
         {
-          "id": "c30e893b-1509-490f-bd23-f0a2b0d7cb74",
+          "id": "e94147dc-84bb-431a-b1b3-e05a900fbebc",
           "name": "List all SKUs in a sales channel",
           "request": {
             "name": "List all SKUs in a sales channel",
@@ -26149,7 +26149,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "207d8474-fe45-439e-9547-7237f14efedc",
+              "id": "40e0b39d-73ec-4452-a242-ed00fe2cb1c4",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26254,7 +26254,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a2c22383-2fda-4283-a752-9da20f29c96a",
+                "id": "9b0ed08c-0ad0-4be3-8e31-b0b4ef40a22e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sku/stockkeepingunitidsbysaleschannel - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26273,7 +26273,7 @@
       "event": []
     },
     {
-      "id": "2da81af1-ffb0-4ea9-bccf-56baa9f53e9f",
+      "id": "8506a94b-06e3-4cc7-b841-8bfc115e240b",
       "name": "Seller",
       "description": {
         "content": "",
@@ -26281,7 +26281,7 @@
       },
       "item": [
         {
-          "id": "c89fc2f8-1aa8-4b89-b810-6ba9a2c09cdf",
+          "id": "f85fa6f3-09f9-45d7-98ac-ac50da9e9459",
           "name": "Get seller list",
           "request": {
             "name": "Get seller list",
@@ -26363,7 +26363,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "010a70dd-1e06-4a90-b0f4-45aa9c407e35",
+              "id": "b22debe5-f815-4fd1-b45a-3d41b22a6e5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26459,7 +26459,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7d9fd326-defd-4724-8788-4fa8010f43bb",
+                "id": "d04eb792-4782-4e8c-bd97-017596f288e4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/seller/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26475,7 +26475,7 @@
           }
         },
         {
-          "id": "93e6824e-fd1d-4bfc-9638-4c7ad7b492fe",
+          "id": "e44c56ac-6053-450a-a132-3a4056f58ffa",
           "name": "Get seller by ID",
           "request": {
             "name": "Get seller by ID",
@@ -26540,7 +26540,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b4b19c3c-2b6f-4805-94de-117fe9581eae",
+              "id": "33533115-42ad-49ab-970c-af6611d1a2e3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26608,7 +26608,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d7fd9ce2-9a63-419a-9d8a-fb4750cb802c",
+                "id": "005decbe-9c85-47f5-9718-0313b89a6420",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/seller/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26624,7 +26624,7 @@
           }
         },
         {
-          "id": "a02aefb7-abc8-4bd6-bcd9-7e57d6212da3",
+          "id": "3f63095f-4281-4473-b7e5-9110fe8f0371",
           "name": "Update seller",
           "request": {
             "name": "Update seller",
@@ -26690,7 +26690,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "af7c7078-d387-4a78-88c8-3f721c0af6f3",
+              "id": "92bfa5a6-989f-4e75-a29b-5bfdf1656fb9",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26770,7 +26770,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7f0e67e0-8ee0-4322-ab53-e194523fd027",
+                "id": "434dc46e-694e-4c9e-86cc-bc14f7e13c50",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog_system/pvt/seller - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26786,7 +26786,7 @@
           }
         },
         {
-          "id": "a5e4b921-cd73-4410-8d55-047278e61f18",
+          "id": "cd61dd29-21cc-4b04-859b-650dab1434bc",
           "name": "Create seller",
           "request": {
             "name": "Create seller",
@@ -26852,7 +26852,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "29fa5e8c-46e8-437f-9700-9708d3a8d07c",
+              "id": "e779dbd3-a9ce-4d40-b2f9-fd5780c30f4d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -26932,7 +26932,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5787ff00-0170-4f0c-8d75-4fd53d5c9d6a",
+                "id": "20b9ae62-b045-421d-8af1-87b1abb96bb9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/seller - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -26948,7 +26948,7 @@
           }
         },
         {
-          "id": "d8ed716b-9036-4682-a74e-70299817f002",
+          "id": "a61223f2-94f4-4eb0-b6c3-e2138d1eb5bc",
           "name": "Get seller by ID",
           "request": {
             "name": "Get seller by ID",
@@ -27013,7 +27013,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "aa77804e-4394-4025-a473-7fdd125fa7c5",
+              "id": "73dbc467-31f5-437d-943e-374f3f7882f5",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27081,7 +27081,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e1af17fc-4c74-4293-a854-2b929e81ab1c",
+                "id": "c710d73f-9434-4dc1-ab20-e21e5d902174",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/sellers/:sellerId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27100,7 +27100,7 @@
       "event": []
     },
     {
-      "id": "37e9ab78-b24c-4788-942f-4a1fa0850e83",
+      "id": "f2303a2f-ca7e-47d8-a7a2-aaacedcaade5",
       "name": "SKU seller",
       "description": {
         "content": "",
@@ -27108,7 +27108,7 @@
       },
       "item": [
         {
-          "id": "fc985ec4-7e41-42f3-b281-620e7b507214",
+          "id": "2cf05397-698f-450c-9843-96bb41c6195d",
           "name": "Get details of a seller's SKU",
           "request": {
             "name": "Get details of a seller's SKU",
@@ -27184,7 +27184,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "430e51d8-fdc1-41f6-ba85-8a88e64d891d",
+              "id": "d8e88c8d-0cf5-4554-afa0-2a9c70a8ea39",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27253,7 +27253,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f58d8678-a5f0-4203-b5b5-eecea421c815",
+                "id": "f3c37137-a17e-42fd-b61e-8d4fe8a40d46",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/skuseller/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27269,7 +27269,7 @@
           }
         },
         {
-          "id": "2bce4ca6-86b3-4c2f-8fe6-3036d6ab0ce6",
+          "id": "e9af789c-957a-4fa3-86d3-c58d16c62672",
           "name": "Remove a seller's SKU binding",
           "request": {
             "name": "Remove a seller's SKU binding",
@@ -27342,7 +27342,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7b0228e3-589e-4ec4-8286-e62b8fc32747",
+              "id": "13b20d2d-bad8-41b8-bc58-d425da11e05b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27402,7 +27402,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2e001f94-09aa-4981-891e-144c8120b01d",
+                "id": "d1c6f903-fb8d-4ef8-8b8c-68b39b067762",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/remove/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -27415,7 +27415,7 @@
           }
         },
         {
-          "id": "1529bd60-b7a6-4569-ae06-24b3a3f4e10f",
+          "id": "66a632f3-e84b-4b57-8fe7-a2bc86bff881",
           "name": "Change notification with seller ID and seller SKU ID",
           "request": {
             "name": "Change notification with seller ID and seller SKU ID",
@@ -27488,7 +27488,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4ee092ae-b08e-45d3-b2a6-a71ac57a1448",
+              "id": "2f2dd6bf-008c-4410-969e-f0e48cbc2802",
               "name": "No Content",
               "originalRequest": {
                 "url": {
@@ -27548,7 +27548,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a3a6550d-efae-4127-89bd-1b8932b77a32",
+                "id": "3f9494b5-4294-4011-b79a-50bebba21d3e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/changenotification/:sellerId/:sellerSkuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -27562,7 +27562,7 @@
           }
         },
         {
-          "id": "7b9c74f3-ddd5-453c-abbe-12693df44784",
+          "id": "ca8a7985-3e27-4ee2-9758-534bf0a8493e",
           "name": "Change notification with SKU ID",
           "request": {
             "name": "Change notification with SKU ID",
@@ -27628,7 +27628,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0e83a83e-9e36-4a5d-b991-779a0c8497a9",
+              "id": "e254fffd-1086-4135-9a23-ea77b60626cc",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -27686,7 +27686,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dbd5c0ce-f4ea-4694-b6e3-63d368b1410c",
+              "id": "ed99552c-7a9b-4f4d-8b78-8abd9d8504cb",
               "name": "Forbidden",
               "originalRequest": {
                 "url": {
@@ -27744,7 +27744,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "37d737b3-59ad-4d9c-8a42-562a09b90b0b",
+              "id": "5cdb4963-b5c7-4859-b947-110bcfdbb05e",
               "name": "Not found",
               "originalRequest": {
                 "url": {
@@ -27812,7 +27812,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "309a66bd-2ecd-4e26-943d-16254f82219c",
+              "id": "35ae660c-59d0-4f70-8897-deb36f2dc91a",
               "name": "Too many requests",
               "originalRequest": {
                 "url": {
@@ -27871,7 +27871,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d73f9a2f-38c8-4ce7-a6e0-a6b89f0fc1f5",
+                "id": "47d53f6e-6bd3-4767-a25f-d58039de3043",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog_system/pvt/skuseller/changenotification/:skuId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -27887,7 +27887,7 @@
       "event": []
     },
     {
-      "id": "8d74d9e1-c452-4a96-b0de-152648db6d58",
+      "id": "0463abaf-739c-4e2f-9569-ad3627bbc37f",
       "name": "SKU attribute",
       "description": {
         "content": "",
@@ -27895,7 +27895,7 @@
       },
       "item": [
         {
-          "id": "4d2d0c04-9ef6-4311-a804-d80d4ac7633d",
+          "id": "eff414d4-0028-4e40-8459-ec3c59c98264",
           "name": "Create SKU attribute",
           "request": {
             "name": "Create SKU attribute",
@@ -27974,7 +27974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "531c601e-0b1b-440c-9b13-0f08afca1058",
+              "id": "9864c9d6-80fa-4b14-82fc-e0fa29a44deb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28055,7 +28055,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "611922a0-c19d-44bf-8753-1aaeadc237f3",
+              "id": "a485ebae-50f6-438f-be8c-ec6cfd22f680",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -28137,7 +28137,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "521bfbc5-52f4-4ca0-b0c2-4e71461d5a31",
+                "id": "ac29b036-cb27-4f20-8d26-0b09492bef44",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28153,7 +28153,7 @@
           }
         },
         {
-          "id": "cfd0c608-cb4c-4f24-968f-b3964dbe96e5",
+          "id": "27c8ccd1-59fc-4cb8-b596-b16d1b259579",
           "name": "Get all SKU attributes",
           "request": {
             "name": "Get all SKU attributes",
@@ -28219,7 +28219,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "360341b8-cf3b-47c9-8784-62b10d9c6e52",
+              "id": "ced6ca0d-830c-42e0-a336-f443ceae4ffb",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28288,7 +28288,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eaf1cfb7-e12a-4a1a-a050-a10677fad5fe",
+                "id": "c3b25286-c4d2-42a8-a8f0-b8d7027b0a2f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28304,7 +28304,7 @@
           }
         },
         {
-          "id": "25fba80f-176e-45d2-951d-9bd59b1bc288",
+          "id": "272344a8-ce3e-4c56-b934-793f7801bc47",
           "name": "Delete all SKU attributes",
           "request": {
             "name": "Delete all SKU attributes",
@@ -28366,7 +28366,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dd2b9494-e43b-4222-966b-a69b0237a78c",
+              "id": "f9adfc3a-4909-4b32-9678-957ef5a5a561",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28425,7 +28425,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6bbb6e67-d41d-4e2a-beab-985f10124054",
+                "id": "5afe9fb4-314e-4001-a6e9-3fde8cca3054",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -28438,7 +28438,7 @@
           }
         },
         {
-          "id": "7fb52679-8e7c-4105-96d4-df88e26c729d",
+          "id": "f38cecba-d827-4e59-8007-b701d0e6e8de",
           "name": "Get SKU attribute by ID",
           "request": {
             "name": "Get SKU attribute by ID",
@@ -28515,7 +28515,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e33fcd6f-3a32-4c5c-8a64-838818b5e5f3",
+              "id": "c5a951ee-d412-4483-a014-62447e25bfb8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28585,7 +28585,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c333b1e6-4307-4275-b288-0fba1e43b711",
+                "id": "146fd75d-6784-4122-b8e5-3db5b9569ec1",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28601,7 +28601,7 @@
           }
         },
         {
-          "id": "1267247a-c261-4a5e-a4f6-7c52f0d85bd5",
+          "id": "cfdb7ba3-8259-41a1-8d09-147bf13e7969",
           "name": "Update SKU attribute",
           "request": {
             "name": "Update SKU attribute",
@@ -28691,7 +28691,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "321d216f-46c0-4888-b643-d9b733194d14",
+              "id": "631f86ef-2333-4def-b7b6-8364a5326cea",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -28773,7 +28773,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6d4fa1d7-a2c8-40a6-b871-504eb8f828c4",
+              "id": "cdd2b832-e3fc-43e9-a94d-5d38113c1ded",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -28856,7 +28856,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e946c453-090a-43fc-b7bc-07c73b65bf0c",
+                "id": "9e581dc0-60d1-4688-b6c2-8310e4ed0d68",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -28872,7 +28872,7 @@
           }
         },
         {
-          "id": "281e8941-9df8-43eb-b24f-1b6d6cb3be10",
+          "id": "9af5ba76-e81d-4fa4-bf8a-42a24e16bb9c",
           "name": "Delete SKU attribute",
           "request": {
             "name": "Delete SKU attribute",
@@ -28945,7 +28945,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ccd98070-07ec-4c8e-9eb4-c06a04a82c70",
+              "id": "664b3fca-32aa-4e32-abd0-19736a9d958e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29005,7 +29005,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7f937473-ac57-45b2-a70f-65ba50a2328b",
+                "id": "fbb5cd28-95f7-46c1-b866-71f4b717b495",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -29021,7 +29021,7 @@
       "event": []
     },
     {
-      "id": "a9a0ffed-9add-49e9-8004-0e0c2686a6b6",
+      "id": "287639b3-ae5f-495f-9b4b-fe3a978aedb9",
       "name": "Multi-language",
       "description": {
         "content": "",
@@ -29029,7 +29029,7 @@
       },
       "item": [
         {
-          "id": "97097a59-e7e9-44b1-80a1-e8935b244771",
+          "id": "0eb9f700-c3c0-4459-a6af-ac0f1328388d",
           "name": "Get product translation by product ID",
           "request": {
             "name": "Get product translation by product ID",
@@ -29106,7 +29106,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "17150ee7-bca3-4a56-82d2-535475e771b5",
+              "id": "4dce3e93-033e-444f-bdc9-195e66f04c5f",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29175,7 +29175,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "784e8a6d-d5da-4618-aa85-f0edfd6d1781",
+              "id": "4834438b-ed7e-43b9-b4ac-8774df2e9300",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29235,7 +29235,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8433a43c-7241-4d4b-b4a2-e82f844e130f",
+                "id": "62703a02-e41f-40d2-84c8-28661a06334d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/product/:productId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -29251,7 +29251,7 @@
           }
         },
         {
-          "id": "8613061c-0674-4835-ab76-07cc2221258a",
+          "id": "dc38271d-df37-47f6-a0df-f98956c13983",
           "name": "Create or update product translation by product ID",
           "request": {
             "name": "Create or update product translation by product ID",
@@ -29326,7 +29326,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f21928da-faeb-42ed-9c55-ac9d9a216269",
+              "id": "3b98d402-f696-4b2d-a701-bb3318906b09",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -29397,7 +29397,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e4bc4ee6-fe69-401d-a950-0905258bf063",
+              "id": "699eb546-7bad-4f80-9f68-312c26a5d252",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -29468,7 +29468,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6fa71f5e-ac3b-43f1-ad72-8440df2a414f",
+              "id": "d15acb82-7d72-4af8-9e7d-ceadeda58407",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29539,7 +29539,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9a453ad3-7ab2-44a5-b7c1-72f6ff0fff78",
+              "id": "d16efa46-b0b2-4306-9c13-7846a2fa8596",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -29611,7 +29611,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "89802d77-3498-44a4-9d5e-6dfc0cd5a41c",
+                "id": "06683d62-b079-4bae-9fdb-207bc2053307",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/product/:productId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -29624,7 +29624,7 @@
           }
         },
         {
-          "id": "3534ea5e-ee11-4930-9ef0-aefedc242c7f",
+          "id": "03a516ec-48ed-4ded-b923-a239e458a6bc",
           "name": "Get product specification translation by product ID",
           "request": {
             "name": "Get product specification translation by product ID",
@@ -29713,7 +29713,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b90118bc-c5a6-4cd1-96cd-c2f0c3078103",
+              "id": "eec9cb46-90ec-45ba-8076-1eae4cba7547",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -29784,7 +29784,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fbc5f24e-f9b6-4e34-85d4-de48cbb2e9ff",
+              "id": "e8d732ad-9db3-4e8b-89d1-4cb237ca913f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -29846,7 +29846,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ecddccf0-ba5d-46fb-87cd-6754e862ba03",
+                "id": "7e5f5cd8-8c11-41dc-940d-04a8c5bbf718",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/products/:productId/specification/:specificationId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -29862,7 +29862,7 @@
           }
         },
         {
-          "id": "fc6f7791-a98a-4d8d-882d-2f76c9eb78b2",
+          "id": "311382fa-4af8-480c-9c7b-571f835b4cc9",
           "name": "Create or update product specification translation by product ID",
           "request": {
             "name": "Create or update product specification translation by product ID",
@@ -29949,7 +29949,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "673876eb-692e-4b63-b95f-0bfc5fa22a8d",
+              "id": "20a904d2-9a3c-4b7a-bbaf-bc6e196db1b2",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -30022,7 +30022,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cf1843f4-12f5-467c-8137-52e708c399af",
+              "id": "5dc7b9a1-45e9-4f83-930b-e26b3998b14b",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -30095,7 +30095,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b255dfbb-be6f-4acf-9713-bb4803f2f885",
+              "id": "2c08e0aa-a946-444b-948c-5e1f91a04c3d",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30168,7 +30168,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ac305b9c-7caa-48b3-b3cd-bf2565b8130f",
+              "id": "179ccc66-3966-45ea-915e-0677c1bb0c55",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -30242,7 +30242,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "32855cf7-127c-4422-b71c-e87ed22f5835",
+                "id": "95ab0a65-1949-4560-b226-7617ef7208c5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/products/:productId/specification/:specificationId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -30258,7 +30258,7 @@
       "event": []
     },
     {
-      "id": "e5613693-4eea-42f7-b18b-0e905eb873cb",
+      "id": "363647b7-aaa2-4d70-be70-bfff528b4a6e",
       "name": "Multi-language SKU",
       "description": {
         "content": "",
@@ -30266,7 +30266,7 @@
       },
       "item": [
         {
-          "id": "cd67405d-e4cf-4da9-98f7-c9539f71d694",
+          "id": "9b4e69d3-84e9-449c-a37e-43b97f30a88e",
           "name": "Get SKU translation by SKU ID",
           "request": {
             "name": "Get SKU translation by SKU ID",
@@ -30343,7 +30343,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4f4bf4ef-c4e9-49c4-adf2-8494b49d69a6",
+              "id": "af880e67-8a1b-4eda-b685-022fb347e1b1",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -30412,7 +30412,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "484e2ac1-a6f2-40dd-af04-2b6d7f28c9f9",
+              "id": "7ba869a7-dd32-4eb3-818d-0fca2ae95d2a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30472,7 +30472,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7c11a87e-79d1-4b7b-b0ac-51ef177bed08",
+                "id": "d4c723cf-f0db-41b0-9f78-8ccdb753cef4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -30488,7 +30488,7 @@
           }
         },
         {
-          "id": "71c8fe59-b117-47df-b29d-893cfc3e35d8",
+          "id": "fe55dfb1-d364-4e0d-90c5-db19d43388b2",
           "name": "Create or update SKU translation by SKU ID",
           "request": {
             "name": "Create or update SKU translation by SKU ID",
@@ -30563,7 +30563,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8798363c-0fbc-4242-a7b9-099e08c8ffa7",
+              "id": "af11b8a4-52ba-4967-8afd-c1340bf77396",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -30634,7 +30634,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e6f01c81-934d-4599-9851-debd5608d1f8",
+              "id": "39284efe-7796-42e7-bf0c-378c36b49ad5",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -30705,7 +30705,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7f95c922-d062-4dcf-8842-f5e0d48ce131",
+              "id": "fc965a73-b0d2-43cb-b8b9-86fdb086196c",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -30776,7 +30776,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1ea0e7e4-394a-403d-8cd7-b4afe81a3713",
+              "id": "43dc60ec-7b05-44bc-9ff3-9e9e390b750b",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -30848,7 +30848,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f0f77861-5ba1-4d5d-a7f5-dcc90234067d",
+                "id": "8917f2f8-fb5b-4e3a-9a72-95b66b8f4240",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -30861,7 +30861,7 @@
           }
         },
         {
-          "id": "0a4a63e8-39cf-4e92-819a-af7206b847fd",
+          "id": "16c7a121-f67e-460f-b202-e38d70ace1ea",
           "name": "Get SKU attribute translation by SKU ID",
           "request": {
             "name": "Get SKU attribute translation by SKU ID",
@@ -30950,7 +30950,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c4b32b87-5c4f-4614-8549-ff7bafba8902",
+              "id": "9d6f1ff6-a282-49bf-9cf4-029f82072476",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -31021,7 +31021,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "362c7e57-36a9-432a-ae93-dfdb6a5ceaad",
+              "id": "a699884f-3bda-48b3-b177-787655f11b1a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31083,7 +31083,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e34b2920-008c-421f-a9f9-b5f612eec8e3",
+                "id": "06c5dea4-c10b-4993-89b7-b83d3bee6d43",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -31099,7 +31099,7 @@
           }
         },
         {
-          "id": "2f0ba055-5f3e-4d0e-928d-62c8fa4b1abd",
+          "id": "4e900a38-b173-4fda-a00a-882b3501f517",
           "name": "Create or update SKU attribute translation by SKU ID",
           "request": {
             "name": "Create or update SKU attribute translation by SKU ID",
@@ -31186,7 +31186,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7fbf60d5-4d54-4c09-8a74-dd1cec9ba853",
+              "id": "2f8229bc-ab87-4115-8677-60afdede9ac9",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -31259,7 +31259,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "06bc5af3-65b2-43d2-a07b-e08665d955a6",
+              "id": "7d651f6a-dec1-4afb-a696-b6932173837f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -31332,7 +31332,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cbd4a40c-6561-4db5-926e-2adb662ddee7",
+              "id": "42bb3f09-2c05-4966-abe9-ce650dc26ae8",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31405,7 +31405,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8124d920-3a88-4e23-8c36-42a915bde51a",
+              "id": "0c46dd5b-1646-4bf8-9dd2-0270f605764a",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -31479,7 +31479,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "901cf1d0-8c15-4cd7-b0d0-25da289ed1b9",
+                "id": "ce1f32ce-09d0-435f-bb44-a30023b8b1c8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/attribute/:skuAttributeId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -31492,7 +31492,7 @@
           }
         },
         {
-          "id": "d56bbfc7-69e7-4743-8f10-198ec203a29e",
+          "id": "05a57c92-4d44-4fd1-a3dc-55a942980b2b",
           "name": "Get SKU file translation by SKU ID",
           "request": {
             "name": "Get SKU file translation by SKU ID",
@@ -31581,7 +31581,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4de3d15c-1d7c-4d19-8c7e-40227387d74f",
+              "id": "ca08b9d6-03a2-43e6-9320-f0ec8fb8d8ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -31652,7 +31652,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "dda52a38-5dde-454c-bf78-5bbd03a2c3b1",
+              "id": "67d3675a-0ec6-4a40-b630-4b2e594bcc4a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -31714,7 +31714,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "07810145-74f3-42f7-8282-4ac1dc967820",
+                "id": "2ba752f2-d1ab-4e19-99f5-5190b8cde658",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -31730,7 +31730,7 @@
           }
         },
         {
-          "id": "fa41c0d3-1a45-4c40-b88f-0bad745854d3",
+          "id": "c6c85c14-719f-4164-ad35-0148d4780adf",
           "name": "Create or update SKU file translation by SKU ID",
           "request": {
             "name": "Create or update SKU file translation by SKU ID",
@@ -31817,7 +31817,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "04dc0bc8-5474-4c0a-a964-d9c62a77fe7c",
+              "id": "e57a4de6-1c83-4f6d-bf35-5246223a5c7f",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -31890,7 +31890,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "49bde3d3-cc19-4427-b3c5-de47dab18eae",
+              "id": "20f42b96-e263-4f4b-8ec9-4b773957a51a",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -31963,7 +31963,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "daad128c-abee-47a0-9e79-5e0de5f2feee",
+              "id": "38879844-803e-42dc-bf49-19dcd46f5520",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32036,7 +32036,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "10500e5d-b960-4fd9-80e1-314d1e921e31",
+              "id": "005f1f70-e05e-47b2-8e07-6a04ec312693",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -32110,7 +32110,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6788dd55-b135-4931-893d-8861f7a5214a",
+                "id": "f48003e6-e957-4984-bbe2-6343efada626",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/stockkeepingunit/:skuId/file/:skuFileId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -32126,7 +32126,7 @@
       "event": []
     },
     {
-      "id": "f602c33c-1fb9-47fb-91ab-1b77594de65f",
+      "id": "4bd9663c-d6c3-4f52-844e-21b2c27f4a74",
       "name": "Multi-language specification",
       "description": {
         "content": "",
@@ -32134,7 +32134,7 @@
       },
       "item": [
         {
-          "id": "0a85d065-2133-47fe-b94a-e8892d1639ea",
+          "id": "4bc767cf-a954-4082-8afd-5eacfec8f098",
           "name": "Get specification group translation",
           "request": {
             "name": "Get specification group translation",
@@ -32211,7 +32211,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b25bdfdf-9807-4f03-80c5-0b451cf66f6b",
+              "id": "72ee726b-7923-45a2-afb3-a7e059af1b2b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -32280,7 +32280,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a8dc5714-9a36-4756-81f2-6a68bf496731",
+              "id": "8dcb1439-df24-4e1d-815f-92152641eeaa",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32340,7 +32340,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b435a0e2-04c4-4887-9e95-6993f3afa395",
+                "id": "ec6eef77-0fea-4301-8035-909cabb436fd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationgroup/:specificationGroupId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -32356,7 +32356,7 @@
           }
         },
         {
-          "id": "1b983635-d562-48df-b034-9e590741df32",
+          "id": "2feb8c3d-8396-4215-9057-226a9104cfae",
           "name": "Create or update specification group translation",
           "request": {
             "name": "Create or update specification group translation",
@@ -32431,7 +32431,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cb08e850-59f6-4f43-b769-4920f113f35a",
+              "id": "8ed8e30c-944f-4780-9de7-6a92a742638b",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -32502,7 +32502,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a93010d1-6935-4981-a4c4-625ac7eaf5b8",
+              "id": "1c82f82d-8418-48c3-a291-91cccba8f76b",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -32573,7 +32573,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b0e5bec5-0aba-4ece-aca2-f42cb6f43c6d",
+              "id": "277c1cbe-5689-4fd9-ae5c-d2b036028602",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32644,7 +32644,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0acfea29-038f-4766-bf23-2dc4ca88e47e",
+              "id": "559c8fd3-05e2-421e-a686-303875c40e9c",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -32716,7 +32716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "305baa87-f388-4068-8153-48cfb8c3b6fa",
+                "id": "adf8698b-2699-42e4-af28-cf104f4bbb67",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationgroup/:specificationGroupId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -32729,7 +32729,7 @@
           }
         },
         {
-          "id": "2976e279-6169-4158-960e-bae974edc67a",
+          "id": "4fed2b1c-2bde-43cc-a10d-c2b4c9f6b69d",
           "name": "Get specification translation",
           "request": {
             "name": "Get specification translation",
@@ -32806,7 +32806,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1f246072-97f6-4766-80c9-9e1db967bcca",
+              "id": "abed3a3a-ffe8-4b59-a4ce-397845a25688",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -32875,7 +32875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c480ea5c-acb2-4569-a6f2-29a50a6cf484",
+              "id": "74305a0b-1b54-4e61-bd17-613ede19b1ff",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -32935,7 +32935,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d5274d39-cca6-4890-9d2e-cfbec62b06b7",
+                "id": "09246efc-9ced-4fd2-a30b-ac7f1ce65cd3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specification/:specificationId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -32951,7 +32951,7 @@
           }
         },
         {
-          "id": "7bbc30fb-a9d3-4731-ad0f-7f8186e5fae2",
+          "id": "a7060bc1-f829-4aa8-8617-a697ce42fa98",
           "name": "Create or update specification translation",
           "request": {
             "name": "Create or update specification translation",
@@ -33026,7 +33026,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9718ae2f-ab6f-478f-99ae-b33b68c7196b",
+              "id": "836cf3f7-5761-4d5c-8854-da83a7ab5ce1",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -33097,7 +33097,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b5a66259-c920-4561-9a6b-85a7b2129192",
+              "id": "abe38431-d749-495c-8287-ab671f45b7c8",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -33168,7 +33168,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "17a05757-bf88-4554-bb1f-cb1e8a17875a",
+              "id": "5e1a5c88-063b-4758-bbb5-bfe34d822870",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33239,7 +33239,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a6601041-b675-480f-a8be-b9357f9e590a",
+              "id": "cac752f4-0309-4f0e-8e22-611b9561f094",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -33311,7 +33311,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "891c1f75-bee5-49b4-a20c-030575a396d3",
+                "id": "1922b802-63cc-473d-b888-f92328473be7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specification/:specificationId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -33324,7 +33324,7 @@
           }
         },
         {
-          "id": "7d2580d1-103d-4096-8078-d44eec8df5a6",
+          "id": "6daf42ec-bee9-451e-8141-9339131170fc",
           "name": "Get specification value translation",
           "request": {
             "name": "Get specification value translation",
@@ -33401,7 +33401,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5ad22ef0-5ad1-4260-b265-dbde5c7827cb",
+              "id": "7f1eb67f-98b2-4de0-9c43-3791bcd48408",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -33470,7 +33470,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3fc4e220-d9cf-43e9-828e-40df990fbde2",
+              "id": "8f0444d4-c1e4-425d-bb50-e792a1a2193f",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33530,7 +33530,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b5e65502-9105-450d-b4b4-923a1cdb73e9",
+                "id": "c17db870-f041-4119-880c-f05c7a68c23d",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/specificationvalue/:valueId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -33546,7 +33546,7 @@
           }
         },
         {
-          "id": "6da8ead5-ec64-4f94-94b5-b96e71774351",
+          "id": "ff37f4dd-552f-4305-a91f-00d4cb5840a4",
           "name": "Create or update specification value translation",
           "request": {
             "name": "Create or update specification value translation",
@@ -33621,7 +33621,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9507aef6-d20a-434a-8525-620bdb6a3b33",
+              "id": "953464a9-71e4-4b81-82c9-faf6276983fa",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -33692,7 +33692,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2555649e-70e5-4c63-888d-96c0bc3f23bc",
+              "id": "cf1880ea-cd57-433e-8c51-5f6604c74012",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -33763,7 +33763,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "006e2286-6bb4-4703-950c-e83f7622ab72",
+              "id": "1f485896-5530-4c04-bf88-01ff0891405e",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -33834,7 +33834,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6b07bbf8-bbfc-4892-94f9-f01dfb38b2c4",
+              "id": "5ad61d2b-bd31-4d5f-916c-ae0106ed2b2b",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -33906,7 +33906,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1d0f092d-fc4e-4a1f-97c7-9b07bdb11624",
+                "id": "20d0c403-9383-4607-ae28-c61d74de2ab0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/specificationvalue/:valueId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -33922,7 +33922,7 @@
       "event": []
     },
     {
-      "id": "57862a4a-bc18-42cd-b1d2-7766f605cb15",
+      "id": "966a5ea7-8617-4636-aceb-fd936df09515",
       "name": "Multi-language category",
       "description": {
         "content": "",
@@ -33930,7 +33930,7 @@
       },
       "item": [
         {
-          "id": "8048c06c-35e3-49fd-87ad-263fd8f10d48",
+          "id": "d8fbb270-d92c-462e-a2ad-735a08cb6797",
           "name": "Get category translation",
           "request": {
             "name": "Get category translation",
@@ -34007,7 +34007,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fab0d9c0-792e-462b-858a-d1c11c6fa2d7",
+              "id": "ad61f2a3-bd48-4ea7-89c5-2d284fe922d3",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -34076,7 +34076,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "86c1b1a7-11a8-49c9-9465-5688238f6a08",
+              "id": "c7d66d21-a511-4fb3-9023-3c0b72286aa1",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34136,7 +34136,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c5f20d8d-2c05-42c9-ac73-3f149f7e5bc5",
+                "id": "9640259d-37df-432a-bd13-4e84ed879fa9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/category/:categoryId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -34152,7 +34152,7 @@
           }
         },
         {
-          "id": "c03deeac-3412-4ff0-927f-c1bfb19d6b0c",
+          "id": "ae27eaa5-5106-43c0-8246-6a36504d8847",
           "name": "Create or update category translation",
           "request": {
             "name": "Create or update category translation",
@@ -34227,7 +34227,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "16ee73eb-dd93-4f4d-98fe-fd43def0076f",
+              "id": "04c551f1-5d1b-485f-9afc-fcc497745310",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -34298,7 +34298,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "62781f2b-7939-43de-a5dd-4b28326321fd",
+              "id": "31e403c4-5bfb-4158-ba63-e71f98ac464f",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -34369,7 +34369,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f990df5c-53ae-45ed-946d-a07ddea8c6af",
+              "id": "b039b35e-ada0-4123-b5be-682f1ae1be50",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34440,7 +34440,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "14d81211-ecd8-42e4-8a71-1e880acf4002",
+              "id": "938709c8-5915-484b-9763-1d13538ff5ae",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -34512,7 +34512,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "57657971-6ea9-4428-b3b3-91c3f82d77f4",
+                "id": "4fe407f7-ae20-4901-8719-56225098b39a",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/category/:categoryId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -34528,7 +34528,7 @@
       "event": []
     },
     {
-      "id": "d5f4b298-258a-4f0a-9371-1664630a2a07",
+      "id": "fc1025e4-e876-4b91-93c8-b9099f9567d4",
       "name": "Multi-language brand",
       "description": {
         "content": "",
@@ -34536,7 +34536,7 @@
       },
       "item": [
         {
-          "id": "8eb12ae7-11c3-47f5-9e03-f11377efc01c",
+          "id": "3fd54365-79bf-4400-b1c1-46aa162939ea",
           "name": "Get brand translation",
           "request": {
             "name": "Get brand translation",
@@ -34613,7 +34613,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d9f1ed7f-3020-45a2-b93f-aa7c82b30884",
+              "id": "d480f1f6-fdcc-433f-ac36-1d947c5068af",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -34682,7 +34682,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "de57311b-67f3-4c4e-9842-158197f04f8c",
+              "id": "30498e61-4826-4e64-af30-45103d8ed375",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -34742,7 +34742,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d8b5947a-be5c-4cd2-950a-85012a6627ac",
+                "id": "8f60846d-6720-42bf-a7f0-2d026033ae97",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/brand/:brandId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -34758,7 +34758,7 @@
           }
         },
         {
-          "id": "cbaec166-ccd3-4c30-99cc-630f75fa29d1",
+          "id": "291386d7-6885-4239-9e13-33eb8f0f9f18",
           "name": "Create or update brand translation",
           "request": {
             "name": "Create or update brand translation",
@@ -34833,7 +34833,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ba51cef1-b4b5-4489-a499-01f1eca905e9",
+              "id": "44a9c6e9-1ce1-4731-8076-0e3a08782fb7",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -34904,7 +34904,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e92fb14c-156b-4880-90fb-70da574de842",
+              "id": "92aae173-31a1-4f66-824a-0af911e7bb23",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -34975,7 +34975,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "71017ded-8e10-4185-8d6e-b109dbe6ba31",
+              "id": "6741f933-f7e1-4bce-acfb-dfaa3f88b0ed",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35046,7 +35046,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0732f6e9-3d12-4941-aee1-d133ff432eb4",
+              "id": "d5e057db-b504-4070-82b9-d434990ef559",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -35118,7 +35118,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "65b4b797-1387-4f60-9bd4-3fb0e12eaaee",
+                "id": "b2d043e8-eb3e-44e8-8273-c78a4afca751",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/brand/:brandId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -35134,7 +35134,7 @@
       "event": []
     },
     {
-      "id": "9b14260d-ca87-4319-a74c-88b2d1a8febc",
+      "id": "62a7bc7d-ffad-4052-8c04-ee83022a98c6",
       "name": "Multi-language attachment and service",
       "description": {
         "content": "",
@@ -35142,7 +35142,7 @@
       },
       "item": [
         {
-          "id": "c8023873-a36b-4d83-a808-8c01c29d7bcc",
+          "id": "2c61190a-7fda-4c49-9f16-195993062558",
           "name": "Get attachment translation",
           "request": {
             "name": "Get attachment translation",
@@ -35219,7 +35219,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3b35e972-7298-4570-a9d7-582c53bf4a92",
+              "id": "77a190a7-b6b9-4490-942f-c9b667f72f49",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -35288,7 +35288,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6257a1fd-498c-4e36-86ed-b4aaed0de377",
+              "id": "1450c2ed-7bec-4f0d-a130-957344a2d370",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35348,7 +35348,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ff669c6a-77dc-404b-a45d-ba7ad7724d75",
+                "id": "c4a93f63-a3f2-4eed-a732-7ef68188052f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/attachment/:attachmentId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -35364,7 +35364,7 @@
           }
         },
         {
-          "id": "6e682dc6-1f8b-493f-8ce6-b41538eecd66",
+          "id": "6dc0f009-6bcf-4c34-8b48-f2f18f4cf87d",
           "name": "Create or update attachment translation",
           "request": {
             "name": "Create or update attachment translation",
@@ -35439,7 +35439,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f5fa465e-4a90-4234-958b-5d3b147b8893",
+              "id": "eb06cd4e-2caa-4450-baae-7106a73f46e1",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -35510,7 +35510,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0bc69b85-5710-41bb-878a-c4d8258e4e36",
+              "id": "e1de4de5-e342-4473-b07e-ecbb393914ed",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -35581,7 +35581,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4cf13042-4bb5-4f83-ae05-1e126e5225ab",
+              "id": "d8aae626-5d76-45ba-afdb-49779b3213ab",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35652,7 +35652,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "aad533ec-0e06-45f2-8f94-e520cdbc8809",
+              "id": "031fa4be-b062-49a0-b302-3d09903f07f0",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -35724,7 +35724,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "887b6b4e-e86d-45ec-9923-9ddc4778c0c0",
+                "id": "cc721579-3180-48c1-bbe1-b9eda21f05a7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/attachment/:attachmentId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -35737,7 +35737,7 @@
           }
         },
         {
-          "id": "31db765f-1348-466a-9c09-12e4a4424e3b",
+          "id": "f69b0967-dbb9-47ef-b02f-876c55d44800",
           "name": "Get SKU service type translation",
           "request": {
             "name": "Get SKU service type translation",
@@ -35814,7 +35814,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "7431383f-d14c-4d08-98ff-56ddbe79a5c1",
+              "id": "b30d90fe-c49d-400d-8731-380654e9387b",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -35883,7 +35883,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9bb3a663-b232-47ad-8d1c-a99afaf208fa",
+              "id": "042df46e-175d-4040-bec9-3fb907fc165a",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -35943,7 +35943,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4f75e8bc-da77-464c-a45d-abeb38770782",
+                "id": "adc65205-a146-414b-9da4-d61bb5e6aca9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -35959,7 +35959,7 @@
           }
         },
         {
-          "id": "75093e0a-7531-437a-83fa-bdc8759a9030",
+          "id": "5d2a95da-4273-4e68-8ba4-cb526ac85c5d",
           "name": "Create or update SKU service type translation",
           "request": {
             "name": "Create or update SKU service type translation",
@@ -36034,7 +36034,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "49db8003-483c-49a0-8d75-e10fc0c4ca03",
+              "id": "f896eac9-601e-4762-9844-4c936fa3c5ad",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -36105,7 +36105,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e7c259a0-e5a9-45e6-9e91-549fd063170f",
+              "id": "307898b9-7bdb-45a5-9e19-6e7d571e5256",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -36176,7 +36176,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5a0d22a5-c2dd-4266-851a-1964f6e48bcd",
+              "id": "a4888f9a-5465-45a0-993f-24de65f25a59",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36247,7 +36247,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4046c505-17c0-4569-8e40-cdf91e35801c",
+              "id": "773c51fa-fa23-4ca6-b6d9-35e2c72e7795",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -36319,7 +36319,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "5845e6d8-eabb-45ae-865f-cf57ad68fa98",
+                "id": "391b167f-4840-48cf-abfe-bf04a46f7395",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicetype/:skuServiceTypeId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -36332,7 +36332,7 @@
           }
         },
         {
-          "id": "3fc9c992-3cd6-4805-867f-9c9da3efd932",
+          "id": "0cc46812-3c02-4e90-92e3-5d0014462955",
           "name": "Get SKU service translation",
           "request": {
             "name": "Get SKU service translation",
@@ -36409,7 +36409,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bef88086-ea9d-4244-9872-542dc68f025d",
+              "id": "3a86559e-e3c4-40e2-9122-661ea73dc91e",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -36478,7 +36478,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "488c4432-dc95-4f39-82cd-d13100c5deec",
+              "id": "ec2d2492-85be-4c52-94dd-dcde16e967ff",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36538,7 +36538,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1d085c7f-4ea5-40cc-998b-c70b391ee8ba",
+                "id": "f19a5993-0361-4b51-acb8-93fed2174878",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservice/:skuserviceId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -36554,7 +36554,7 @@
           }
         },
         {
-          "id": "308ceecb-b7af-471c-a78a-2c88b921f397",
+          "id": "c58033fe-c8a2-4597-b079-2ebf97df4401",
           "name": "Create or update SKU service translation",
           "request": {
             "name": "Create or update SKU service translation",
@@ -36629,7 +36629,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3d8ffe54-2187-4eba-93e0-9148a8903c1f",
+              "id": "4e6a3dad-f6e7-4934-a222-53775ffbcc0a",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -36700,7 +36700,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c288abe2-69dd-42ad-b97c-c6c521e28262",
+              "id": "96eff3f3-80a9-4f45-8509-0ae56214728e",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -36771,7 +36771,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3b346274-479b-4f70-92eb-4d0330950625",
+              "id": "48910aa4-303a-47a4-b735-06bca22285c8",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -36842,7 +36842,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "55676f6d-7e9a-46ab-bc78-0658767641b2",
+              "id": "f564c689-1577-4fcc-938b-82cf1e624c7c",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -36914,7 +36914,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "267492d5-88fa-4de1-a58a-12e4b5d294c3",
+                "id": "547da57f-e763-4504-8f42-244ebcf0c273",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservice/:skuserviceId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -36927,7 +36927,7 @@
           }
         },
         {
-          "id": "b66a852b-85d8-4744-b952-579189651c18",
+          "id": "ec57405f-d6a9-4f67-8e2a-0b41df154e83",
           "name": "Get SKU service value translation",
           "request": {
             "name": "Get SKU service value translation",
@@ -37004,7 +37004,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bb0ffd22-ab51-42c3-96d9-5a39ecca1de9",
+              "id": "7f79a877-89af-476c-98d4-325715c3f502",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -37073,7 +37073,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8c8c23a0-99e2-4214-8984-05c811f6dc12",
+              "id": "d95447da-b892-4739-a2e9-c1487d6b8430",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37133,7 +37133,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4f18d035-b299-4cb8-8c3d-82f2ec360673",
+                "id": "7ca2694f-c2bc-4173-bc65-a3b3e2a5bd54",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -37149,7 +37149,7 @@
           }
         },
         {
-          "id": "cd3a89cd-4d58-47a7-bdce-82963255c9de",
+          "id": "8e913b7e-d565-470b-9c4b-775d66556602",
           "name": "Create or update SKU service value translation",
           "request": {
             "name": "Create or update SKU service value translation",
@@ -37224,7 +37224,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2b9eebc3-cf21-4005-922f-0fdfa1986114",
+              "id": "7113459a-e5d1-48ac-8f82-9a4c8cad18c3",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -37295,7 +37295,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7e3694c4-02d0-4c64-ade8-7fec42c68e01",
+              "id": "4c74c334-4b7a-4a47-9dd6-0e63497fd364",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -37366,7 +37366,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "fb353252-c5a0-4eb3-911e-16e7749e0c7e",
+              "id": "e6166a1e-e199-4d69-9b89-3001d3291eb2",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37437,7 +37437,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "295b1330-7127-4bba-b933-38c387888ac8",
+              "id": "3a78bb61-7fba-48a1-8f50-5ddcef47f00f",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -37509,7 +37509,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7bd131af-dd46-4aa6-9feb-3cfe9bb5f349",
+                "id": "b53b760a-6e4b-4af0-8069-55f404b6ca60",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/skuservicevalue/:skuServiceValueId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -37525,7 +37525,7 @@
       "event": []
     },
     {
-      "id": "a5a1494b-7bb9-41bf-a724-43abb341a432",
+      "id": "839d6a0d-d6f3-4a30-8355-229c9ac68b8f",
       "name": "Multi-language collection",
       "description": {
         "content": "",
@@ -37533,7 +37533,7 @@
       },
       "item": [
         {
-          "id": "6fa786fb-63a9-47f8-b8a8-106190517f57",
+          "id": "97380df1-0125-44d8-8ce2-96e8abd1932b",
           "name": "Get collection translation",
           "request": {
             "name": "Get collection translation",
@@ -37610,7 +37610,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c918d954-570a-4a7f-8b0a-36b988bf61eb",
+              "id": "34b8035a-3459-4cf1-8db2-5eb8cfd7333d",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -37679,7 +37679,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a8c9a841-ecee-497b-8392-3f215595cb7f",
+              "id": "3f43df42-1026-4514-a15f-41cf9a621af9",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -37739,7 +37739,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d86139b2-971e-43a6-ac2f-701086dfbfcc",
+                "id": "e68fe53b-11ac-4ddf-a2a2-2f89ebb34551",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog/pvt/collection/:collectionId/language/:locale - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -37755,7 +37755,7 @@
           }
         },
         {
-          "id": "0fe67ec8-20de-48dc-8b94-8622b2462e04",
+          "id": "e36edf4d-0070-4ff4-bd46-e7df698b4d73",
           "name": "Create or update collection translation",
           "request": {
             "name": "Create or update collection translation",
@@ -37830,7 +37830,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3db5cf70-aa14-4807-b9f2-ebbed65fab05",
+              "id": "be3f149e-e18a-4e94-901a-a23809c6ca9e",
               "name": "Created",
               "originalRequest": {
                 "url": {
@@ -37901,7 +37901,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c5cfbed5-dfee-4fef-b785-a209aaf007cd",
+              "id": "87ad770c-0a44-482e-b6d9-5bbc3b2a6648",
               "name": "Bad Request",
               "originalRequest": {
                 "url": {
@@ -37972,7 +37972,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "67b4dc7f-8d27-497b-9e19-ac3a74c6531e",
+              "id": "822f0f7d-f039-4e30-b412-92592dab01db",
               "name": "Not Found",
               "originalRequest": {
                 "url": {
@@ -38043,7 +38043,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "216b5706-d843-44ac-a40e-ee4d7e118630",
+              "id": "c8e10c12-3f70-4415-88c8-22cf56f61db0",
               "name": "Conflict",
               "originalRequest": {
                 "url": {
@@ -38115,7 +38115,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e645155e-18f6-44b1-98c6-1778da612e08",
+                "id": "c6928ecd-7dc0-444c-8128-5d8b4d83d406",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/catalog/pvt/collection/:collectionId/language - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -38131,7 +38131,7 @@
       "event": []
     },
     {
-      "id": "a4e5c231-4e8d-4a6c-9d27-8f6e47d23efb",
+      "id": "37fe95bc-a3e1-4bb5-a0de-b564da6fef9b",
       "name": "Product indexing",
       "description": {
         "content": "",
@@ -38139,7 +38139,7 @@
       },
       "item": [
         {
-          "id": "64d5e8bf-c327-4246-855f-52c1d2d780d0",
+          "id": "e5e2b890-f0f1-4ae0-821c-e73e754aa5af",
           "name": "Get product indexed information",
           "request": {
             "name": "Get product indexed information",
@@ -38205,7 +38205,7 @@
               "_": {
                 "postman_previewlanguage": "xml"
               },
-              "id": "bb0ed7ed-5cdd-4841-9082-10d17406d885",
+              "id": "5464d46a-2bb3-4bf0-b481-5351214812a2",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38274,7 +38274,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3bb10d66-11b9-49ca-a952-a71846dbf686",
+                "id": "6713ad1b-072b-4ecb-b3d7-141f16aeac90",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/products/GetIndexedInfo/:productId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38291,7 +38291,7 @@
       "event": []
     },
     {
-      "id": "50b66821-0a34-45a1-b02e-80ae05f6197d",
+      "id": "a59e4e9c-841c-42c0-8b50-73614af897d1",
       "name": "Commercial conditions",
       "description": {
         "content": "",
@@ -38299,7 +38299,7 @@
       },
       "item": [
         {
-          "id": "d741ce14-3f30-4955-9d48-dcc7304cd906",
+          "id": "abc51ecf-ba3f-401e-b723-9393b5494810",
           "name": "Get all commercial conditions",
           "request": {
             "name": "Get all commercial conditions",
@@ -38353,7 +38353,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ad4e5ab1-6f24-45fc-8081-b9c93a44c5b2",
+              "id": "a88b2ca4-a6b6-4a97-a2c4-04dc5baeeeab",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38421,7 +38421,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "adec12b9-823e-4852-a8ae-9b6ba5e9acd4",
+                "id": "6926a967-c20e-4c39-b6b9-627b06af7f81",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/commercialcondition/list - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38437,7 +38437,7 @@
           }
         },
         {
-          "id": "27b53ddf-e499-4da9-bcb3-8a5199e198e9",
+          "id": "89788846-fd95-4b81-8eab-6f1730699c15",
           "name": "Get commercial condition",
           "request": {
             "name": "Get commercial condition",
@@ -38502,7 +38502,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ae1a5372-e0af-4a7e-a4db-44a4a830e7cb",
+              "id": "80db7fcc-2648-4f80-90b9-f1bc1e87f223",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38570,7 +38570,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a4afc60a-3413-4b26-885d-ed84b9deca10",
+                "id": "d10c1118-0ee0-4056-be2b-ac776bd48291",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/catalog_system/pvt/commercialcondition/:commercialConditionId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38589,7 +38589,7 @@
       "event": []
     },
     {
-      "id": "b70b9f71-5c65-4779-959d-6c7005dce390",
+      "id": "ee53b5c7-6850-4c2a-a655-e30611a679be",
       "name": "Gift list",
       "description": {
         "content": "",
@@ -38597,7 +38597,7 @@
       },
       "item": [
         {
-          "id": "da67acc6-d1fe-40ad-9db7-4e6ea43f5cb7",
+          "id": "d4830c09-9ae9-4ee4-8efe-bb8b2622c273",
           "name": "Get gift list",
           "request": {
             "name": "Get gift list",
@@ -38663,7 +38663,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9f6c5839-21f7-43fe-9f6a-8bafde3a33c7",
+              "id": "09a1e941-7740-40af-8ffb-108967a932d8",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -38732,7 +38732,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "da3b2dbf-4cce-4b37-8430-dcde38099be4",
+                "id": "ddc5204c-0177-4faf-b0cb-c331b7d07211",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/addon/pvt/giftlist/get/:listId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -38790,7 +38790,7 @@
     }
   ],
   "info": {
-    "_postman_id": "c52ef862-3313-49a8-bdd4-8cbaf3a548cd",
+    "_postman_id": "6a4d6e50-11af-4db4-b939-ac4ad681926d",
     "name": "Catalog API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/VTEX - Catalog API.json
+++ b/VTEX - Catalog API.json
@@ -17349,11 +17349,6 @@
                                                 "type": "string",
                                                 "description": "Translated name of the specification."
                                             },
-                                            "Description": {
-                                                "type": "string",
-                                                "description": "Translated description of the specification.",
-                                                "nullable": true
-                                            },
                                             "Values": {
                                                 "type": "array",
                                                 "description": "List of the translated specification values.",
@@ -17371,7 +17366,6 @@
                                         "Id": 59,
                                         "Locale": "en-US",
                                         "Name": "Color",
-                                        "Description": "Navy blue",
                                         "Values": null
                                     }
                                 ]
@@ -17420,17 +17414,11 @@
                                         "type": "string",
                                         "description": "Translated name of the specification."
                                     },
-                                    "Description": {
-                                        "type": "string",
-                                        "description": "Translated description of the specification, limited to 15 characters. When updating, if the field is not provided, it will turn to `null`.",
-                                        "nullable": true
-                                    }
                                 }
                             },
                             "example": {
                                 "Locale": "en-US",
-                                "Name": "Color",
-                                "Description": "Navy blue"
+                                "Name": "Color"
                             }
                         }
                     }


### PR DESCRIPTION
## Problem

When translating a specification, the API request and response included a `Description` field. This field is no longer used, so it should be removed from the documentation and examples.

## Solution

Removed `Description` from the specification translation endpoints in both Postman collections and the API spec:

- **PostmanCollections/VTEX - Catalog API.json**
  - Removed `Description` from the GET specification translation example body
  - Removed `Description` from the response validation JSON schema
  - Removed `Description` from the PUT update translation example bodies
- **VTEX - Catalog API.json**
  - Removed `Description` from the GET response schema and example
  - Removed `Description` from the PUT update request schema and example