### PR TITLE
EDU-19408: add Get product results by campaign endpoint to Ads API

### DIFF
--- a/PostmanCollections/VTEX - Ads API.json
+++ b/PostmanCollections/VTEX - Ads API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "f2d412cf-1d8b-47ef-8a1f-3ccbefae82be"
+    "postman_id": "31b7cec3-965c-4b7d-8606-ca59df4611d1"
   },
   "item": [
     {
-      "id": "f3656544-9af1-4992-aaab-356b2daac8c3",
+      "id": "1f05a99d-1825-4859-8c89-4d1094503e17",
       "name": "Catalog synchronization",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "d973abc6-055a-4b43-b34e-9c44add0cb84",
+          "id": "914f62b4-fb11-4bb0-a4ee-0329a9e2bb71",
           "name": "Synchronize product information",
           "request": {
             "name": "Synchronize product information",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5d2b3ea8-6ae1-4f20-912e-98c6545caded",
+              "id": "b614de2a-7fd4-4b85-8c4b-2baad2a6d0a6",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -155,7 +155,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "92bd86f9-3d24-4be8-9359-5ad44f3144f2",
+              "id": "b6a8e819-2bd1-4e8c-aad0-9048fec043cc",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -224,7 +224,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "386d6e2c-d4e5-4ea8-80ec-b54d55251a3c",
+                "id": "62d970a4-22de-496c-ab07-5eb6637a8a6e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -240,7 +240,7 @@
           }
         },
         {
-          "id": "60dc76f8-a85c-41bc-b6e2-a3d9b9aca473",
+          "id": "f074f06d-a8ff-4e69-b1ec-63fcc541a89b",
           "name": "Synchronize inventory information",
           "request": {
             "name": "Synchronize inventory information",
@@ -305,7 +305,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ce9dbdff-b203-40ea-9fa2-28e6735cebab",
+              "id": "d340be00-73c4-428b-87f4-5fdf7ff710e3",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -383,7 +383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "62bf0a61-9363-436f-b16f-38f2cf9c4f32",
+              "id": "6db1b3f8-20e1-4e3c-8856-b1e57583b88c",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -452,7 +452,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9fd406a7-c04f-47e3-9c84-11eff444d34f",
+                "id": "aea9b4bf-b1fc-4080-80f1-2880e61effa6",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/inventories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -471,7 +471,7 @@
       "event": []
     },
     {
-      "id": "aa28b06d-3a2f-42a4-b422-1e4027093fe9",
+      "id": "f3c2ceec-405d-4a15-9021-b2db0950ae66",
       "name": "Audiences",
       "description": {
         "content": "",
@@ -479,7 +479,7 @@
       },
       "item": [
         {
-          "id": "0f5c35b3-404e-4062-9eb1-5e8a0c08bf18",
+          "id": "98f64615-7e5f-493b-b1d2-07921c43cede",
           "name": "Generate audience upload URL",
           "request": {
             "name": "Generate audience upload URL",
@@ -521,7 +521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c025ae53-0da0-47ec-95ab-a0ee5b814199",
+              "id": "50096a98-d459-432d-acf9-5663078527fa",
               "name": "OK\n\nPresigned upload URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -576,7 +576,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0d998b2d-59c4-4c64-a710-3ae553be514b",
+              "id": "e57ed9f4-1a3e-4f0f-b509-d841f628a0ff",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "42338361-f335-4fc5-8d71-7c52eb1a37e9",
+                "id": "4476b3de-6b5a-4b92-893d-cab94e693ce3",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/audience/upload-url - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -641,7 +641,7 @@
       "event": []
     },
     {
-      "id": "faeefd8e-daa5-406e-9eab-536de0c1f68e",
+      "id": "ff36fd77-1f7b-4115-a1f3-e3a1fb8a4c18",
       "name": "Ads events notification",
       "description": {
         "content": "",
@@ -649,7 +649,7 @@
       },
       "item": [
         {
-          "id": "6f18cab3-a7f5-492a-99ec-842d8279813b",
+          "id": "998207e6-f88c-4227-a915-ec015a880845",
           "name": "Track ad impressions",
           "request": {
             "name": "Track ad impressions",
@@ -736,7 +736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3419d454-fe39-4cfc-ba5e-870ad092c343",
+              "id": "e727d473-ae91-40d8-a598-82f860272d0f",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -825,7 +825,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9fa18947-fa2d-4dca-b9bc-bb72f3400576",
+              "id": "78f4c9aa-f3f7-4906-ac04-5afc712c0e8f",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -914,7 +914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e70573a0-8f91-422b-abda-46a46f271534",
+              "id": "864a6c77-9791-4d10-b74a-18f5c6e85a6a",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -994,7 +994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "07db7974-0d2e-4daa-bf5b-419a03c9c4d0",
+                "id": "a2dc11d7-79db-4f06-a25c-879dbb0e9214",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/impression/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1010,7 +1010,7 @@
           }
         },
         {
-          "id": "e6093a21-9078-4e65-a990-939ebc74f210",
+          "id": "ac8ea883-d14a-45f4-b497-3279d00ef7e1",
           "name": "Track ad clicks",
           "request": {
             "name": "Track ad clicks",
@@ -1097,7 +1097,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a9f870e1-4020-41bd-8cad-19d7d7372d96",
+              "id": "c1302865-892b-4169-8244-64a797a3962a",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1186,7 +1186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "01836fa1-6ecd-441a-b5cc-6a30a060b6c3",
+              "id": "1bbcef30-ab2f-4776-9471-ea6946b95d81",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1275,7 +1275,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f1c1111d-b3a7-4731-b695-56cc955f8224",
+              "id": "1a3423c0-f85b-4074-a94a-c913a60de153",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1355,7 +1355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "850bbf41-0874-4758-ada3-5046ca1d40c0",
+                "id": "7f6e0774-053d-4666-a882-d6af6c45e774",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/click/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1371,7 +1371,7 @@
           }
         },
         {
-          "id": "2ed44453-2433-42a4-b5ef-75e524bb0533",
+          "id": "f74e2561-94ab-4c1c-9acf-6405e8f99bee",
           "name": "Track ad views",
           "request": {
             "name": "Track ad views",
@@ -1458,7 +1458,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ab60a0af-a1bc-4626-a30e-aa156ae950e4",
+              "id": "d3c51787-b3e2-44b5-a264-3601d07ebe50",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1547,7 +1547,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b28397b7-82af-4750-8ed5-4c128ac9297a",
+              "id": "60d6027b-f48f-4a65-83bb-71bd691cb839",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1636,7 +1636,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "be58d79b-8f3a-44de-9a2b-fc6fa868ab7a",
+              "id": "470610b1-4057-4594-80db-9a4456a2a55e",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1716,7 +1716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c3559e4f-1a61-4f79-a7e7-06b7e25d4474",
+                "id": "2caab2fb-1e5d-4204-9c67-a991b2b05f6e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/view/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1732,7 +1732,7 @@
           }
         },
         {
-          "id": "7d56365f-3580-4d27-a766-ba39307360fd",
+          "id": "9e67119d-375a-48ed-b595-6b13ef406d1a",
           "name": "Track conversions",
           "request": {
             "name": "Track conversions",
@@ -1797,7 +1797,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "59c7f6f2-6576-4ece-ae64-0f97f1f94498",
+              "id": "47c8a4c8-6e4c-4d09-aa8f-50d32624bf55",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -1875,7 +1875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9f814189-74df-4cc2-9b99-a3511b951769",
+              "id": "08feffbe-6dfd-41b2-8dc2-b2b025f0e698",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1944,7 +1944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7a6455e1-f675-4203-b85b-27244c6f057b",
+                "id": "11c83dc9-699a-4418-8b89-a768345280ad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/conversion - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1963,7 +1963,7 @@
       "event": []
     },
     {
-      "id": "e570293f-61fc-4930-b186-4153e1265ebb",
+      "id": "6727feef-cd45-4856-ba68-04e3db469237",
       "name": "Ads",
       "description": {
         "content": "",
@@ -1971,7 +1971,7 @@
       },
       "item": [
         {
-          "id": "5672f0de-3f82-4512-af05-95ba075477e4",
+          "id": "550b433f-6d4f-4688-80c4-5c6b5c61d0f0",
           "name": "Get ads",
           "request": {
             "name": "Get ads",
@@ -2047,7 +2047,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "51ca5f37-7e31-4277-9465-09a17222eb5c",
+              "id": "822b928f-cb0d-48ec-87aa-9ed934eab602",
               "name": "OK\n\nQuery processed successfully.",
               "originalRequest": {
                 "url": {
@@ -2125,7 +2125,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "aed95d01-ae68-46e7-acfd-5a00b25771eb",
+              "id": "17fc308d-d3b5-4e20-9c77-2480f3d38ddd",
               "name": "Bad Request\n\nInvalid request.",
               "originalRequest": {
                 "url": {
@@ -2193,7 +2193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d024914b-a813-4fcf-9ffb-f79040099855",
+              "id": "5fc9aa4b-3fb7-4dfb-8973-eb88f7ad297a",
               "name": "Not Found\n\nResource not found.",
               "originalRequest": {
                 "url": {
@@ -2261,7 +2261,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3747dd31-b077-448b-b523-b77ac1c7bf25",
+              "id": "83f26b45-1a40-4f4e-88cf-3594012f8a42",
               "name": "Unprocessable Entity\n\nField validation error.",
               "originalRequest": {
                 "url": {
@@ -2329,7 +2329,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "24cae327-9f09-47dd-a180-ef8dd4b5757d",
+              "id": "0014662b-b6d0-4886-acfc-6b1051229a3b",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -2398,7 +2398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "387fa737-e8ce-4174-b335-8df27ee3181b",
+                "id": "05d5f6c1-778f-4a73-b4aa-4091e0139fa4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/rma/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2417,7 +2417,7 @@
       "event": []
     },
     {
-      "id": "c0fbbcc2-df5c-46c0-80a6-eaa4b0d45130",
+      "id": "f50bdc03-93d4-4b6c-bedd-bcaa83dee83c",
       "name": "Reports",
       "description": {
         "content": "",
@@ -2425,7 +2425,7 @@
       },
       "item": [
         {
-          "id": "e98d6fdb-cfc1-41c1-9476-afd471cb5d92",
+          "id": "d3b9bab6-a37c-4aa2-96d9-da82bf527a36",
           "name": "Get advertisers report",
           "request": {
             "name": "Get advertisers report",
@@ -2541,7 +2541,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4045e265-5143-4bf0-b661-76195c601bad",
+              "id": "48fa323a-e8cb-4745-9d58-bb871133485d",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -2670,7 +2670,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7aa497a1-e315-46d0-a579-a517002212c0",
+              "id": "6ceab505-9d9d-4747-a4f2-657b677a5a8a",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2789,7 +2789,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0f21d77d-4913-4e71-ae18-0c7dd0406267",
+              "id": "03630b82-c99b-4556-9d9c-11c4b630160a",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -2919,7 +2919,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "7f5c6478-07d8-43ae-a373-75e73894d9ef",
+                "id": "c41c989e-7d10-4189-8ee6-ee89db3a02fc",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/advertisers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2935,7 +2935,7 @@
           }
         },
         {
-          "id": "f75c0456-7249-4cfd-b629-553d2490b902",
+          "id": "d1f0f15f-979e-4090-8f21-3fe7be9cf214",
           "name": "Get publishers report",
           "request": {
             "name": "Get publishers report",
@@ -3078,7 +3078,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "87778463-ad23-4cc7-a29a-2b081790fb3c",
+              "id": "24d5ea99-543b-4fa0-958b-d3ea355891c1",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3234,7 +3234,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "540ba753-87fa-4254-9817-ffb4f6e7212d",
+              "id": "997d2080-e9a4-4dc3-a4b2-45c34f6a6e7d",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3380,7 +3380,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "136a3c00-87ce-418e-b3e2-bf89097fe572",
+              "id": "358d028b-6a6d-48c7-924f-861d7ec6a426",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "417a4284-d62a-4c88-a839-d286833d7b5f",
+                "id": "7229a589-b1ae-4f7d-94e2-2f4c3733899c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3553,7 +3553,7 @@
           }
         },
         {
-          "id": "44cefa67-489d-49c6-8a87-723d0027d037",
+          "id": "1fab4993-a13c-4232-86b6-a9a8857a5d3d",
           "name": "Get network publishers report",
           "request": {
             "name": "Get network publishers report",
@@ -3696,7 +3696,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a5159425-9dd9-46bd-b8c9-3ce3f5a4b91d",
+              "id": "7a5605ec-fdfe-4d7f-971d-77c01ae3eba4",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3852,7 +3852,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b729a6c1-9f22-4af2-92a1-d204612b5522",
+              "id": "72d4472d-78bc-4640-b6ef-4c821fb73535",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3998,7 +3998,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "eea688d3-2d81-4282-a1f5-4879ceb3a4c6",
+              "id": "8e1a8044-8121-43a7-9ae5-396bfc9a1bd7",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4155,7 +4155,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "49bc6c26-720b-4041-8ac3-35fea3e02ddb",
+                "id": "378408c4-9011-497a-a6b2-f39b881891f7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/network/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4171,7 +4171,7 @@
           }
         },
         {
-          "id": "c09ffd20-2b39-4cfd-adf6-f077c1461993",
+          "id": "7616747e-ca3a-444f-bc8b-eb95d9a54187",
           "name": "List campaigns",
           "request": {
             "name": "List campaigns",
@@ -4340,7 +4340,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ba099870-b721-4be2-83da-ac42480834c1",
+              "id": "1b0fd9fc-79f2-489f-a30e-75e8d763f3a7",
               "name": "OK\n\nCampaigns returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4522,7 +4522,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6a0656e2-09f0-4aed-a333-c3dfeda2df2a",
+              "id": "ced12ea4-c1d2-4438-9742-b0cd211b0cf1",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4694,7 +4694,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "73e056b7-3d90-4868-88a3-fc57005b9838",
+              "id": "00af1724-d967-4e27-85a1-28f2b03122f8",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4877,7 +4877,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6a89b9ff-957f-4950-8f23-c46d02eefa80",
+                "id": "d710efa5-2296-4fee-a1be-155ed9289620",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4893,7 +4893,7 @@
           }
         },
         {
-          "id": "de870917-f038-4511-a1b7-04201ec37df6",
+          "id": "d71089d4-72df-4771-afd9-f8e9a4eca1fb",
           "name": "Get campaign details",
           "request": {
             "name": "Get campaign details",
@@ -4974,7 +4974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c3587b12-2019-4157-b8c8-59c642d6e3e7",
+              "id": "2a4f5581-7f03-4435-8e5d-e6dc02f4039c",
               "name": "OK\n\nCampaign returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5057,7 +5057,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "98eb3bc0-7b96-429d-b0e5-d771f17afe07",
+              "id": "4e6bd3b6-6256-4937-813e-99694a2f4e95",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5130,7 +5130,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0c61b117-baf8-4d6e-9d98-85b741590a15",
+              "id": "d09ecae7-ad44-4020-bbee-d3a1c681bf4e",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
@@ -5203,7 +5203,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3d6d80aa-16ae-4169-b98e-e716a5fdb765",
+              "id": "2547282f-6570-4200-b2d6-3c466481cd2f",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -5287,7 +5287,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9adfccfb-f6ed-479c-aff1-08d3add4d2f2",
+                "id": "88068869-938b-4632-a020-156fef00d6e7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5303,7 +5303,7 @@
           }
         },
         {
-          "id": "b80a69de-84a1-4153-8855-398f2c8a5d48",
+          "id": "d4fb0ded-7fd4-4dfd-92d7-4207b65e38e2",
           "name": "Get advertiser campaigns detailed report",
           "request": {
             "name": "Get advertiser campaigns detailed report",
@@ -5527,7 +5527,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a9fa9345-f774-498b-8f30-59dde4e65221",
+              "id": "3e0407dd-aca4-40df-946d-2d24560f1b8d",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5764,7 +5764,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f9208ad4-df68-4cd9-b3f5-b7b619301b5c",
+              "id": "6cd898d8-4f70-46fc-ba04-8c969c99c97d",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5991,7 +5991,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "69d186f5-2395-44cd-a370-9f17a8fea317",
+              "id": "83a72b3b-24de-49b9-b4b0-c722e724d297",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -6229,7 +6229,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fc31c7a7-b7ce-4f3e-a6c4-6b594231f502",
+                "id": "fa6124cf-0b41-42d9-bfa7-7ba5f1917322",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6245,7 +6245,7 @@
           }
         },
         {
-          "id": "d31ae865-80c4-4aa8-9ed1-0d489e1dde45",
+          "id": "72e8d47a-9464-4913-8514-21c8308c9e5c",
           "name": "Get advertiser ads detailed report",
           "request": {
             "name": "Get advertiser ads detailed report",
@@ -6487,7 +6487,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a038c73f-4d06-4ec3-a1dc-88224fecc210",
+              "id": "73eef359-e790-4137-ab4c-64f2ad4b40c2",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -6742,7 +6742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "af679f98-7c1d-40b0-8597-01a79423e6e6",
+              "id": "2abdd260-66ab-40de-88b0-2c6595646d75",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6987,7 +6987,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "9816efcf-5d5f-40f9-903f-37616e8675ba",
+              "id": "3218fe54-9463-43a6-87dd-72b120024822",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -7243,7 +7243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "90627735-23c2-4c17-b5c8-7cb03c607c96",
+                "id": "114985bf-d43a-4213-bf7d-ddb290f66dd4",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/ads-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7259,7 +7259,7 @@
           }
         },
         {
-          "id": "964a53cb-cfaa-4e26-96b4-2c3d594565ce",
+          "id": "e5d358c3-965a-4a29-97da-6deff9794b09",
           "name": "Get ads performance report",
           "request": {
             "name": "Get ads performance report",
@@ -7465,7 +7465,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fd120791-f81d-4bc3-9b34-45a5a24b7556",
+              "id": "20a5c889-d8f4-4684-98d5-815b9e6dc0aa",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -7684,7 +7684,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4bd31f55-052b-4a74-8e53-451423db177d",
+              "id": "e9d2696d-380b-457b-841a-4f5508abb5d2",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "68f5a160-337c-4077-bc63-825bd780103e",
+              "id": "a18a1f81-98e0-40ec-bfe5-19142d04e2b9",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -8113,7 +8113,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8f9744a8-1b48-485e-b98c-5a0be3b8856c",
+                "id": "656d2680-9133-43ba-9710-7304706c8931",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/ad/results/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8129,25 +8129,32 @@
           }
         },
         {
-          "id": "9121db49-0336-4b5c-aa7e-9311743e3057",
+          "id": "334fef92-0fed-457d-8f49-c91b0b7f8425",
           "name": "Get product results by campaign",
           "request": {
             "name": "Get product results by campaign",
             "description": {
-              "content": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current date.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current date.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified by the `campaign_id` query parameter, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
               "path": [
                 "product",
-                "result",
-                "by-campaign",
-                ":campaign_id"
+                "results"
               ],
               "host": [
                 "{{baseUrl}}"
               ],
               "query": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) Unique identifier of the campaign to fetch product results for.",
+                    "type": "text/plain"
+                  },
+                  "key": "campaign_id",
+                  "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3"
+                },
                 {
                   "disabled": true,
                   "description": {
@@ -8212,18 +8219,7 @@
                   "value": "true"
                 }
               ],
-              "variable": [
-                {
-                  "disabled": false,
-                  "description": {
-                    "content": "(Required) Unique identifier of the campaign to fetch product results for.",
-                    "type": "text/plain"
-                  },
-                  "type": "any",
-                  "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3",
-                  "key": "campaign_id"
-                }
-              ]
+              "variable": []
             },
             "header": [
               {
@@ -8248,20 +8244,27 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b396f9e6-e6b6-4898-aac9-ad403d7c73ea",
+              "id": "61eee7ec-f122-4650-84f7-c9d5214f86de",
               "name": "Paginated response (default)",
               "originalRequest": {
                 "url": {
                   "path": [
                     "product",
-                    "result",
-                    "by-campaign",
-                    ":campaign_id"
+                    "results"
                   ],
                   "host": [
                     "{{baseUrl}}"
                   ],
                   "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Unique identifier of the campaign to fetch product results for.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3"
+                    },
                     {
                       "disabled": true,
                       "description": {
@@ -8369,20 +8372,27 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ea4a1b0e-8408-488f-b0aa-2540b8efc960",
+              "id": "aeab427d-bc1f-4ab9-8d2a-e2f1455900de",
               "name": "Array response when `count=false`",
               "originalRequest": {
                 "url": {
                   "path": [
                     "product",
-                    "result",
-                    "by-campaign",
-                    ":campaign_id"
+                    "results"
                   ],
                   "host": [
                     "{{baseUrl}}"
                   ],
                   "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Unique identifier of the campaign to fetch product results for.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3"
+                    },
                     {
                       "disabled": true,
                       "description": {
@@ -8490,20 +8500,27 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "5d15af27-c492-4cc3-998a-ddbd2120f465",
+              "id": "3c04bc02-9881-4d4b-a658-3e3fe7a420a8",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "product",
-                    "result",
-                    "by-campaign",
-                    ":campaign_id"
+                    "results"
                   ],
                   "host": [
                     "{{baseUrl}}"
                   ],
                   "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Unique identifier of the campaign to fetch product results for.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3"
+                    },
                     {
                       "disabled": true,
                       "description": {
@@ -8601,20 +8618,27 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "165b399f-b0fb-4824-8bb6-91b0f0c40d3e",
+              "id": "55b4d76f-157f-4a2d-bbbe-5d17d09ec58f",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "product",
-                    "result",
-                    "by-campaign",
-                    ":campaign_id"
+                    "results"
                   ],
                   "host": [
                     "{{baseUrl}}"
                   ],
                   "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Unique identifier of the campaign to fetch product results for.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3"
+                    },
                     {
                       "disabled": true,
                       "description": {
@@ -8712,20 +8736,27 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a2a3b891-d3ce-4c5e-be89-a052fe7332b6",
+              "id": "b2c7c431-4cf7-45fa-aa66-6cf3801175ff",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
                   "path": [
                     "product",
-                    "result",
-                    "by-campaign",
-                    ":campaign_id"
+                    "results"
                   ],
                   "host": [
                     "{{baseUrl}}"
                   ],
                   "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) Unique identifier of the campaign to fetch product results for.",
+                        "type": "text/plain"
+                      },
+                      "key": "campaign_id",
+                      "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3"
+                    },
                     {
                       "disabled": true,
                       "description": {
@@ -8834,13 +8865,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "92fbf5cc-181a-4f91-b6c3-e8a157a785ad",
+                "id": "75af1668-7f4c-4bfd-9506-da6befcf4d21",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate status 2xx \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
-                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"title\":\"Paginated response\",\"description\":\"Returned by default or when `count=true`. Wraps the product results in a pagination envelope.\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of products.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of product result objects.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category breadcrumb path, with levels separated by ` > `.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}}},{\"type\":\"array\",\"title\":\"Array response\",\"description\":\"Returned when `count=false`. Contains the product results without the pagination envelope.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category breadcrumb path, with levels separated by ` > `.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate status 2xx \npm.test(\"[GET]::/product/results - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/product/results - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/product/results - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"title\":\"Paginated response\",\"description\":\"Returned by default or when `count=true`. Wraps the product results in a pagination envelope.\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of products.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of product result objects.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category breadcrumb path, with levels separated by ` > `.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}}},{\"type\":\"array\",\"title\":\"Array response\",\"description\":\"Returned when `count=false`. Contains the product results without the pagination envelope.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category breadcrumb path, with levels separated by ` > `.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/product/results - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -8853,7 +8884,7 @@
       "event": []
     },
     {
-      "id": "6de9bb9e-2fa5-4b49-a63b-0a14b000961b",
+      "id": "adae2a7c-f49e-44b6-96ed-e7a7981e40ff",
       "name": "Credit transfer",
       "description": {
         "content": "",
@@ -8861,7 +8892,7 @@
       },
       "item": [
         {
-          "id": "5041c5e2-603b-4e28-819c-d908a8a06285",
+          "id": "137e2824-e7dc-4d69-a6d6-9961432a7002",
           "name": "Notify credit transfer status",
           "request": {
             "name": "Notify credit transfer status",
@@ -8954,7 +8985,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6bba97f7-9204-4279-a3ce-1dd421131840",
+              "id": "991c43bd-b88e-4445-a452-7cbc54bc19d6",
               "name": "No Content\n\nNotification accepted.",
               "originalRequest": {
                 "url": {
@@ -9023,7 +9054,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2620ccf1-aee3-497e-8c12-bc79889b03df",
+              "id": "4abdd6a1-3180-44cd-a37a-1f0e4aced62e",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -9093,7 +9124,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "646b7617-75b5-4d17-b030-2073a3c66014",
+                "id": "bd720d5d-96e8-40a5-9c2c-aa48cec03530",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/webhook/marketplace/transfers/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9110,7 +9141,7 @@
       "event": []
     },
     {
-      "id": "5a5958ce-98a6-45df-9a38-d3ac2a37feda",
+      "id": "f5ab690e-ae0d-4d6e-9d0f-ac77759e379e",
       "name": "Single sign-on",
       "description": {
         "content": "",
@@ -9118,7 +9149,7 @@
       },
       "item": [
         {
-          "id": "9bd6d106-d44e-4a51-a4d6-973217147f02",
+          "id": "affd843f-fc49-478c-98fb-62eef597815a",
           "name": "Generate seller single sign-on URL",
           "request": {
             "name": "Generate seller single sign-on URL",
@@ -9182,7 +9213,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1164f82c-9ef6-4aa8-822b-baadc0cd8156",
+              "id": "5f64345c-c549-4d2f-aaba-0c9c1c740c38",
               "name": "OK\n\nRedirect URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -9259,7 +9290,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7e902751-e90d-403c-97de-1ac5ec97e78d",
+              "id": "056f9c12-16d4-4efa-812c-7772e7fcaad3",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -9327,7 +9358,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "c177d6c8-9267-41a2-9be7-81f0e8d021d8",
+                "id": "2940cdcc-91c1-4171-ab86-d00209d63564",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/sso/marketplace - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9375,7 +9406,7 @@
     }
   ],
   "info": {
-    "_postman_id": "f2d412cf-1d8b-47ef-8a1f-3ccbefae82be",
+    "_postman_id": "31b7cec3-965c-4b7d-8606-ca59df4611d1",
     "name": "VTEX Ads API",
     "version": {
       "raw": "1.0.0",

--- a/PostmanCollections/VTEX - Ads API.json
+++ b/PostmanCollections/VTEX - Ads API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "72917313-af3b-44c0-9788-41cf77acd7b4"
+    "postman_id": "f2d412cf-1d8b-47ef-8a1f-3ccbefae82be"
   },
   "item": [
     {
-      "id": "9e1df6c4-3a10-4486-ad20-dedc24f75633",
+      "id": "f3656544-9af1-4992-aaab-356b2daac8c3",
       "name": "Catalog synchronization",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "976cf5f7-e2a5-4049-8a2f-bc22653a83e7",
+          "id": "d973abc6-055a-4b43-b34e-9c44add0cb84",
           "name": "Synchronize product information",
           "request": {
             "name": "Synchronize product information",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "64adf3ad-7869-4d9a-9fbd-08d4e8dcb9a8",
+              "id": "5d2b3ea8-6ae1-4f20-912e-98c6545caded",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -155,7 +155,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "35ec16b6-1fcf-4582-a3a0-519609c2608e",
+              "id": "92bd86f9-3d24-4be8-9359-5ad44f3144f2",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -224,7 +224,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "747a6a70-578e-44f6-b8e5-1a92fe515dec",
+                "id": "386d6e2c-d4e5-4ea8-80ec-b54d55251a3c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -240,7 +240,7 @@
           }
         },
         {
-          "id": "7934e623-1ab6-4d07-bd6b-c8b9e019868c",
+          "id": "60dc76f8-a85c-41bc-b6e2-a3d9b9aca473",
           "name": "Synchronize inventory information",
           "request": {
             "name": "Synchronize inventory information",
@@ -305,7 +305,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "13cde107-7bcc-4d08-b06b-fb286ae33c0c",
+              "id": "ce9dbdff-b203-40ea-9fa2-28e6735cebab",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -383,7 +383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3ee9f416-29c1-4dc6-b481-e0101c383680",
+              "id": "62bf0a61-9363-436f-b16f-38f2cf9c4f32",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -452,7 +452,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1834ecd0-f73e-441e-8a80-f7255c384bbd",
+                "id": "9fd406a7-c04f-47e3-9c84-11eff444d34f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/inventories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -471,7 +471,7 @@
       "event": []
     },
     {
-      "id": "5bca977b-8b02-4f8d-9193-051033d3ef2f",
+      "id": "aa28b06d-3a2f-42a4-b422-1e4027093fe9",
       "name": "Audiences",
       "description": {
         "content": "",
@@ -479,7 +479,7 @@
       },
       "item": [
         {
-          "id": "a4f5b916-e502-4e10-80ed-2f02e2d05639",
+          "id": "0f5c35b3-404e-4062-9eb1-5e8a0c08bf18",
           "name": "Generate audience upload URL",
           "request": {
             "name": "Generate audience upload URL",
@@ -521,7 +521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5be4ae18-3537-425e-b8bd-ec0aaf1b6a75",
+              "id": "c025ae53-0da0-47ec-95ab-a0ee5b814199",
               "name": "OK\n\nPresigned upload URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -576,7 +576,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9fdfee42-80db-4284-9df4-629f2a380cc9",
+              "id": "0d998b2d-59c4-4c64-a710-3ae553be514b",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "45c28bb2-20f5-4cb8-b6a0-f3664ea0e186",
+                "id": "42338361-f335-4fc5-8d71-7c52eb1a37e9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/audience/upload-url - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -641,7 +641,7 @@
       "event": []
     },
     {
-      "id": "f831cdb7-9e86-4ee4-ac50-64674703718b",
+      "id": "faeefd8e-daa5-406e-9eab-536de0c1f68e",
       "name": "Ads events notification",
       "description": {
         "content": "",
@@ -649,7 +649,7 @@
       },
       "item": [
         {
-          "id": "6a7123ab-30db-49f7-b9eb-fa99b15dd944",
+          "id": "6f18cab3-a7f5-492a-99ec-842d8279813b",
           "name": "Track ad impressions",
           "request": {
             "name": "Track ad impressions",
@@ -736,7 +736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2ac7027c-a950-401e-a286-b4a73f277bde",
+              "id": "3419d454-fe39-4cfc-ba5e-870ad092c343",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -825,7 +825,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0c78b94a-6158-4f8d-8426-d55dd2aea8a7",
+              "id": "9fa18947-fa2d-4dca-b9bc-bb72f3400576",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -914,7 +914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "52988364-010b-4723-9099-ebc65cd9d31a",
+              "id": "e70573a0-8f91-422b-abda-46a46f271534",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -994,7 +994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "57fadac8-0a8e-40d4-82f2-868e1a908ab7",
+                "id": "07db7974-0d2e-4daa-bf5b-419a03c9c4d0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/impression/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1010,7 +1010,7 @@
           }
         },
         {
-          "id": "1074f365-9636-44be-9dfd-b294f88131f3",
+          "id": "e6093a21-9078-4e65-a990-939ebc74f210",
           "name": "Track ad clicks",
           "request": {
             "name": "Track ad clicks",
@@ -1097,7 +1097,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "cade1919-8f1e-4856-9993-046407552e79",
+              "id": "a9f870e1-4020-41bd-8cad-19d7d7372d96",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1186,7 +1186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ecb64ba4-3955-40f2-9417-679b9441dd53",
+              "id": "01836fa1-6ecd-441a-b5cc-6a30a060b6c3",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1275,7 +1275,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "919a83c0-ff8f-4d78-8d70-03b1556273c8",
+              "id": "f1c1111d-b3a7-4731-b695-56cc955f8224",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1355,7 +1355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "59873d56-a817-488d-be46-bfe61b0b33ea",
+                "id": "850bbf41-0874-4758-ada3-5046ca1d40c0",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/click/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1371,7 +1371,7 @@
           }
         },
         {
-          "id": "a0ee0ad4-6a43-4964-a23c-f44001273f3c",
+          "id": "2ed44453-2433-42a4-b5ef-75e524bb0533",
           "name": "Track ad views",
           "request": {
             "name": "Track ad views",
@@ -1458,7 +1458,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0918dd4b-78e2-4e81-a079-48da61495172",
+              "id": "ab60a0af-a1bc-4626-a30e-aa156ae950e4",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1547,7 +1547,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c5b46d9b-66ff-4aee-9a70-dc34de49124b",
+              "id": "b28397b7-82af-4750-8ed5-4c128ac9297a",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1636,7 +1636,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "82884656-b369-4d74-91da-8c79d7886bc6",
+              "id": "be58d79b-8f3a-44de-9a2b-fc6fa868ab7a",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1716,7 +1716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "0837f421-fbbd-4b36-bc91-d8f9423fc940",
+                "id": "c3559e4f-1a61-4f79-a7e7-06b7e25d4474",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/view/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1732,7 +1732,7 @@
           }
         },
         {
-          "id": "7edaece7-ef1a-4224-8f93-2e5f277cf1c1",
+          "id": "7d56365f-3580-4d27-a766-ba39307360fd",
           "name": "Track conversions",
           "request": {
             "name": "Track conversions",
@@ -1797,7 +1797,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d7a88b7b-2716-442a-9c2f-48e4f08df092",
+              "id": "59c7f6f2-6576-4ece-ae64-0f97f1f94498",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -1875,7 +1875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "188163dd-096b-4238-b883-5aa078121e85",
+              "id": "9f814189-74df-4cc2-9b99-a3511b951769",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1944,7 +1944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "68c1776d-7fa6-4a02-bf20-f8aca3f1660f",
+                "id": "7a6455e1-f675-4203-b85b-27244c6f057b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/conversion - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1963,7 +1963,7 @@
       "event": []
     },
     {
-      "id": "7a6db046-90c8-48af-a7cb-437384f423a9",
+      "id": "e570293f-61fc-4930-b186-4153e1265ebb",
       "name": "Ads",
       "description": {
         "content": "",
@@ -1971,7 +1971,7 @@
       },
       "item": [
         {
-          "id": "1f096d11-9ed4-451b-adcc-7d9c14527f3f",
+          "id": "5672f0de-3f82-4512-af05-95ba075477e4",
           "name": "Get ads",
           "request": {
             "name": "Get ads",
@@ -2047,7 +2047,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e3663217-e463-464a-8d2b-f152343854da",
+              "id": "51ca5f37-7e31-4277-9465-09a17222eb5c",
               "name": "OK\n\nQuery processed successfully.",
               "originalRequest": {
                 "url": {
@@ -2125,7 +2125,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "64cc078c-b715-414a-a54d-df0e28bcd6a5",
+              "id": "aed95d01-ae68-46e7-acfd-5a00b25771eb",
               "name": "Bad Request\n\nInvalid request.",
               "originalRequest": {
                 "url": {
@@ -2193,7 +2193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9710646d-dd51-4500-a05f-7b3c6b95ad14",
+              "id": "d024914b-a813-4fcf-9ffb-f79040099855",
               "name": "Not Found\n\nResource not found.",
               "originalRequest": {
                 "url": {
@@ -2261,7 +2261,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "90191fd8-eab3-42be-898f-db04bbe0c7cc",
+              "id": "3747dd31-b077-448b-b523-b77ac1c7bf25",
               "name": "Unprocessable Entity\n\nField validation error.",
               "originalRequest": {
                 "url": {
@@ -2329,7 +2329,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "192edccc-b1dd-4e8a-8df2-007c5ebac93d",
+              "id": "24cae327-9f09-47dd-a180-ef8dd4b5757d",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -2398,7 +2398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6b132c12-d463-4fdf-925d-912c5ca37564",
+                "id": "387fa737-e8ce-4174-b335-8df27ee3181b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/rma/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2417,7 +2417,7 @@
       "event": []
     },
     {
-      "id": "296fbfad-f4c0-4a61-98f1-8d6857085cea",
+      "id": "c0fbbcc2-df5c-46c0-80a6-eaa4b0d45130",
       "name": "Reports",
       "description": {
         "content": "",
@@ -2425,7 +2425,7 @@
       },
       "item": [
         {
-          "id": "e5715d70-d321-4d13-89fd-f1df17756888",
+          "id": "e98d6fdb-cfc1-41c1-9476-afd471cb5d92",
           "name": "Get advertisers report",
           "request": {
             "name": "Get advertisers report",
@@ -2541,7 +2541,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "1bb9216e-1ead-4538-82a5-271d525684b0",
+              "id": "4045e265-5143-4bf0-b661-76195c601bad",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -2670,7 +2670,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d54dee08-8fca-455c-bc88-8bbc0090c237",
+              "id": "7aa497a1-e315-46d0-a579-a517002212c0",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2789,7 +2789,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "25ceb438-ecbb-4a09-8632-c8b07ef06538",
+              "id": "0f21d77d-4913-4e71-ae18-0c7dd0406267",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -2919,7 +2919,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fa8ad6ac-8680-4a35-843f-3a5dadffac12",
+                "id": "7f5c6478-07d8-43ae-a373-75e73894d9ef",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/advertisers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2935,7 +2935,7 @@
           }
         },
         {
-          "id": "0425d2b7-de34-41d6-969b-b99a0357f4fd",
+          "id": "f75c0456-7249-4cfd-b629-553d2490b902",
           "name": "Get publishers report",
           "request": {
             "name": "Get publishers report",
@@ -3078,7 +3078,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "0afe4ea7-e568-4326-85e9-6869a24a676d",
+              "id": "87778463-ad23-4cc7-a29a-2b081790fb3c",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3234,7 +3234,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b9a0609e-d59c-4660-8f18-ae929d56da19",
+              "id": "540ba753-87fa-4254-9817-ffb4f6e7212d",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3380,7 +3380,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "255a6296-ba00-4556-ad7f-73d2c244e70a",
+              "id": "136a3c00-87ce-418e-b3e2-bf89097fe572",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8365028f-2862-46a2-9298-ce36caf88b37",
+                "id": "417a4284-d62a-4c88-a839-d286833d7b5f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3553,7 +3553,7 @@
           }
         },
         {
-          "id": "901225b2-c8db-44fe-8b20-db6bdec52747",
+          "id": "44cefa67-489d-49c6-8a87-723d0027d037",
           "name": "Get network publishers report",
           "request": {
             "name": "Get network publishers report",
@@ -3696,7 +3696,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "65358337-ca52-456c-9a59-846b7b2829b3",
+              "id": "a5159425-9dd9-46bd-b8c9-3ce3f5a4b91d",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3852,7 +3852,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c72069d7-d2a1-4a33-b3d8-2d3ef84e93f6",
+              "id": "b729a6c1-9f22-4af2-92a1-d204612b5522",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3998,7 +3998,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6ead74e6-5ed6-4310-83d5-054f2f270508",
+              "id": "eea688d3-2d81-4282-a1f5-4879ceb3a4c6",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4155,7 +4155,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1a634277-1c65-44c5-b103-e604d042cba9",
+                "id": "49bc6c26-720b-4041-8ac3-35fea3e02ddb",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/network/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4171,7 +4171,7 @@
           }
         },
         {
-          "id": "a2b4750a-573e-4f02-bd3a-18ad69fd3a7f",
+          "id": "c09ffd20-2b39-4cfd-adf6-f077c1461993",
           "name": "List campaigns",
           "request": {
             "name": "List campaigns",
@@ -4340,7 +4340,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "65564c5f-5a22-444f-ae8e-ab15b6c96a6c",
+              "id": "ba099870-b721-4be2-83da-ac42480834c1",
               "name": "OK\n\nCampaigns returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4522,7 +4522,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "d9c9683c-9f3e-4402-8386-1a5805cd0419",
+              "id": "6a0656e2-09f0-4aed-a333-c3dfeda2df2a",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4694,7 +4694,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8cfedbc2-ce90-482f-965b-eed8e841c2cd",
+              "id": "73e056b7-3d90-4868-88a3-fc57005b9838",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4877,7 +4877,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "394ca34c-7835-4257-82f8-3a8a37a01688",
+                "id": "6a89b9ff-957f-4950-8f23-c46d02eefa80",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4893,7 +4893,7 @@
           }
         },
         {
-          "id": "1fbd41ee-5503-41e7-8fc1-b8f741afcf0a",
+          "id": "de870917-f038-4511-a1b7-04201ec37df6",
           "name": "Get campaign details",
           "request": {
             "name": "Get campaign details",
@@ -4974,7 +4974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "230f72cf-a84d-4488-81c6-8f29a9bc022a",
+              "id": "c3587b12-2019-4157-b8c8-59c642d6e3e7",
               "name": "OK\n\nCampaign returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5057,7 +5057,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4f52ae58-e09f-4a6b-be68-fdd03f2e4ae0",
+              "id": "98eb3bc0-7b96-429d-b0e5-d771f17afe07",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5130,7 +5130,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bfd12e34-413f-4666-a309-f1aad7e2fea2",
+              "id": "0c61b117-baf8-4d6e-9d98-85b741590a15",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
@@ -5203,7 +5203,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "aebd5fe3-784e-46a2-b9dd-1c0b8db63972",
+              "id": "3d6d80aa-16ae-4169-b98e-e716a5fdb765",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -5287,7 +5287,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4e9193a1-e539-496e-8aed-d5dd2ea1d4c2",
+                "id": "9adfccfb-f6ed-479c-aff1-08d3add4d2f2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5303,7 +5303,7 @@
           }
         },
         {
-          "id": "7c581285-642d-4ade-a8c2-a321aa75128c",
+          "id": "b80a69de-84a1-4153-8855-398f2c8a5d48",
           "name": "Get advertiser campaigns detailed report",
           "request": {
             "name": "Get advertiser campaigns detailed report",
@@ -5527,7 +5527,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "15782aba-af08-43df-9498-a4633f3cd944",
+              "id": "a9fa9345-f774-498b-8f30-59dde4e65221",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5764,7 +5764,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "2ef00b1b-a1a5-4b23-897f-1aa5fd54e0f7",
+              "id": "f9208ad4-df68-4cd9-b3f5-b7b619301b5c",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5991,7 +5991,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e9788f9d-9382-4255-a4c8-5fc1843ce8ef",
+              "id": "69d186f5-2395-44cd-a370-9f17a8fea317",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -6229,7 +6229,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "20dbe821-0f05-4c7e-a38d-551f32fdb625",
+                "id": "fc31c7a7-b7ce-4f3e-a6c4-6b594231f502",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6245,7 +6245,7 @@
           }
         },
         {
-          "id": "f3ab3741-2b2b-464d-9624-79deddd668a7",
+          "id": "d31ae865-80c4-4aa8-9ed1-0d489e1dde45",
           "name": "Get advertiser ads detailed report",
           "request": {
             "name": "Get advertiser ads detailed report",
@@ -6487,7 +6487,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b0e6589a-15d6-4663-b006-dee4b9086484",
+              "id": "a038c73f-4d06-4ec3-a1dc-88224fecc210",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -6742,7 +6742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e3de6bbe-c0dc-4f27-a2d0-3d77810931e4",
+              "id": "af679f98-7c1d-40b0-8597-01a79423e6e6",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6987,7 +6987,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "4fa7dc41-5bcb-4856-92e1-29d259ba2585",
+              "id": "9816efcf-5d5f-40f9-903f-37616e8675ba",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -7243,7 +7243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "22afe640-9f70-4e4e-932b-7ae21769106e",
+                "id": "90627735-23c2-4c17-b5c8-7cb03c607c96",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/ads-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7259,7 +7259,7 @@
           }
         },
         {
-          "id": "24f6a0b0-866a-45a1-b840-6c050104e992",
+          "id": "964a53cb-cfaa-4e26-96b4-2c3d594565ce",
           "name": "Get ads performance report",
           "request": {
             "name": "Get ads performance report",
@@ -7465,7 +7465,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "27dc19cd-ee79-4079-9cc0-8927748923cf",
+              "id": "fd120791-f81d-4bc3-9b34-45a5a24b7556",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -7684,7 +7684,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b8a9152a-6fbe-4673-bab1-17e50116d8b2",
+              "id": "4bd31f55-052b-4a74-8e53-451423db177d",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f527299f-994e-4679-883c-c01d11428f2f",
+              "id": "68f5a160-337c-4077-bc63-825bd780103e",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -8113,7 +8113,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a5503df4-bfdb-4ca3-8a81-ab2da658cd6b",
+                "id": "8f9744a8-1b48-485e-b98c-5a0be3b8856c",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/ad/results/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8129,12 +8129,12 @@
           }
         },
         {
-          "id": "d67a17a3-513c-437b-b39d-ea1eb5507594",
+          "id": "9121db49-0336-4b5c-aa7e-9311743e3057",
           "name": "Get product results by campaign",
           "request": {
             "name": "Get product results by campaign",
             "description": {
-              "content": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current day.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "content": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current date.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
               "type": "text/plain"
             },
             "url": {
@@ -8178,7 +8178,7 @@
                 {
                   "disabled": true,
                   "description": {
-                    "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                    "content": "Sort direction. Unrecognized values fall back to `desc`.",
                     "type": "text/plain"
                   },
                   "key": "order_direction",
@@ -8248,7 +8248,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "603d067c-60ac-41b8-9734-c7e3164c0c3a",
+              "id": "b396f9e6-e6b6-4898-aac9-ad403d7c73ea",
               "name": "Paginated response (default)",
               "originalRequest": {
                 "url": {
@@ -8292,7 +8292,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "content": "Sort direction. Unrecognized values fall back to `desc`.",
                         "type": "text/plain"
                       },
                       "key": "order_direction",
@@ -8362,15 +8362,15 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"total\": 2,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73\",\n      \"name\": \"Product Name\",\n      \"product_sku\": \"SKU-123\",\n      \"image_url\": \"https://example.com/image.png\",\n      \"categories\": [\n        \"National Beers\",\n        \"National Beers > Drinks\"\n      ],\n      \"active\": true,\n      \"impressions\": \"2900\",\n      \"impressions_cost\": \"29.00\",\n      \"clicks\": \"53\",\n      \"clicks_cost\": \"79.50\",\n      \"views\": \"2689\",\n      \"conversions\": \"12\",\n      \"conversions_quantity\": \"18\",\n      \"conversions_value\": \"5361.00\"\n    },\n    {\n      \"id\": \"c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab\",\n      \"name\": \"Other Product Name\",\n      \"product_sku\": \"SKU-456\",\n      \"image_url\": \"https://example.com/other-image.png\",\n      \"categories\": null,\n      \"active\": false,\n      \"impressions\": \"0\",\n      \"impressions_cost\": \"0.00\",\n      \"clicks\": \"0\",\n      \"clicks_cost\": \"0.00\",\n      \"views\": \"0\",\n      \"conversions\": \"0\",\n      \"conversions_quantity\": \"0\",\n      \"conversions_value\": \"0.00\"\n    }\n  ]\n}",
+              "body": "{\n  \"total\": 51,\n  \"pages\": 2,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"a9c9e0e8-8e9a-41e5-af26-29f6eb5c3b83\",\n      \"name\": \"Extratora de Sujeira e Água e Higienizadora Vertical Wap Comfort Cleaner Pro 2000W 2 em 1 para Tapetes Carpetes e Estofados\",\n      \"product_sku\": \"55004728\",\n      \"image_url\": \"https://imgs.casasbahia.com.br/55004728/1xg.jpg\",\n      \"categories\": [\n        \"Eletroportáteis\",\n        \"Eletroportáteis > Aspiradores e Acessórios\",\n        \"Eletroportáteis > Aspiradores e Acessórios > Aspirador Água e Pó\"\n      ],\n      \"active\": false,\n      \"impressions\": \"0\",\n      \"impressions_cost\": \"0\",\n      \"clicks\": \"0\",\n      \"clicks_cost\": \"0\",\n      \"views\": \"0\",\n      \"conversions\": \"0\",\n      \"conversions_quantity\": \"0\",\n      \"conversions_value\": \"0\"\n    },\n    {\n      \"id\": \"2b19df76-0596-43cb-892d-a364dcaaf054\",\n      \"name\": \"Lavadora de Alta Pressão WAP Ousada WL 2610 Ultra 1750PSI 1500W – Cinza e Amarelo\",\n      \"product_sku\": \"55065795\",\n      \"image_url\": \"https://imgs.casasbahia.com.br/55065795/1g.jpg\",\n      \"categories\": [\n        \"Ferramentas\",\n        \"Ferramentas > Lavadoras de Pressão\",\n        \"Ferramentas > Lavadoras de Pressão > Lavadoras Residenciais\"\n      ],\n      \"active\": true,\n      \"impressions\": \"0\",\n      \"impressions_cost\": \"0.00000000\",\n      \"clicks\": \"0\",\n      \"clicks_cost\": \"0.00000000\",\n      \"views\": \"0\",\n      \"conversions\": \"2\",\n      \"conversions_quantity\": \"2\",\n      \"conversions_value\": \"1107.76\"\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5db26831-0966-4df8-989e-c41db8e35596",
-              "name": "Array response when count=false",
+              "id": "ea4a1b0e-8408-488f-b0aa-2540b8efc960",
+              "name": "Array response when `count=false`",
               "originalRequest": {
                 "url": {
                   "path": [
@@ -8413,7 +8413,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "content": "Sort direction. Unrecognized values fall back to `desc`.",
                         "type": "text/plain"
                       },
                       "key": "order_direction",
@@ -8483,14 +8483,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "[\n  {\n    \"id\": \"5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73\",\n    \"name\": \"Product Name\",\n    \"product_sku\": \"SKU-123\",\n    \"image_url\": \"https://example.com/image.png\",\n    \"categories\": [\n      \"National Beers\",\n      \"National Beers > Drinks\"\n    ],\n    \"active\": true,\n    \"impressions\": \"2900\",\n    \"impressions_cost\": \"29.00\",\n    \"clicks\": \"53\",\n    \"clicks_cost\": \"79.50\",\n    \"views\": \"2689\",\n    \"conversions\": \"12\",\n    \"conversions_quantity\": \"18\",\n    \"conversions_value\": \"5361.00\"\n  },\n  {\n    \"id\": \"c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab\",\n    \"name\": \"Other Product Name\",\n    \"product_sku\": \"SKU-456\",\n    \"image_url\": \"https://example.com/other-image.png\",\n    \"categories\": null,\n    \"active\": false,\n    \"impressions\": \"0\",\n    \"impressions_cost\": \"0.00\",\n    \"clicks\": \"0\",\n    \"clicks_cost\": \"0.00\",\n    \"views\": \"0\",\n    \"conversions\": \"0\",\n    \"conversions_quantity\": \"0\",\n    \"conversions_value\": \"0.00\"\n  }\n]",
+              "body": "[\n  {\n    \"id\": \"a9c9e0e8-8e9a-41e5-af26-29f6eb5c3b83\",\n    \"name\": \"Extratora de Sujeira e Água e Higienizadora Vertical Wap Comfort Cleaner Pro 2000W 2 em 1 para Tapetes Carpetes e Estofados\",\n    \"product_sku\": \"55004728\",\n    \"image_url\": \"https://imgs.casasbahia.com.br/55004728/1xg.jpg\",\n    \"categories\": [\n      \"Eletroportáteis\",\n      \"Eletroportáteis > Aspiradores e Acessórios\",\n      \"Eletroportáteis > Aspiradores e Acessórios > Aspirador Água e Pó\"\n    ],\n    \"active\": false,\n    \"impressions\": \"0\",\n    \"impressions_cost\": \"0\",\n    \"clicks\": \"0\",\n    \"clicks_cost\": \"0\",\n    \"views\": \"0\",\n    \"conversions\": \"0\",\n    \"conversions_quantity\": \"0\",\n    \"conversions_value\": \"0\"\n  },\n  {\n    \"id\": \"2b19df76-0596-43cb-892d-a364dcaaf054\",\n    \"name\": \"Lavadora de Alta Pressão WAP Ousada WL 2610 Ultra 1750PSI 1500W – Cinza e Amarelo\",\n    \"product_sku\": \"55065795\",\n    \"image_url\": \"https://imgs.casasbahia.com.br/55065795/1g.jpg\",\n    \"categories\": [\n      \"Ferramentas\",\n      \"Ferramentas > Lavadoras de Pressão\",\n      \"Ferramentas > Lavadoras de Pressão > Lavadoras Residenciais\"\n    ],\n    \"active\": true,\n    \"impressions\": \"0\",\n    \"impressions_cost\": \"0.00000000\",\n    \"clicks\": \"0\",\n    \"clicks_cost\": \"0.00000000\",\n    \"views\": \"0\",\n    \"conversions\": \"2\",\n    \"conversions_quantity\": \"2\",\n    \"conversions_value\": \"1107.76\"\n  }\n]",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "3d1083cf-1b5b-412f-8a1e-466d77e560f8",
+              "id": "5d15af27-c492-4cc3-998a-ddbd2120f465",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -8534,7 +8534,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "content": "Sort direction. Unrecognized values fall back to `desc`.",
                         "type": "text/plain"
                       },
                       "key": "order_direction",
@@ -8601,7 +8601,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "671df341-1833-46f2-b82f-5538d41ccd6f",
+              "id": "165b399f-b0fb-4824-8bb6-91b0f0c40d3e",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
@@ -8645,7 +8645,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "content": "Sort direction. Unrecognized values fall back to `desc`.",
                         "type": "text/plain"
                       },
                       "key": "order_direction",
@@ -8712,7 +8712,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "15b323c8-2f12-479b-9a9b-f455f329dd3e",
+              "id": "a2a3b891-d3ce-4c5e-be89-a052fe7332b6",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -8756,7 +8756,7 @@
                     {
                       "disabled": true,
                       "description": {
-                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "content": "Sort direction. Unrecognized values fall back to `desc`.",
                         "type": "text/plain"
                       },
                       "key": "order_direction",
@@ -8834,13 +8834,13 @@
             {
               "listen": "test",
               "script": {
-                "id": "f874413d-9fbd-45b6-b57c-c1e46fee33d6",
+                "id": "92fbf5cc-181a-4f91-b6c3-e8a157a785ad",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
                   "// Validate if response has JSON Body \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"title\":\"Paginated response\",\"description\":\"Returned by default or when `count=true`. Wraps the product results in a pagination envelope.\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of products.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of product result objects.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"Category path list for the product. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category name or full category path.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of viewability.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}}},{\"type\":\"array\",\"title\":\"Array response\",\"description\":\"Returned when `count=false`. Contains the product results without the pagination envelope.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"Category path list for the product. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category name or full category path.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of viewability.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"title\":\"Paginated response\",\"description\":\"Returned by default or when `count=true`. Wraps the product results in a pagination envelope.\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of products.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of product result objects.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category breadcrumb path, with levels separated by ` > `.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}}},{\"type\":\"array\",\"title\":\"Array response\",\"description\":\"Returned when `count=false`. Contains the product results without the pagination envelope.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category breadcrumb path, with levels separated by ` > `.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -8853,7 +8853,7 @@
       "event": []
     },
     {
-      "id": "36c84173-eb68-4889-b7b2-b0bfd92f2c2f",
+      "id": "6de9bb9e-2fa5-4b49-a63b-0a14b000961b",
       "name": "Credit transfer",
       "description": {
         "content": "",
@@ -8861,7 +8861,7 @@
       },
       "item": [
         {
-          "id": "db9bb4f5-e043-451c-976b-9d24abd106a2",
+          "id": "5041c5e2-603b-4e28-819c-d908a8a06285",
           "name": "Notify credit transfer status",
           "request": {
             "name": "Notify credit transfer status",
@@ -8954,7 +8954,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "acb05e7c-1828-4db2-9e13-9016e1b533c2",
+              "id": "6bba97f7-9204-4279-a3ce-1dd421131840",
               "name": "No Content\n\nNotification accepted.",
               "originalRequest": {
                 "url": {
@@ -9023,7 +9023,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "edef63b3-75a6-41df-9fa8-951d07b4318f",
+              "id": "2620ccf1-aee3-497e-8c12-bc79889b03df",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -9093,7 +9093,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "14b0ec70-612e-4437-8c80-18b530e247ef",
+                "id": "646b7617-75b5-4d17-b030-2073a3c66014",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/webhook/marketplace/transfers/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9110,7 +9110,7 @@
       "event": []
     },
     {
-      "id": "61fade7c-3fed-40a9-9b36-936f9395fd32",
+      "id": "5a5958ce-98a6-45df-9a38-d3ac2a37feda",
       "name": "Single sign-on",
       "description": {
         "content": "",
@@ -9118,7 +9118,7 @@
       },
       "item": [
         {
-          "id": "e2b06c59-d98a-4b4d-ab53-feb3faaa2219",
+          "id": "9bd6d106-d44e-4a51-a4d6-973217147f02",
           "name": "Generate seller single sign-on URL",
           "request": {
             "name": "Generate seller single sign-on URL",
@@ -9182,7 +9182,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "e167396e-5adf-476e-8f04-94221dc0e5ef",
+              "id": "1164f82c-9ef6-4aa8-822b-baadc0cd8156",
               "name": "OK\n\nRedirect URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -9259,7 +9259,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "141236a2-622b-419e-93c8-ea64c932e6af",
+              "id": "7e902751-e90d-403c-97de-1ac5ec97e78d",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -9327,7 +9327,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a7ec2213-2407-4227-9ac5-3cbc3ae254c9",
+                "id": "c177d6c8-9267-41a2-9be7-81f0e8d021d8",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/sso/marketplace - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -9375,7 +9375,7 @@
     }
   ],
   "info": {
-    "_postman_id": "72917313-af3b-44c0-9788-41cf77acd7b4",
+    "_postman_id": "f2d412cf-1d8b-47ef-8a1f-3ccbefae82be",
     "name": "VTEX Ads API",
     "version": {
       "raw": "1.0.0",

--- a/PostmanCollections/VTEX - Ads API.json
+++ b/PostmanCollections/VTEX - Ads API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "07266f83-32a3-496b-9316-34e53ff3a829"
+    "postman_id": "72917313-af3b-44c0-9788-41cf77acd7b4"
   },
   "item": [
     {
-      "id": "ec289d64-7f1a-4c66-9665-ea435ac4ead4",
+      "id": "9e1df6c4-3a10-4486-ad20-dedc24f75633",
       "name": "Catalog synchronization",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "49dade55-e150-4c69-bb33-5e35e5c3d490",
+          "id": "976cf5f7-e2a5-4049-8a2f-bc22653a83e7",
           "name": "Synchronize product information",
           "request": {
             "name": "Synchronize product information",
@@ -77,7 +77,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "c955fffd-c675-4349-b37f-419b26c1b784",
+              "id": "64adf3ad-7869-4d9a-9fbd-08d4e8dcb9a8",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -155,7 +155,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "53b401ff-06fb-44d5-ac0f-e0a95a5b249c",
+              "id": "35ec16b6-1fcf-4582-a3a0-519609c2608e",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -224,7 +224,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8b66afb7-67c3-4e43-ad40-a9122ddb2eda",
+                "id": "747a6a70-578e-44f6-b8e5-1a92fe515dec",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/products - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -240,7 +240,7 @@
           }
         },
         {
-          "id": "4b865ed2-7de4-451e-8c9a-5cc75c5ac18c",
+          "id": "7934e623-1ab6-4d07-bd6b-c8b9e019868c",
           "name": "Synchronize inventory information",
           "request": {
             "name": "Synchronize inventory information",
@@ -305,7 +305,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "3928bff3-71a3-4a0c-a1d1-accd55ac926c",
+              "id": "13cde107-7bcc-4d08-b06b-fb286ae33c0c",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -383,7 +383,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cd395085-3aba-4d2e-9bef-a09a571986ab",
+              "id": "3ee9f416-29c1-4dc6-b481-e0101c383680",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -452,7 +452,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "6d0a6ca5-0d98-49cd-a02b-ac07ec3438aa",
+                "id": "1834ecd0-f73e-441e-8a80-f7255c384bbd",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/product/bulk/inventories - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -471,7 +471,7 @@
       "event": []
     },
     {
-      "id": "84d72c7c-4a64-4b96-8afe-28dbe1c09b01",
+      "id": "5bca977b-8b02-4f8d-9193-051033d3ef2f",
       "name": "Audiences",
       "description": {
         "content": "",
@@ -479,7 +479,7 @@
       },
       "item": [
         {
-          "id": "8648df2e-8da3-4f57-a0e8-b056de80aa90",
+          "id": "a4f5b916-e502-4e10-80ed-2f02e2d05639",
           "name": "Generate audience upload URL",
           "request": {
             "name": "Generate audience upload URL",
@@ -521,7 +521,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fce073ae-a113-4223-9e3e-ec79308432f6",
+              "id": "5be4ae18-3537-425e-b8bd-ec0aaf1b6a75",
               "name": "OK\n\nPresigned upload URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -576,7 +576,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bb0b05f4-b70f-41fd-b2d7-0ec3b0551cc5",
+              "id": "9fdfee42-80db-4284-9df4-629f2a380cc9",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -622,7 +622,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3b56f9f3-f918-4296-a156-b54058c47276",
+                "id": "45c28bb2-20f5-4cb8-b6a0-f3664ea0e186",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/audience/upload-url - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -641,7 +641,7 @@
       "event": []
     },
     {
-      "id": "2bb69c36-1187-411d-985b-91aaf32edae8",
+      "id": "f831cdb7-9e86-4ee4-ac50-64674703718b",
       "name": "Ads events notification",
       "description": {
         "content": "",
@@ -649,7 +649,7 @@
       },
       "item": [
         {
-          "id": "a40a3986-3f87-4268-892c-e9f9f2e561e9",
+          "id": "6a7123ab-30db-49f7-b9eb-fa99b15dd944",
           "name": "Track ad impressions",
           "request": {
             "name": "Track ad impressions",
@@ -736,7 +736,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b5c14d35-59a5-46d3-bf34-2dc851882df5",
+              "id": "2ac7027c-a950-401e-a286-b4a73f277bde",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -825,7 +825,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "6d0cb76f-383b-48bf-b43c-34e21959ad18",
+              "id": "0c78b94a-6158-4f8d-8426-d55dd2aea8a7",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -914,7 +914,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b9b89fde-d0c0-4a5f-b547-b746fb686f55",
+              "id": "52988364-010b-4723-9099-ebc65cd9d31a",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -994,7 +994,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "e945b31f-c18a-4112-967a-9563b5b8514e",
+                "id": "57fadac8-0a8e-40d4-82f2-868e1a908ab7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/impression/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1010,7 +1010,7 @@
           }
         },
         {
-          "id": "d5a32e0c-050d-47a1-9883-496f51356f7e",
+          "id": "1074f365-9636-44be-9dfd-b294f88131f3",
           "name": "Track ad clicks",
           "request": {
             "name": "Track ad clicks",
@@ -1097,7 +1097,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f0a73153-000b-408f-958b-ae0796c2c547",
+              "id": "cade1919-8f1e-4856-9993-046407552e79",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1186,7 +1186,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "43bbfc09-1699-4f4a-ad06-8b5dc5bfb6af",
+              "id": "ecb64ba4-3955-40f2-9417-679b9441dd53",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1275,7 +1275,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "85d3be5d-92a3-44e8-b776-bdc0b9fa6afb",
+              "id": "919a83c0-ff8f-4d78-8d70-03b1556273c8",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1355,7 +1355,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "3628113d-5852-4785-b5aa-e65000dcb7fc",
+                "id": "59873d56-a817-488d-be46-bfe61b0b33ea",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/click/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1371,7 +1371,7 @@
           }
         },
         {
-          "id": "8b0ee435-15da-476e-b497-02f503a8b377",
+          "id": "a0ee0ad4-6a43-4964-a23c-f44001273f3c",
           "name": "Track ad views",
           "request": {
             "name": "Track ad views",
@@ -1458,7 +1458,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "539ed201-c7a3-4805-90ec-935059d38767",
+              "id": "0918dd4b-78e2-4e81-a079-48da61495172",
               "name": "Identified user",
               "originalRequest": {
                 "url": {
@@ -1547,7 +1547,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f34fde51-c6ef-470c-bb15-8e83cad9a2dd",
+              "id": "c5b46d9b-66ff-4aee-9a70-dc34de49124b",
               "name": "Anonymous session",
               "originalRequest": {
                 "url": {
@@ -1636,7 +1636,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "805602ab-7b76-411f-bfb3-fe92014518fe",
+              "id": "82884656-b369-4d74-91da-8c79d7886bc6",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1716,7 +1716,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "72eb84ca-7f6b-416d-80f7-97020e524f4a",
+                "id": "0837f421-fbbd-4b36-bc91-d8f9423fc940",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/view/:ad_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1732,7 +1732,7 @@
           }
         },
         {
-          "id": "60efdcb6-8e9e-4104-949e-d471d94fd4eb",
+          "id": "7edaece7-ef1a-4224-8f93-2e5f277cf1c1",
           "name": "Track conversions",
           "request": {
             "name": "Track conversions",
@@ -1797,7 +1797,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a109c660-e6e1-4f8d-afa0-09ef069b57a5",
+              "id": "d7a88b7b-2716-442a-9c2f-48e4f08df092",
               "name": "Accepted",
               "originalRequest": {
                 "url": {
@@ -1875,7 +1875,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "597c00a6-9ae3-4cef-91e0-c148b02c1996",
+              "id": "188163dd-096b-4238-b883-5aa078121e85",
               "name": "Validation Error",
               "originalRequest": {
                 "url": {
@@ -1944,7 +1944,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "9666e80f-5814-460a-9882-89caed14cab9",
+                "id": "68c1776d-7fa6-4a02-bf20-f8aca3f1660f",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/beacon/conversion - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1963,7 +1963,7 @@
       "event": []
     },
     {
-      "id": "48897e02-a94a-4726-a6bd-ac2bf47b51e3",
+      "id": "7a6db046-90c8-48af-a7cb-437384f423a9",
       "name": "Ads",
       "description": {
         "content": "",
@@ -1971,7 +1971,7 @@
       },
       "item": [
         {
-          "id": "2aab6393-f674-41b4-9d27-7c289f9cac05",
+          "id": "1f096d11-9ed4-451b-adcc-7d9c14527f3f",
           "name": "Get ads",
           "request": {
             "name": "Get ads",
@@ -2047,7 +2047,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "90091c8a-bae1-40ac-a65c-d7f8d8f830d7",
+              "id": "e3663217-e463-464a-8d2b-f152343854da",
               "name": "OK\n\nQuery processed successfully.",
               "originalRequest": {
                 "url": {
@@ -2125,7 +2125,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "026e482d-25a5-4843-82d4-5431d01486cd",
+              "id": "64cc078c-b715-414a-a54d-df0e28bcd6a5",
               "name": "Bad Request\n\nInvalid request.",
               "originalRequest": {
                 "url": {
@@ -2193,7 +2193,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ce70e0c8-1028-4443-82a8-d36a46a5748a",
+              "id": "9710646d-dd51-4500-a05f-7b3c6b95ad14",
               "name": "Not Found\n\nResource not found.",
               "originalRequest": {
                 "url": {
@@ -2261,7 +2261,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "62535ca0-4d42-4b0c-844e-a2d1fdf4476e",
+              "id": "90191fd8-eab3-42be-898f-db04bbe0c7cc",
               "name": "Unprocessable Entity\n\nField validation error.",
               "originalRequest": {
                 "url": {
@@ -2329,7 +2329,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1236fce0-735d-4dd5-936b-3745f76facc8",
+              "id": "192edccc-b1dd-4e8a-8df2-007c5ebac93d",
               "name": "Too Many Requests\n\nRate limit exceeded.",
               "originalRequest": {
                 "url": {
@@ -2398,7 +2398,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "eff677b7-5b16-4489-9d3e-8299b59f7a2b",
+                "id": "6b132c12-d463-4fdf-925d-912c5ca37564",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/v1/rma/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2417,7 +2417,7 @@
       "event": []
     },
     {
-      "id": "38bddacf-3a38-4752-91b8-3e541a4e844b",
+      "id": "296fbfad-f4c0-4a61-98f1-8d6857085cea",
       "name": "Reports",
       "description": {
         "content": "",
@@ -2425,7 +2425,7 @@
       },
       "item": [
         {
-          "id": "4060b9e5-3b9e-42bd-bd9b-8e6d7f1fd87f",
+          "id": "e5715d70-d321-4d13-89fd-f1df17756888",
           "name": "Get advertisers report",
           "request": {
             "name": "Get advertisers report",
@@ -2541,7 +2541,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fbacbef1-8113-49ea-997d-65c6f77a4e89",
+              "id": "1bb9216e-1ead-4538-82a5-271d525684b0",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -2670,7 +2670,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0d59789a-6198-438c-98f4-6ec13fb5a0d7",
+              "id": "d54dee08-8fca-455c-bc88-8bbc0090c237",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -2789,7 +2789,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "5b51b370-db3d-4c59-97df-a7e307e7ab02",
+              "id": "25ceb438-ecbb-4a09-8632-c8b07ef06538",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -2919,7 +2919,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b4c98c6a-fe6e-4a6b-aab8-145323911db8",
+                "id": "fa8ad6ac-8680-4a35-843f-3a5dadffac12",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/advertisers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2935,7 +2935,7 @@
           }
         },
         {
-          "id": "5ac14834-8ab2-48ec-89af-6c4bed6dcc81",
+          "id": "0425d2b7-de34-41d6-969b-b99a0357f4fd",
           "name": "Get publishers report",
           "request": {
             "name": "Get publishers report",
@@ -3078,7 +3078,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "28436b8c-5aa7-403f-842c-ae6cd3325ccc",
+              "id": "0afe4ea7-e568-4326-85e9-6869a24a676d",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3234,7 +3234,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "bf5d23cc-92a6-4fb5-9677-8c26ce65286d",
+              "id": "b9a0609e-d59c-4660-8f18-ae929d56da19",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3380,7 +3380,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d462a9f4-934c-4055-85f5-ae8856450bf2",
+              "id": "255a6296-ba00-4556-ad7f-73d2c244e70a",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -3537,7 +3537,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "fccec12f-71cb-43bd-bd34-6a92b1cd98d0",
+                "id": "8365028f-2862-46a2-9298-ce36caf88b37",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/v2/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -3553,7 +3553,7 @@
           }
         },
         {
-          "id": "861385e1-390e-475e-8711-bf75130e9a3f",
+          "id": "901225b2-c8db-44fe-8b20-db6bdec52747",
           "name": "Get network publishers report",
           "request": {
             "name": "Get network publishers report",
@@ -3696,7 +3696,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f6d0c498-d17b-4c4f-b862-1d998d46552b",
+              "id": "65358337-ca52-456c-9a59-846b7b2829b3",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -3852,7 +3852,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "1c2701bf-3007-432a-820a-e427578fd044",
+              "id": "c72069d7-d2a1-4a33-b3d8-2d3ef84e93f6",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -3998,7 +3998,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dd76abb7-e1a4-4e77-b10d-a65c8f33a8d1",
+              "id": "6ead74e6-5ed6-4310-83d5-054f2f270508",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4155,7 +4155,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "a03fd31c-afcd-4b8f-a704-6aa97b903604",
+                "id": "1a634277-1c65-44c5-b103-e604d042cba9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/network/publishers - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4171,7 +4171,7 @@
           }
         },
         {
-          "id": "65568426-151c-4aeb-98f5-96e4a43b9363",
+          "id": "a2b4750a-573e-4f02-bd3a-18ad69fd3a7f",
           "name": "List campaigns",
           "request": {
             "name": "List campaigns",
@@ -4340,7 +4340,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "f77e40a5-bdb9-455f-98b7-549d6dc8c43c",
+              "id": "65564c5f-5a22-444f-ae8e-ab15b6c96a6c",
               "name": "OK\n\nCampaigns returned successfully.",
               "originalRequest": {
                 "url": {
@@ -4522,7 +4522,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "f386f9fb-24d6-4b44-b5e8-69ec275b4d6a",
+              "id": "d9c9683c-9f3e-4402-8386-1a5805cd0419",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -4694,7 +4694,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "255d0526-e825-40a1-8840-80960a504ef2",
+              "id": "8cfedbc2-ce90-482f-965b-eed8e841c2cd",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -4877,7 +4877,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "d4d63d0c-bea2-414e-824a-8f7b80c6fbd2",
+                "id": "394ca34c-7835-4257-82f8-3a8a37a01688",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -4893,7 +4893,7 @@
           }
         },
         {
-          "id": "703c2da0-722d-4b8d-a440-9f59a0d03575",
+          "id": "1fbd41ee-5503-41e7-8fc1-b8f741afcf0a",
           "name": "Get campaign details",
           "request": {
             "name": "Get campaign details",
@@ -4974,7 +4974,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a46f474e-9623-4d3b-b655-3a073ff1db25",
+              "id": "230f72cf-a84d-4488-81c6-8f29a9bc022a",
               "name": "OK\n\nCampaign returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5057,7 +5057,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "977b97fe-92dd-42c2-bf0a-ac88d9f27414",
+              "id": "4f52ae58-e09f-4a6b-be68-fdd03f2e4ae0",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5130,7 +5130,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "472a9635-5e7e-42d8-8a40-2eb09f33120e",
+              "id": "bfd12e34-413f-4666-a309-f1aad7e2fea2",
               "name": "Not Found\n\nCampaign not found.",
               "originalRequest": {
                 "url": {
@@ -5203,7 +5203,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a7673247-d60d-47b5-9806-61e07f42cf89",
+              "id": "aebd5fe3-784e-46a2-b9dd-1c0b8db63972",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -5287,7 +5287,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "39cc9dff-d7df-4a67-bff9-aa6bb07e9a41",
+                "id": "4e9193a1-e539-496e-8aed-d5dd2ea1d4c2",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -5303,7 +5303,7 @@
           }
         },
         {
-          "id": "55c12ebd-e5a5-4266-a80a-283aacf2b1f7",
+          "id": "7c581285-642d-4ade-a8c2-a321aa75128c",
           "name": "Get advertiser campaigns detailed report",
           "request": {
             "name": "Get advertiser campaigns detailed report",
@@ -5527,7 +5527,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "8aefcf65-a959-469d-9c46-4396a05cee86",
+              "id": "15782aba-af08-43df-9498-a4633f3cd944",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -5764,7 +5764,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "4aebfc85-18c5-4173-9886-5468c74f1c56",
+              "id": "2ef00b1b-a1a5-4b23-897f-1aa5fd54e0f7",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -5991,7 +5991,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a3cd5b4d-ef8a-4582-90a4-7ba60868775b",
+              "id": "e9788f9d-9382-4255-a4c8-5fc1843ce8ef",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -6229,7 +6229,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "4846db69-7c71-4ef6-82d1-dd1661761090",
+                "id": "20dbe821-0f05-4c7e-a38d-551f32fdb625",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/campaigns-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -6245,7 +6245,7 @@
           }
         },
         {
-          "id": "52127348-9053-46e4-a94c-060940f452de",
+          "id": "f3ab3741-2b2b-464d-9624-79deddd668a7",
           "name": "Get advertiser ads detailed report",
           "request": {
             "name": "Get advertiser ads detailed report",
@@ -6487,7 +6487,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "11902eb2-3a0b-469b-ac3c-ec2f3c94717e",
+              "id": "b0e6589a-15d6-4663-b006-dee4b9086484",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -6742,7 +6742,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "171d1006-ff0f-439c-9c07-0d34aefa5b29",
+              "id": "e3de6bbe-c0dc-4f27-a2d0-3d77810931e4",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -6987,7 +6987,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "b132b171-e5ee-474b-9e35-6a9f57e57489",
+              "id": "4fa7dc41-5bcb-4856-92e1-29d259ba2585",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -7243,7 +7243,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "80dd7821-628e-42b2-a896-1e74f2ce5058",
+                "id": "22afe640-9f70-4e4e-932b-7ae21769106e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/report/advertisers/ads-detailed - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -7259,7 +7259,7 @@
           }
         },
         {
-          "id": "a8a41263-19ca-45cb-b083-537fb440e712",
+          "id": "24f6a0b0-866a-45a1-b840-6c050104e992",
           "name": "Get ads performance report",
           "request": {
             "name": "Get ads performance report",
@@ -7465,7 +7465,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "dd28c346-a577-47b0-a0d0-b288092d1b54",
+              "id": "27dc19cd-ee79-4079-9cc0-8927748923cf",
               "name": "OK\n\nReport returned successfully.",
               "originalRequest": {
                 "url": {
@@ -7684,7 +7684,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7155b510-100a-454a-b303-0276a710452c",
+              "id": "b8a9152a-6fbe-4673-bab1-17e50116d8b2",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -7893,7 +7893,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d9e9b227-0a1a-4c01-9b75-7385b26b81fe",
+              "id": "f527299f-994e-4679-883c-c01d11428f2f",
               "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
               "originalRequest": {
                 "url": {
@@ -8113,7 +8113,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "22538372-387e-45f7-b7cb-74a9fa6dbe41",
+                "id": "a5503df4-bfdb-4ca3-8a81-ab2da658cd6b",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/ad/results/v2 - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8127,12 +8127,733 @@
           "protocolProfileBehavior": {
             "disableBodyPruning": true
           }
+        },
+        {
+          "id": "d67a17a3-513c-437b-b39d-ea1eb5507594",
+          "name": "Get product results by campaign",
+          "request": {
+            "name": "Get product results by campaign",
+            "description": {
+              "content": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current day.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "product",
+                "result",
+                "by-campaign",
+                ":campaign_id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "Page number of the results.",
+                    "type": "text/plain"
+                  },
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "Number of items per page.",
+                    "type": "text/plain"
+                  },
+                  "key": "quantity",
+                  "value": "100"
+                },
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "Field used to sort results. Unrecognized values fall back to `name`.",
+                    "type": "text/plain"
+                  },
+                  "key": "order_by",
+                  "value": "impressions"
+                },
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                    "type": "text/plain"
+                  },
+                  "key": "order_direction",
+                  "value": "asc"
+                },
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "Start date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                    "type": "text/plain"
+                  },
+                  "key": "start_date",
+                  "value": "2025-01-01"
+                },
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "End date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                    "type": "text/plain"
+                  },
+                  "key": "end_date",
+                  "value": "2025-01-31"
+                },
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "If `true`, the response is wrapped in a pagination envelope with `total`, `pages`, and `currentPage`. If `false`, the response is a bare array of product objects, without pagination metadata.",
+                    "type": "text/plain"
+                  },
+                  "key": "count",
+                  "value": "true"
+                }
+              ],
+              "variable": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) Unique identifier of the campaign to fetch product results for.",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "ab90a43b-582e-4be9-b126-2067dd8f30a3",
+                  "key": "campaign_id"
+                }
+              ]
+            },
+            "header": [
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                  "type": "text/plain"
+                },
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "response": [
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "603d067c-60ac-41b8-9734-c7e3164c0c3a",
+              "name": "Paginated response (default)",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    "result",
+                    "by-campaign",
+                    ":campaign_id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results. Unrecognized values fall back to `name`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "impressions"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "asc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Start date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "End date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, the response is wrapped in a pagination envelope with `total`, `pages`, and `currentPage`. If `false`, the response is a bare array of product objects, without pagination metadata.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "true"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"total\": 2,\n  \"pages\": 1,\n  \"currentPage\": 1,\n  \"data\": [\n    {\n      \"id\": \"5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73\",\n      \"name\": \"Product Name\",\n      \"product_sku\": \"SKU-123\",\n      \"image_url\": \"https://example.com/image.png\",\n      \"categories\": [\n        \"National Beers\",\n        \"National Beers > Drinks\"\n      ],\n      \"active\": true,\n      \"impressions\": \"2900\",\n      \"impressions_cost\": \"29.00\",\n      \"clicks\": \"53\",\n      \"clicks_cost\": \"79.50\",\n      \"views\": \"2689\",\n      \"conversions\": \"12\",\n      \"conversions_quantity\": \"18\",\n      \"conversions_value\": \"5361.00\"\n    },\n    {\n      \"id\": \"c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab\",\n      \"name\": \"Other Product Name\",\n      \"product_sku\": \"SKU-456\",\n      \"image_url\": \"https://example.com/other-image.png\",\n      \"categories\": null,\n      \"active\": false,\n      \"impressions\": \"0\",\n      \"impressions_cost\": \"0.00\",\n      \"clicks\": \"0\",\n      \"clicks_cost\": \"0.00\",\n      \"views\": \"0\",\n      \"conversions\": \"0\",\n      \"conversions_quantity\": \"0\",\n      \"conversions_value\": \"0.00\"\n    }\n  ]\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "5db26831-0966-4df8-989e-c41db8e35596",
+              "name": "Array response when count=false",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    "result",
+                    "by-campaign",
+                    ":campaign_id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results. Unrecognized values fall back to `name`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "impressions"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "asc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Start date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "End date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, the response is wrapped in a pagination envelope with `total`, `pages`, and `currentPage`. If `false`, the response is a bare array of product objects, without pagination metadata.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "true"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "[\n  {\n    \"id\": \"5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73\",\n    \"name\": \"Product Name\",\n    \"product_sku\": \"SKU-123\",\n    \"image_url\": \"https://example.com/image.png\",\n    \"categories\": [\n      \"National Beers\",\n      \"National Beers > Drinks\"\n    ],\n    \"active\": true,\n    \"impressions\": \"2900\",\n    \"impressions_cost\": \"29.00\",\n    \"clicks\": \"53\",\n    \"clicks_cost\": \"79.50\",\n    \"views\": \"2689\",\n    \"conversions\": \"12\",\n    \"conversions_quantity\": \"18\",\n    \"conversions_value\": \"5361.00\"\n  },\n  {\n    \"id\": \"c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab\",\n    \"name\": \"Other Product Name\",\n    \"product_sku\": \"SKU-456\",\n    \"image_url\": \"https://example.com/other-image.png\",\n    \"categories\": null,\n    \"active\": false,\n    \"impressions\": \"0\",\n    \"impressions_cost\": \"0.00\",\n    \"clicks\": \"0\",\n    \"clicks_cost\": \"0.00\",\n    \"views\": \"0\",\n    \"conversions\": \"0\",\n    \"conversions_quantity\": \"0\",\n    \"conversions_value\": \"0.00\"\n  }\n]",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "3d1083cf-1b5b-412f-8a1e-466d77e560f8",
+              "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    "result",
+                    "by-campaign",
+                    ":campaign_id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results. Unrecognized values fall back to `name`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "impressions"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "asc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Start date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "End date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, the response is wrapped in a pagination envelope with `total`, `pages`, and `currentPage`. If `false`, the response is a bare array of product objects, without pagination metadata.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "true"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "671df341-1833-46f2-b82f-5538d41ccd6f",
+              "name": "Not Found\n\nCampaign not found.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    "result",
+                    "by-campaign",
+                    ":campaign_id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results. Unrecognized values fall back to `name`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "impressions"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "asc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Start date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "End date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, the response is wrapped in a pagination envelope with `total`, `pages`, and `currentPage`. If `false`, the response is a bare array of product objects, without pagination metadata.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "true"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "15b323c8-2f12-479b-9a9b-f455f329dd3e",
+              "name": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    "result",
+                    "by-campaign",
+                    ":campaign_id"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Page number of the results.",
+                        "type": "text/plain"
+                      },
+                      "key": "page",
+                      "value": "1"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Number of items per page.",
+                        "type": "text/plain"
+                      },
+                      "key": "quantity",
+                      "value": "100"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Field used to sort results. Unrecognized values fall back to `name`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_by",
+                      "value": "impressions"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "type": "text/plain"
+                      },
+                      "key": "order_direction",
+                      "value": "asc"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Start date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "start_date",
+                      "value": "2025-01-01"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "End date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "type": "text/plain"
+                      },
+                      "key": "end_date",
+                      "value": "2025-01-31"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "If `true`, the response is wrapped in a pagination envelope with `total`, `pages`, and `currentPage`. If `false`, the response is a bare array of product objects, without pagination metadata.",
+                        "type": "text/plain"
+                      },
+                      "key": "count",
+                      "value": "true"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-App-Id",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"error\": \"Rate limit exceeded for this account\"\n}",
+              "cookie": []
+            }
+          ],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "f874413d-9fbd-45b6-b57c-c1e46fee33d6",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate status 2xx \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"title\":\"Paginated response\",\"description\":\"Returned by default or when `count=true`. Wraps the product results in a pagination envelope.\",\"properties\":{\"total\":{\"type\":\"integer\",\"description\":\"Total number of products.\"},\"pages\":{\"type\":\"integer\",\"description\":\"Total number of pages for pagination.\"},\"currentPage\":{\"type\":\"integer\",\"description\":\"Current page number.\"},\"data\":{\"type\":\"array\",\"description\":\"Array of product result objects.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"Category path list for the product. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category name or full category path.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of viewability.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}}},{\"type\":\"array\",\"title\":\"Array response\",\"description\":\"Returned when `count=false`. Contains the product results without the pagination envelope.\",\"items\":{\"type\":\"object\",\"description\":\"Product result object.\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"Unique product identifier (UUID).\"},\"name\":{\"type\":\"string\",\"description\":\"Product name.\"},\"product_sku\":{\"type\":\"string\",\"description\":\"Product SKU.\"},\"image_url\":{\"type\":\"string\",\"description\":\"Product image URL.\"},\"categories\":{\"type\":[\"array\",\"null\"],\"description\":\"Category path list for the product. Returns `null` when the product has no categories.\",\"items\":{\"type\":\"string\",\"description\":\"Category name or full category path.\"}},\"active\":{\"type\":\"boolean\",\"description\":\"Indicates whether the product is enabled on the campaign.\"},\"impressions\":{\"type\":\"string\",\"description\":\"Total number of ad impressions for the product in the selected date range, regardless of viewability.\"},\"impressions_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's impressions, for impression-billed formats such as CPM.\"},\"clicks\":{\"type\":\"string\",\"description\":\"Total number of clicks on the product's ad in the selected date range.\"},\"clicks_cost\":{\"type\":\"string\",\"description\":\"Ad spend attributed to this product's clicks, for click-billed formats such as CPC.\"},\"views\":{\"type\":\"string\",\"description\":\"Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria.\"},\"conversions\":{\"type\":\"string\",\"description\":\"Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count.\"},\"conversions_quantity\":{\"type\":\"string\",\"description\":\"Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1.\"},\"conversions_value\":{\"type\":\"string\",\"description\":\"Total monetary value of the conversions attributed to the product.\"}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/product/result/by-campaign/:campaign_id - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
         }
       ],
       "event": []
     },
     {
-      "id": "74b1553f-e7f9-4b03-96d1-12ad4ee20eed",
+      "id": "36c84173-eb68-4889-b7b2-b0bfd92f2c2f",
       "name": "Credit transfer",
       "description": {
         "content": "",
@@ -8140,7 +8861,7 @@
       },
       "item": [
         {
-          "id": "c4e3f7ba-49d6-410a-80c6-a9cf221f4ba1",
+          "id": "db9bb4f5-e043-451c-976b-9d24abd106a2",
           "name": "Notify credit transfer status",
           "request": {
             "name": "Notify credit transfer status",
@@ -8233,7 +8954,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b7aaf2d5-8724-4ecb-be83-94133d8c4def",
+              "id": "acb05e7c-1828-4db2-9e13-9016e1b533c2",
               "name": "No Content\n\nNotification accepted.",
               "originalRequest": {
                 "url": {
@@ -8302,7 +9023,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7991b9b0-55e9-45d1-b53e-8fad36f850c5",
+              "id": "edef63b3-75a6-41df-9fa8-951d07b4318f",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -8372,7 +9093,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "2ff8866d-5657-49dd-b553-b5a2054a4bff",
+                "id": "14b0ec70-612e-4437-8c80-18b530e247ef",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/webhook/marketplace/transfers/:publisher_id - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8389,7 +9110,7 @@
       "event": []
     },
     {
-      "id": "19aeab06-0fc3-48a7-88ae-28d1c762de06",
+      "id": "61fade7c-3fed-40a9-9b36-936f9395fd32",
       "name": "Single sign-on",
       "description": {
         "content": "",
@@ -8397,7 +9118,7 @@
       },
       "item": [
         {
-          "id": "42da6682-c643-410f-b9d7-ecfaeba42a95",
+          "id": "e2b06c59-d98a-4b4d-ab53-feb3faaa2219",
           "name": "Generate seller single sign-on URL",
           "request": {
             "name": "Generate seller single sign-on URL",
@@ -8461,7 +9182,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "2e32e1ad-57b4-48c2-89c9-8f44aa99e8d3",
+              "id": "e167396e-5adf-476e-8f04-94221dc0e5ef",
               "name": "OK\n\nRedirect URL generated successfully.",
               "originalRequest": {
                 "url": {
@@ -8538,7 +9259,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "cf098111-4c09-47e1-b12d-163bc7323856",
+              "id": "141236a2-622b-419e-93c8-ea64c932e6af",
               "name": "Unauthorized\n\nMissing or invalid authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -8606,7 +9327,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "53119861-94fa-459e-9e16-daa5398ec683",
+                "id": "a7ec2213-2407-4227-9ac5-3cbc3ae254c9",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/sso/marketplace - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -8654,7 +9375,7 @@
     }
   ],
   "info": {
-    "_postman_id": "07266f83-32a3-496b-9316-34e53ff3a829",
+    "_postman_id": "72917313-af3b-44c0-9788-41cf77acd7b4",
     "name": "VTEX Ads API",
     "version": {
       "raw": "1.0.0",

--- a/VTEX - Ads API.json
+++ b/VTEX - Ads API.json
@@ -5305,7 +5305,7 @@
                     "Reports"
                 ],
                 "summary": "Get product results by campaign",
-                "description": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current day.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current date.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Accept"
@@ -5357,7 +5357,7 @@
                     {
                         "name": "order_direction",
                         "in": "query",
-                        "description": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "description": "Sort direction. Unrecognized values fall back to `desc`.",
                         "required": false,
                         "schema": {
                             "type": "string",
@@ -5452,11 +5452,11 @@
                                                             },
                                                             "categories": {
                                                                 "type": "array",
-                                                                "description": "Category path list for the product. Returns `null` when the product has no categories.",
+                                                                "description": "List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.",
                                                                 "nullable": true,
                                                                 "items": {
                                                                     "type": "string",
-                                                                    "description": "Category name or full category path."
+                                                                    "description": "Category breadcrumb path, with levels separated by ` > `."
                                                                 }
                                                             },
                                                             "active": {
@@ -5465,7 +5465,7 @@
                                                             },
                                                             "impressions": {
                                                                 "type": "string",
-                                                                "description": "Total number of ad impressions for the product in the selected date range, regardless of viewability."
+                                                                "description": "Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user."
                                                             },
                                                             "impressions_cost": {
                                                                 "type": "string",
@@ -5481,7 +5481,7 @@
                                                             },
                                                             "views": {
                                                                 "type": "string",
-                                                                "description": "Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria."
+                                                                "description": "Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second."
                                                             },
                                                             "conversions": {
                                                                 "type": "string",
@@ -5526,11 +5526,11 @@
                                                     },
                                                     "categories": {
                                                         "type": "array",
-                                                        "description": "Category path list for the product. Returns `null` when the product has no categories.",
+                                                        "description": "List of category breadcrumb paths the product belongs to, from the root category to the most specific one. Returns `null` when the product has no categories.",
                                                         "nullable": true,
                                                         "items": {
                                                             "type": "string",
-                                                            "description": "Category name or full category path."
+                                                            "description": "Category breadcrumb path, with levels separated by ` > `."
                                                         }
                                                     },
                                                     "active": {
@@ -5539,7 +5539,7 @@
                                                     },
                                                     "impressions": {
                                                         "type": "string",
-                                                        "description": "Total number of ad impressions for the product in the selected date range, regardless of viewability."
+                                                        "description": "Total number of ad impressions for the product in the selected date range, regardless of whether the ad became visible to the user."
                                                     },
                                                     "impressions_cost": {
                                                         "type": "string",
@@ -5555,7 +5555,7 @@
                                                     },
                                                     "views": {
                                                         "type": "string",
-                                                        "description": "Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria."
+                                                        "description": "Total number of ad views for the product in the selected date range. A view is counted when the ad becomes visible to the user, occupying at least 50% of the viewport for at least 1 second."
                                                     },
                                                     "conversions": {
                                                         "type": "string",
@@ -5577,86 +5577,98 @@
                                 "examples": {
                                     "paginated": {
                                         "summary": "Paginated response (default)",
+                                        "description": "Real response abridged to two products. The `total`, `pages`, and `currentPage` values describe the full result set, so `data` shows fewer products than a complete page.",
                                         "value": {
-                                            "total": 2,
-                                            "pages": 1,
+                                            "total": 51,
+                                            "pages": 2,
                                             "currentPage": 1,
                                             "data": [
                                                 {
-                                                    "id": "5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73",
-                                                    "name": "Product Name",
-                                                    "product_sku": "SKU-123",
-                                                    "image_url": "https://example.com/image.png",
+                                                    "id": "a9c9e0e8-8e9a-41e5-af26-29f6eb5c3b83",
+                                                    "name": "Extratora de Sujeira e Água e Higienizadora Vertical Wap Comfort Cleaner Pro 2000W 2 em 1 para Tapetes Carpetes e Estofados",
+                                                    "product_sku": "55004728",
+                                                    "image_url": "https://imgs.casasbahia.com.br/55004728/1xg.jpg",
                                                     "categories": [
-                                                        "National Beers",
-                                                        "National Beers > Drinks"
+                                                        "Eletroportáteis",
+                                                        "Eletroportáteis > Aspiradores e Acessórios",
+                                                        "Eletroportáteis > Aspiradores e Acessórios > Aspirador Água e Pó"
                                                     ],
-                                                    "active": true,
-                                                    "impressions": "2900",
-                                                    "impressions_cost": "29.00",
-                                                    "clicks": "53",
-                                                    "clicks_cost": "79.50",
-                                                    "views": "2689",
-                                                    "conversions": "12",
-                                                    "conversions_quantity": "18",
-                                                    "conversions_value": "5361.00"
-                                                },
-                                                {
-                                                    "id": "c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab",
-                                                    "name": "Other Product Name",
-                                                    "product_sku": "SKU-456",
-                                                    "image_url": "https://example.com/other-image.png",
-                                                    "categories": null,
                                                     "active": false,
                                                     "impressions": "0",
-                                                    "impressions_cost": "0.00",
+                                                    "impressions_cost": "0",
                                                     "clicks": "0",
-                                                    "clicks_cost": "0.00",
+                                                    "clicks_cost": "0",
                                                     "views": "0",
                                                     "conversions": "0",
                                                     "conversions_quantity": "0",
-                                                    "conversions_value": "0.00"
+                                                    "conversions_value": "0"
+                                                },
+                                                {
+                                                    "id": "2b19df76-0596-43cb-892d-a364dcaaf054",
+                                                    "name": "Lavadora de Alta Pressão WAP Ousada WL 2610 Ultra 1750PSI 1500W – Cinza e Amarelo",
+                                                    "product_sku": "55065795",
+                                                    "image_url": "https://imgs.casasbahia.com.br/55065795/1g.jpg",
+                                                    "categories": [
+                                                        "Ferramentas",
+                                                        "Ferramentas > Lavadoras de Pressão",
+                                                        "Ferramentas > Lavadoras de Pressão > Lavadoras Residenciais"
+                                                    ],
+                                                    "active": true,
+                                                    "impressions": "0",
+                                                    "impressions_cost": "0.00000000",
+                                                    "clicks": "0",
+                                                    "clicks_cost": "0.00000000",
+                                                    "views": "0",
+                                                    "conversions": "2",
+                                                    "conversions_quantity": "2",
+                                                    "conversions_value": "1107.76"
                                                 }
                                             ]
                                         }
                                     },
                                     "rawArray": {
-                                        "summary": "Array response when count=false",
+                                        "summary": "Array response when `count=false`",
+                                        "description": "Real response abridged to the same two products.",
                                         "value": [
                                             {
-                                                "id": "5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73",
-                                                "name": "Product Name",
-                                                "product_sku": "SKU-123",
-                                                "image_url": "https://example.com/image.png",
+                                                "id": "a9c9e0e8-8e9a-41e5-af26-29f6eb5c3b83",
+                                                "name": "Extratora de Sujeira e Água e Higienizadora Vertical Wap Comfort Cleaner Pro 2000W 2 em 1 para Tapetes Carpetes e Estofados",
+                                                "product_sku": "55004728",
+                                                "image_url": "https://imgs.casasbahia.com.br/55004728/1xg.jpg",
                                                 "categories": [
-                                                    "National Beers",
-                                                    "National Beers > Drinks"
+                                                    "Eletroportáteis",
+                                                    "Eletroportáteis > Aspiradores e Acessórios",
+                                                    "Eletroportáteis > Aspiradores e Acessórios > Aspirador Água e Pó"
                                                 ],
-                                                "active": true,
-                                                "impressions": "2900",
-                                                "impressions_cost": "29.00",
-                                                "clicks": "53",
-                                                "clicks_cost": "79.50",
-                                                "views": "2689",
-                                                "conversions": "12",
-                                                "conversions_quantity": "18",
-                                                "conversions_value": "5361.00"
-                                            },
-                                            {
-                                                "id": "c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab",
-                                                "name": "Other Product Name",
-                                                "product_sku": "SKU-456",
-                                                "image_url": "https://example.com/other-image.png",
-                                                "categories": null,
                                                 "active": false,
                                                 "impressions": "0",
-                                                "impressions_cost": "0.00",
+                                                "impressions_cost": "0",
                                                 "clicks": "0",
-                                                "clicks_cost": "0.00",
+                                                "clicks_cost": "0",
                                                 "views": "0",
                                                 "conversions": "0",
                                                 "conversions_quantity": "0",
-                                                "conversions_value": "0.00"
+                                                "conversions_value": "0"
+                                            },
+                                            {
+                                                "id": "2b19df76-0596-43cb-892d-a364dcaaf054",
+                                                "name": "Lavadora de Alta Pressão WAP Ousada WL 2610 Ultra 1750PSI 1500W – Cinza e Amarelo",
+                                                "product_sku": "55065795",
+                                                "image_url": "https://imgs.casasbahia.com.br/55065795/1g.jpg",
+                                                "categories": [
+                                                    "Ferramentas",
+                                                    "Ferramentas > Lavadoras de Pressão",
+                                                    "Ferramentas > Lavadoras de Pressão > Lavadoras Residenciais"
+                                                ],
+                                                "active": true,
+                                                "impressions": "0",
+                                                "impressions_cost": "0.00000000",
+                                                "clicks": "0",
+                                                "clicks_cost": "0.00000000",
+                                                "views": "0",
+                                                "conversions": "2",
+                                                "conversions_quantity": "2",
+                                                "conversions_value": "1107.76"
                                             }
                                         ]
                                     }

--- a/VTEX - Ads API.json
+++ b/VTEX - Ads API.json
@@ -5293,7 +5293,7 @@
                 }
             }
         },
-        "/product/result/by-campaign/{campaign_id}": {
+        "/product/results": {
             "servers": [
                 {
                     "url": "https://api-retail-media.newtail.com.br",
@@ -5305,14 +5305,14 @@
                     "Reports"
                 ],
                 "summary": "Get product results by campaign",
-                "description": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current date.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "description": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current date.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified by the `campaign_id` query parameter, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/Accept"
                     },
                     {
                         "name": "campaign_id",
-                        "in": "path",
+                        "in": "query",
                         "description": "Unique identifier of the campaign to fetch product results for.",
                         "required": true,
                         "schema": {

--- a/VTEX - Ads API.json
+++ b/VTEX - Ads API.json
@@ -5293,6 +5293,405 @@
                 }
             }
         },
+        "/product/result/by-campaign/{campaign_id}": {
+            "servers": [
+                {
+                    "url": "https://api-retail-media.newtail.com.br",
+                    "description": "VTEX Ads server."
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Get product results by campaign",
+                "description": "Retrieves per-product (SKU) performance metrics for every product linked to a campaign, including impressions, clicks, views, conversions, and the ad spend and conversion value attributed to each product. Metrics are aggregated over an inclusive date range, which defaults to the current day.\r\n\r\nUse this endpoint for a SKU-level breakdown of a single campaign, rather than the campaign-level totals returned by [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-).\r\n\r\n>ℹ️ Do not confuse this endpoint with [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` and returns some of the same product fields. That report lists results per ad across campaigns, with each item's metrics nested under a `metrics` object. This endpoint lists results per product (SKU) for the campaign identified in the path, with each product's metrics flat on the product object.\r\n\r\n>ℹ️ By default, the response is wrapped in a pagination envelope. To receive a bare array of product objects instead, set `count=false`.\r\n\r\n>⚠️ This endpoint is limited to 100 requests per minute per account. Exceeding the limit returns `429 Too Many Requests`.\r\n\r\n## Permissions\r\n\r\nThis endpoint does not require [License Manager resources](https://help.vtex.com/docs/tutorials/license-manager-resources).",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/Accept"
+                    },
+                    {
+                        "name": "campaign_id",
+                        "in": "path",
+                        "description": "Unique identifier of the campaign to fetch product results for.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "ab90a43b-582e-4be9-b126-2067dd8f30a3"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/Page"
+                    },
+                    {
+                        "name": "quantity",
+                        "in": "query",
+                        "description": "Number of items per page.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 100,
+                            "example": 100
+                        }
+                    },
+                    {
+                        "name": "order_by",
+                        "in": "query",
+                        "description": "Field used to sort results. Unrecognized values fall back to `name`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "name",
+                                "impressions",
+                                "clicks",
+                                "views",
+                                "conversions_quantity",
+                                "conversions_value",
+                                "conversions"
+                            ],
+                            "default": "name",
+                            "example": "impressions"
+                        }
+                    },
+                    {
+                        "name": "order_direction",
+                        "in": "query",
+                        "description": "Sort direction. The value `asc` is case-insensitive, and any other value resolves to `desc`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ],
+                            "default": "asc",
+                            "example": "asc"
+                        }
+                    },
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "description": "Start date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date",
+                            "example": "2025-01-01"
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "description": "End date of the metrics range, in `YYYY-MM-DD` format. This date is inclusive and defaults to the current date when omitted.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date",
+                            "example": "2025-01-31"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "If `true`, the response is wrapped in a pagination envelope with `total`, `pages`, and `currentPage`. If `false`, the response is a bare array of product objects, without pagination metadata.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true,
+                            "example": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK\n\nProduct results returned successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "title": "Paginated response",
+                                            "description": "Returned by default or when `count=true`. Wraps the product results in a pagination envelope.",
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "description": "Total number of products."
+                                                },
+                                                "pages": {
+                                                    "type": "integer",
+                                                    "description": "Total number of pages for pagination."
+                                                },
+                                                "currentPage": {
+                                                    "type": "integer",
+                                                    "description": "Current page number."
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "description": "Array of product result objects.",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "description": "Product result object.",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "string",
+                                                                "description": "Unique product identifier (UUID)."
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "Product name."
+                                                            },
+                                                            "product_sku": {
+                                                                "type": "string",
+                                                                "description": "Product SKU."
+                                                            },
+                                                            "image_url": {
+                                                                "type": "string",
+                                                                "description": "Product image URL."
+                                                            },
+                                                            "categories": {
+                                                                "type": "array",
+                                                                "description": "Category path list for the product. Returns `null` when the product has no categories.",
+                                                                "nullable": true,
+                                                                "items": {
+                                                                    "type": "string",
+                                                                    "description": "Category name or full category path."
+                                                                }
+                                                            },
+                                                            "active": {
+                                                                "type": "boolean",
+                                                                "description": "Indicates whether the product is enabled on the campaign."
+                                                            },
+                                                            "impressions": {
+                                                                "type": "string",
+                                                                "description": "Total number of ad impressions for the product in the selected date range, regardless of viewability."
+                                                            },
+                                                            "impressions_cost": {
+                                                                "type": "string",
+                                                                "description": "Ad spend attributed to this product's impressions, for impression-billed formats such as CPM."
+                                                            },
+                                                            "clicks": {
+                                                                "type": "string",
+                                                                "description": "Total number of clicks on the product's ad in the selected date range."
+                                                            },
+                                                            "clicks_cost": {
+                                                                "type": "string",
+                                                                "description": "Ad spend attributed to this product's clicks, for click-billed formats such as CPC."
+                                                            },
+                                                            "views": {
+                                                                "type": "string",
+                                                                "description": "Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria."
+                                                            },
+                                                            "conversions": {
+                                                                "type": "string",
+                                                                "description": "Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count."
+                                                            },
+                                                            "conversions_quantity": {
+                                                                "type": "string",
+                                                                "description": "Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1."
+                                                            },
+                                                            "conversions_value": {
+                                                                "type": "string",
+                                                                "description": "Total monetary value of the conversions attributed to the product."
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "array",
+                                            "title": "Array response",
+                                            "description": "Returned when `count=false`. Contains the product results without the pagination envelope.",
+                                            "items": {
+                                                "type": "object",
+                                                "description": "Product result object.",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string",
+                                                        "description": "Unique product identifier (UUID)."
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "Product name."
+                                                    },
+                                                    "product_sku": {
+                                                        "type": "string",
+                                                        "description": "Product SKU."
+                                                    },
+                                                    "image_url": {
+                                                        "type": "string",
+                                                        "description": "Product image URL."
+                                                    },
+                                                    "categories": {
+                                                        "type": "array",
+                                                        "description": "Category path list for the product. Returns `null` when the product has no categories.",
+                                                        "nullable": true,
+                                                        "items": {
+                                                            "type": "string",
+                                                            "description": "Category name or full category path."
+                                                        }
+                                                    },
+                                                    "active": {
+                                                        "type": "boolean",
+                                                        "description": "Indicates whether the product is enabled on the campaign."
+                                                    },
+                                                    "impressions": {
+                                                        "type": "string",
+                                                        "description": "Total number of ad impressions for the product in the selected date range, regardless of viewability."
+                                                    },
+                                                    "impressions_cost": {
+                                                        "type": "string",
+                                                        "description": "Ad spend attributed to this product's impressions, for impression-billed formats such as CPM."
+                                                    },
+                                                    "clicks": {
+                                                        "type": "string",
+                                                        "description": "Total number of clicks on the product's ad in the selected date range."
+                                                    },
+                                                    "clicks_cost": {
+                                                        "type": "string",
+                                                        "description": "Ad spend attributed to this product's clicks, for click-billed formats such as CPC."
+                                                    },
+                                                    "views": {
+                                                        "type": "string",
+                                                        "description": "Total number of viewable impressions in the selected date range, meaning impressions that met the viewability criteria."
+                                                    },
+                                                    "conversions": {
+                                                        "type": "string",
+                                                        "description": "Total number of conversion events attributed to the product, using last-touch click and view attribution. Each conversion counts once, regardless of how many items it contains. See `conversions_quantity` for the item-level count."
+                                                    },
+                                                    "conversions_quantity": {
+                                                        "type": "string",
+                                                        "description": "Total quantity of items across all conversions attributed to the product. For example, buying two units in a single conversion increases `conversions_quantity` by 2, while `conversions` increases by 1."
+                                                    },
+                                                    "conversions_value": {
+                                                        "type": "string",
+                                                        "description": "Total monetary value of the conversions attributed to the product."
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "paginated": {
+                                        "summary": "Paginated response (default)",
+                                        "value": {
+                                            "total": 2,
+                                            "pages": 1,
+                                            "currentPage": 1,
+                                            "data": [
+                                                {
+                                                    "id": "5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73",
+                                                    "name": "Product Name",
+                                                    "product_sku": "SKU-123",
+                                                    "image_url": "https://example.com/image.png",
+                                                    "categories": [
+                                                        "National Beers",
+                                                        "National Beers > Drinks"
+                                                    ],
+                                                    "active": true,
+                                                    "impressions": "2900",
+                                                    "impressions_cost": "29.00",
+                                                    "clicks": "53",
+                                                    "clicks_cost": "79.50",
+                                                    "views": "2689",
+                                                    "conversions": "12",
+                                                    "conversions_quantity": "18",
+                                                    "conversions_value": "5361.00"
+                                                },
+                                                {
+                                                    "id": "c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab",
+                                                    "name": "Other Product Name",
+                                                    "product_sku": "SKU-456",
+                                                    "image_url": "https://example.com/other-image.png",
+                                                    "categories": null,
+                                                    "active": false,
+                                                    "impressions": "0",
+                                                    "impressions_cost": "0.00",
+                                                    "clicks": "0",
+                                                    "clicks_cost": "0.00",
+                                                    "views": "0",
+                                                    "conversions": "0",
+                                                    "conversions_quantity": "0",
+                                                    "conversions_value": "0.00"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "rawArray": {
+                                        "summary": "Array response when count=false",
+                                        "value": [
+                                            {
+                                                "id": "5f8b2c1a-9d34-4e7a-b8f2-6c1e0a4d9b73",
+                                                "name": "Product Name",
+                                                "product_sku": "SKU-123",
+                                                "image_url": "https://example.com/image.png",
+                                                "categories": [
+                                                    "National Beers",
+                                                    "National Beers > Drinks"
+                                                ],
+                                                "active": true,
+                                                "impressions": "2900",
+                                                "impressions_cost": "29.00",
+                                                "clicks": "53",
+                                                "clicks_cost": "79.50",
+                                                "views": "2689",
+                                                "conversions": "12",
+                                                "conversions_quantity": "18",
+                                                "conversions_value": "5361.00"
+                                            },
+                                            {
+                                                "id": "c2a71e64-3f19-4b8d-9a05-7d6e2f4c81ab",
+                                                "name": "Other Product Name",
+                                                "product_sku": "SKU-456",
+                                                "image_url": "https://example.com/other-image.png",
+                                                "categories": null,
+                                                "active": false,
+                                                "impressions": "0",
+                                                "impressions_cost": "0.00",
+                                                "clicks": "0",
+                                                "clicks_cost": "0.00",
+                                                "views": "0",
+                                                "conversions": "0",
+                                                "conversions_quantity": "0",
+                                                "conversions_value": "0.00"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized\n\nMissing or invalid authentication credentials."
+                    },
+                    "404": {
+                        "description": "Not Found\n\nCampaign not found."
+                    },
+                    "429": {
+                        "description": "Too Many Requests\n\nThis endpoint is limited to 100 requests per minute per account.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "description": "Rate limit error message."
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "error": "Rate limit exceeded for this account"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/webhook/marketplace/transfers/{publisher_id}": {
             "servers": [
                 {


### PR DESCRIPTION
## Summary

Documents the new `GET /product/results` endpoint in the VTEX Ads API reference. This endpoint returns per-product (SKU) performance metrics for every product linked to a campaign, identified by the `campaign_id` query parameter.

> **Path correction (2026-09-02):** the endpoint was initially documented as `GET /product/result/by-campaign/{campaign_id}`, which turned out to be the internal path. The externally exposed path is `GET /product/results`, with `campaign_id` as a required query parameter (confirmed by the Ads team with a fresh curl from the PAC UI).

## Changes

- Added the `/product/results` path under the **Reports** tag, with a dedicated `servers` entry pointing to `https://api-retail-media.newtail.com.br`.
- Wrote the endpoint `summary` and `description`, including:
  - A pointer to [Get campaign details](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/campaign/-campaign_id-) for campaign-level totals.
  - A disambiguation note versus [Get ads performance report](https://developers.vtex.com/docs/api-reference/vtex-ads-api#get-/ad/results/v2), which also accepts `campaign_id` but returns results per ad with metrics nested under a `metrics` object, instead of per product with flat metrics.
  - A note on the default pagination envelope and how `count=false` changes the response shape.
  - The 100 requests per minute per account rate limit.
  - A **Permissions** section stating that no License Manager resources are required.
- Documented 9 parameters: the shared `Accept` and `Page` references, plus `campaign_id` (required query parameter), `quantity`, `order_by`, `order_direction`, `start_date`, `end_date`, and `count`, each with type, default, enum values, and examples where applicable.
- Modeled the `200` response as a `oneOf` covering both shapes:
  - **Paginated response** (default or `count=true`) with `total`, `pages`, `currentPage`, and `data`.
  - **Array response** (`count=false`) with the bare list of product objects.
- Described every product field, including the distinction between `conversions` (one per conversion event) and `conversions_quantity` (item-level count), and between `impressions` and viewable `views`.
- Added two response examples (`paginated` and `rawArray`) taken verbatim from a real response payload provided by the Ads team.
- Added `401`, `404`, and `429` responses, with a schema and example for the rate limit error.

## Key files affected

- `VTEX - Ads API.json`

## Related Task

[EDU-19408](https://vtex-dev.atlassian.net/browse/EDU-19408)


[EDU-19408]: https://vtex-dev.atlassian.net/browse/EDU-19408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ