### PR TITLE
fix: use coordinate object in Search delivery zones request body

### DIFF
--- a/PostmanCollections/VTEX - Delivery Promise Suggestions API.json
+++ b/PostmanCollections/VTEX - Delivery Promise Suggestions API.json
@@ -65,7 +65,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"zipCode\": \"04538132\",\n  \"geoCoordinates\": \"-46.682033,-23.590057\",\n  \"country\": \"BRA\"\n}",
+              "raw": "{\n  \"zipCode\": \"04538132\",\n  \"coordinate\": {\n    \"latitude\": -23.590057,\n    \"longitude\": -46.682033\n  },\n  \"country\": \"BRA\"\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -155,7 +155,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"zipCode\": \"04538132\",\n  \"geoCoordinates\": \"-46.682033,-23.590057\",\n  \"country\": \"BRA\"\n}",
+                  "raw": "{\n  \"zipCode\": \"04538132\",\n  \"coordinate\": {\n    \"latitude\": -23.590057,\n    \"longitude\": -46.682033\n  },\n  \"country\": \"BRA\"\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",

--- a/PostmanCollections/VTEX - Delivery Promise Suggestions API.json
+++ b/PostmanCollections/VTEX - Delivery Promise Suggestions API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "6adfecca-19d1-4566-84ef-fb62d64df46a"
+    "postman_id": "d7e52c7c-1214-4369-98b6-e399a9588edc"
   },
   "item": [
     {
-      "id": "37f569c2-ebfd-43ac-8437-27431ea97aca",
+      "id": "37511f0a-485c-4c6f-8aa8-e1a23b7af91a",
       "name": "Logistics shipping",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "ddfedfea-b4c7-4f4b-9c28-94cbd8ccccfc",
+          "id": "93f5ffc5-b87d-4baa-bf6f-0c9718ca0643",
           "name": "Search delivery zones",
           "request": {
             "name": "Search delivery zones",
@@ -99,7 +99,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0321c7fb-5a57-4279-9c19-3c4c08d6f17e",
+              "id": "99d274ed-19ec-4090-9483-5dee31f1e4ba",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -180,7 +180,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b83de2c3-38fb-4edd-a1c0-363bdc6ed14b",
+                "id": "934abdf0-3a40-469a-a845-817a53eeb2bc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/logistics-shipping/delivery-zones/_search/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -196,7 +196,7 @@
           }
         },
         {
-          "id": "0b8c0e4a-dedd-4051-85c3-a75062f77aaa",
+          "id": "65d4612a-bb60-44c6-bbcf-5da9b39f4960",
           "name": "Search pickup points",
           "request": {
             "name": "Search pickup points",
@@ -292,7 +292,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5f51ac75-1414-4273-9df8-71b434f32301",
+              "id": "52cfda50-35d4-41e9-98d2-fa09ee3b1e8c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -382,7 +382,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7f3927ab-251c-42cc-bc79-a60f4504c7f1",
+                "id": "5f4b78d9-9c02-469e-ba74-7186f34ef7d5",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/logistics-shipping/pickuppoints/_search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -401,7 +401,7 @@
       "event": []
     },
     {
-      "id": "8202b8b4-5090-4e74-8876-5a90c277568c",
+      "id": "e84c40d8-4b50-4578-bcb2-47d2d65d0443",
       "name": "Delivery suggestions",
       "description": {
         "content": "",
@@ -409,7 +409,7 @@
       },
       "item": [
         {
-          "id": "3996e15b-b729-4dd3-b59d-2b79915bdd84",
+          "id": "dd1ae9c5-dca4-4156-91aa-007e7dedfe67",
           "name": "Search delivery suggestions",
           "request": {
             "name": "Search delivery suggestions",
@@ -494,7 +494,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dc183060-7ef6-4e2a-b3a6-df2f5fbe11c1",
+              "id": "c8aa0efa-1f2f-49e5-a189-f8ba7f75a42c",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -572,7 +572,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fe157b57-7f70-48b1-a82f-1c0b0ede274d",
+              "id": "789dd97f-2777-469e-b599-494158ae0bb6",
               "name": "The products array cannot be empty.",
               "originalRequest": {
                 "url": {
@@ -650,7 +650,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1eba3ce2-46c2-459c-a1a6-6dd63b501de3",
+              "id": "2d1e12bd-ef64-4d44-afde-5bbe84262b31",
               "name": "The maximum number of products allowed is 20.",
               "originalRequest": {
                 "url": {
@@ -728,7 +728,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "63c43a99-ee11-4e39-87f1-4fcaced309c3",
+              "id": "cfa3d747-91c0-4409-b1ac-d31e7bcedef1",
               "name": "The product list cannot be empty.",
               "originalRequest": {
                 "url": {
@@ -806,7 +806,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "afe01ccf-5865-4f47-bd61-cd5cde3e0526",
+              "id": "537bbc22-9caa-45f1-bed3-81e88eff7372",
               "name": "Unauthorized",
               "originalRequest": {
                 "url": {
@@ -884,7 +884,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dcc77e7c-e758-4308-a652-603b12aa8f4d",
+              "id": "0ba1c780-3b38-4fd8-805a-1ad1e079a6dc",
               "name": "Forbidden",
               "originalRequest": {
                 "url": {
@@ -962,7 +962,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8270006a-d764-4c19-be65-27d9b634437c",
+              "id": "f0d1541b-d083-4f4e-a69a-a3ba1a73636a",
               "name": "Too Many Requests",
               "originalRequest": {
                 "url": {
@@ -1040,7 +1040,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "bca7f422-0911-47c4-8759-4dba57e38cfe",
+              "id": "a03cc71d-81a9-41af-9ea1-a41ef8764ed7",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -1119,7 +1119,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4d0a9596-7b5d-452c-a448-925abf2b0e94",
+                "id": "9d049554-67f8-48e0-917b-53c83c529afa",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/delivery-promise-suggestions/_search - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1135,7 +1135,7 @@
           }
         },
         {
-          "id": "8a534bfb-c377-4c36-abba-db57fe00236f",
+          "id": "6b9b51ca-524b-4aaf-81da-ab34227992c6",
           "name": "Get delivery suggestions",
           "request": {
             "name": "Get delivery suggestions",
@@ -1243,7 +1243,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1eaf53fa-9185-4c78-99a4-879e7c30478f",
+              "id": "33a1cad1-4b4f-4a71-9c2c-2bfad915ac57",
               "name": "OK",
               "originalRequest": {
                 "url": {
@@ -1344,7 +1344,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2abd0715-9b69-4b99-904c-3e2cd83819e5",
+              "id": "33e8f6c1-aa28-4daa-b76f-523a2edacfc7",
               "name": "Unauthorized",
               "originalRequest": {
                 "url": {
@@ -1445,7 +1445,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "abe704a9-9b29-40eb-a380-2d27cfc9c482",
+              "id": "d696ec05-f02c-457f-80a9-4aeb685625ec",
               "name": "Too Many Requests",
               "originalRequest": {
                 "url": {
@@ -1546,7 +1546,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "79bb109e-9205-469f-9702-c66cca7e7754",
+              "id": "3dbe78e8-bce5-4b00-a30f-dd73eeefefb3",
               "name": "Internal Server Error",
               "originalRequest": {
                 "url": {
@@ -1648,7 +1648,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "886b0d08-bf45-4c7c-bad1-ef606a0ddd4a",
+                "id": "ca4ea77f-3de3-4f5a-a1f2-31eba105f487",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/delivery-promise-suggestions - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1686,7 +1686,7 @@
     }
   ],
   "info": {
-    "_postman_id": "6adfecca-19d1-4566-84ef-fb62d64df46a",
+    "_postman_id": "d7e52c7c-1214-4369-98b6-e399a9588edc",
     "name": "Delivery Promise Suggestions API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/VTEX - Delivery Promise Suggestions API.json
+++ b/VTEX - Delivery Promise Suggestions API.json
@@ -49,7 +49,10 @@
                             },
                             "example": {
                                 "zipCode": "04538132",
-                                "geoCoordinates": "-46.682033,-23.590057",
+                                "coordinate": {
+                                    "latitude": -23.590057,
+                                    "longitude": -46.682033
+                                },
                                 "country": "BRA"
                             }
                         }
@@ -761,9 +764,19 @@
                         "type": "string",
                         "description": "Postal code of the location."
                     },
-                    "geoCoordinates": {
-                        "type": "string",
-                        "description": "Geographic coordinates in the format \"longitude,latitude\"."
+                    "coordinate": {
+                        "type": "object",
+                        "description": "Geographic coordinates.",
+                        "properties": {
+                            "latitude": {
+                                "type": "number",
+                                "description": "Latitude of the location."
+                            },
+                            "longitude": {
+                                "type": "number",
+                                "description": "Longitude of the location."
+                            }
+                        }
                     },
                     "country": {
                         "type": "string",


### PR DESCRIPTION
## What

Fixes the request body of **Search delivery zones** (`POST /api/logistics-shipping/delivery-zones/_search/v2`) in the Delivery Promise Suggestions API.

The endpoint expects a `coordinate` **object** with numeric `latitude` and `longitude`, not the previous `geoCoordinates` **string** (`"longitude,latitude"`). This aligns it with the sibling **Search pickup points** endpoint, whose `PickupPointsSearchRequest` already uses the correct `coordinate` object shape.

**Correct body:**
```json
{
  "zipCode": "37075",
  "coordinate": {
    "latitude": 36.3868982,
    "longitude": -87.6406435
  },
  "country": "USA"
}
```

## Changes

- `VTEX - Delivery Promise Suggestions API.json`
  - `DeliveryZonesSearchRequest` schema: replaced the `geoCoordinates` string property with a `coordinate` object (`latitude`, `longitude` as numbers).
  - Updated the endpoint request example to the object form.
- `PostmanCollections/VTEX - Delivery Promise Suggestions API.json`
  - Updated both raw request bodies for Search delivery zones to the `coordinate` object form.

## Notes

- Unrelated `geoCoordinates` fields in other specs (e.g. Checkout / orderForm address model) are a different, valid field and were left untouched.
- `coordinate` was kept **optional** to preserve the existing contract (`required`: `zipCode`, `country`). If the API mandates a coordinate, add it to `required` — flagging for reviewer confirmation.
- Both JSON files validated as well-formed.
