### PR TITLE
docs: document GET user lookup routes for Authenticator API

### DIFF
--- a/PostmanCollections/VTEX - Authenticator API.json
+++ b/PostmanCollections/VTEX - Authenticator API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "f71565f2-3596-4942-ae34-e894ecf7c51d"
+    "postman_id": "a7066933-156f-443c-aeb7-2c8fade1c774"
   },
   "item": [
     {
-      "id": "1f5e924c-32ed-47ba-b574-0610bb97bcbb",
+      "id": "038f0a39-95e2-43e3-93d6-b53ded6b66b8",
       "name": "Storefront users",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "cfec2c44-e83d-46a8-bae7-cca8ee801642",
+          "id": "a8f06867-73dd-4317-8a22-e8cac13e7888",
           "name": "Create storefront user",
           "request": {
             "name": "Create storefront user",
@@ -75,7 +75,7 @@
             "method": "POST",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"beneson_test_21\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"beneson2010@gmail.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
+              "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -109,7 +109,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "ad0d02ef-b6b6-445e-8abd-08a4626ae050",
+              "id": "c663671c-eb6e-4798-9258-7f5f004c881e",
               "name": "Created\n\nUser created successfully.",
               "originalRequest": {
                 "url": {
@@ -175,7 +175,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"beneson_test_21\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"beneson2010@gmail.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
+                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -192,14 +192,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"userId\": \"f0a15a42-f7fc-4b09-a9ab-fabc76d9f332\",\n  \"identifier\": \"beneson_test_21\"\n}",
+              "body": "{\n  \"userId\": \"f0a15a42-f7fc-4b09-a9ab-fabc76d9f332\",\n  \"identifier\": \"john_doe\"\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "d4dd782a-2554-4e01-a282-6eef3b06425b",
+              "id": "598c4d1f-c0ea-4bac-9420-be0e876f6575",
               "name": "Bad Request\n\nInvalid request format or missing required fields or unsupported identifier type.",
               "originalRequest": {
                 "url": {
@@ -265,7 +265,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"beneson_test_21\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"beneson2010@gmail.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
+                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -289,7 +289,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "72632140-5b33-4a36-92f9-b173f6d70b86",
+              "id": "93ca8da0-8e06-45e2-bbda-3a7376336f4d",
               "name": "Unauthorized\n\nInvalid or missing authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -351,7 +351,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"beneson_test_21\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"beneson2010@gmail.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
+                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -369,7 +369,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "20f18082-13db-45be-9895-5548ceb5e2b5",
+              "id": "31a180dc-485a-44d6-a071-da4e69c874c7",
               "name": "Forbidden\n\nInsufficient permissions to create users.",
               "originalRequest": {
                 "url": {
@@ -431,7 +431,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"beneson_test_21\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"beneson2010@gmail.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
+                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -449,7 +449,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "a830d450-4d0e-4803-bdca-32e0d479e936",
+              "id": "0ec003fb-9dc4-46c4-ba5a-9490d417797a",
               "name": "Conflict\n\nOne or more of the provided identifiers already exist for another user.",
               "originalRequest": {
                 "url": {
@@ -515,7 +515,7 @@
                 "method": "POST",
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"beneson_test_21\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"beneson2010@gmail.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
+                  "raw": "{\n  \"identifiers\": [\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
                   "options": {
                     "raw": {
                       "headerFamily": "json",
@@ -540,7 +540,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "42c6a595-f53a-4a87-a557-fe682ec830ca",
+                "id": "bf4c8ced-ed6d-48b4-8a6b-c24fa01dfd55",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -556,7 +556,7 @@
           }
         },
         {
-          "id": "3654b8ae-0167-4fb5-a8f6-a984dc615101",
+          "id": "78e8b980-bc24-41dd-af4f-2fe338f7e176",
           "name": "Get storefront user by user ID",
           "request": {
             "name": "Get storefront user by user ID",
@@ -584,7 +584,7 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "1761fad7-d87a-45da-af04-5284017fe4b5",
+                  "value": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
                   "key": "userId"
                 }
               ]
@@ -641,7 +641,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "24affa1f-7bd1-4671-ada4-fd2b58f3467f",
+              "id": "02d959b8-3ffd-4373-bb74-1fc30a0671e3",
               "name": "OK\n\nUser found.",
               "originalRequest": {
                 "url": {
@@ -701,14 +701,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"userId\": \"1761fad7-d87a-45da-af04-5284017fe4b5\",\n  \"identifiers\": [\n    {\n      \"type\": \"email\",\n      \"value\": \"test_user@acme.com\"\n    },\n    {\n      \"type\": \"username\",\n      \"value\": \"test_user\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"00123456789\"\n    }\n  ]\n}",
+              "body": "{\n  \"userId\": \"f0a15a42-f7fc-4b09-a9ab-fabc76d9f332\",\n  \"identifiers\": [\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "13654905-5e81-4b3b-9ab5-ee7c939ee747",
+              "id": "e555d83c-0148-4394-9f11-eece229b0071",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -765,7 +765,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "19e06676-2c53-46e9-88f5-6e353354a267",
+              "id": "035190c1-5dc0-41fe-a249-fb1e58a4b01b",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -822,7 +822,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ade9dc17-d962-48a3-a795-b7cf47770884",
+              "id": "b9960f67-cf7b-4df7-a453-de0d1e36fa67",
               "name": "Not Found\n\nUser not found for the given user ID.",
               "originalRequest": {
                 "url": {
@@ -879,7 +879,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8371241a-2521-43aa-b100-e226b699cc9f",
+              "id": "6c03e2d2-fbf9-417d-844f-a7a4bfc50f38",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -937,7 +937,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "ea003548-f7e4-4308-9221-a136decfa0cc",
+                "id": "1e3a37c4-3a90-4755-a97c-bbaa82640b66",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/v1/users/:userId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -953,7 +953,7 @@
           }
         },
         {
-          "id": "de465f4e-993c-466a-bdba-77c7674e0f2b",
+          "id": "2fe1750d-5aab-4dc2-bdf5-f5d4b205d9be",
           "name": "Get storefront user by identifier",
           "request": {
             "name": "Get storefront user by identifier",
@@ -980,7 +980,7 @@
                     "type": "text/plain"
                   },
                   "key": "identifier",
-                  "value": "test_user@acme.com"
+                  "value": "john.doe@acme.com"
                 },
                 {
                   "disabled": true,
@@ -1046,7 +1046,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "726f0323-6ff0-402f-9f18-da145b4f5ab5",
+              "id": "131f86fe-c121-4a68-935d-52c702614f69",
               "name": "OK\n\nUser found.",
               "originalRequest": {
                 "url": {
@@ -1068,7 +1068,7 @@
                         "type": "text/plain"
                       },
                       "key": "identifier",
-                      "value": "test_user@acme.com"
+                      "value": "john.doe@acme.com"
                     },
                     {
                       "disabled": true,
@@ -1125,14 +1125,14 @@
                   "value": "application/json"
                 }
               ],
-              "body": "{\n  \"userId\": \"1761fad7-d87a-45da-af04-5284017fe4b5\",\n  \"identifiers\": [\n    {\n      \"type\": \"email\",\n      \"value\": \"test_user@acme.com\"\n    },\n    {\n      \"type\": \"username\",\n      \"value\": \"test_user\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"00123456789\"\n    }\n  ]\n}",
+              "body": "{\n  \"userId\": \"f0a15a42-f7fc-4b09-a9ab-fabc76d9f332\",\n  \"identifiers\": [\n    {\n      \"type\": \"email\",\n      \"value\": \"john.doe@acme.com\"\n    },\n    {\n      \"type\": \"username\",\n      \"value\": \"john_doe\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"415-602-8838\"\n    }\n  ]\n}",
               "cookie": []
             },
             {
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ade63a12-bc6c-4f1e-bfb8-4e2dfdde787f",
+              "id": "c826fe3b-da79-4e4e-aa84-e3f4e497ac6f",
               "name": "Unauthorized\n\nThe current user could not be resolved.",
               "originalRequest": {
                 "url": {
@@ -1154,7 +1154,7 @@
                         "type": "text/plain"
                       },
                       "key": "identifier",
-                      "value": "test_user@acme.com"
+                      "value": "john.doe@acme.com"
                     },
                     {
                       "disabled": true,
@@ -1208,7 +1208,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "ea5b76a6-6876-40d5-ae10-d073ab716646",
+              "id": "d9de3bf6-9337-4890-a94f-7e3084616278",
               "name": "Forbidden\n\nAccess denied.",
               "originalRequest": {
                 "url": {
@@ -1230,7 +1230,7 @@
                         "type": "text/plain"
                       },
                       "key": "identifier",
-                      "value": "test_user@acme.com"
+                      "value": "john.doe@acme.com"
                     },
                     {
                       "disabled": true,
@@ -1284,7 +1284,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0801654f-4db3-4aa5-950c-2383203aaf42",
+              "id": "2755d0ef-7846-4a85-805d-9d41fa38f0ed",
               "name": "Not Found\n\nUser not found for the given identifier.",
               "originalRequest": {
                 "url": {
@@ -1306,7 +1306,7 @@
                         "type": "text/plain"
                       },
                       "key": "identifier",
-                      "value": "test_user@acme.com"
+                      "value": "john.doe@acme.com"
                     },
                     {
                       "disabled": true,
@@ -1360,7 +1360,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6c7fe050-130e-4046-9609-bffd0cb057b7",
+              "id": "a93c4ca6-fea5-4130-8a81-14ffebad4458",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1382,7 +1382,7 @@
                         "type": "text/plain"
                       },
                       "key": "identifier",
-                      "value": "test_user@acme.com"
+                      "value": "john.doe@acme.com"
                     },
                     {
                       "disabled": true,
@@ -1437,7 +1437,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "73f10715-23e3-4954-99a6-25a0cf093e31",
+                "id": "ce1baf2c-7aef-4371-9722-b42f098dbda7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/v1/users/info - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1456,7 +1456,7 @@
       "event": []
     },
     {
-      "id": "892b7cc3-a555-4bc5-a1e7-ace268f0f656",
+      "id": "d0d0685c-505e-41a7-913a-660fb70c7667",
       "name": "Password migration",
       "description": {
         "content": "",
@@ -1464,7 +1464,7 @@
       },
       "item": [
         {
-          "id": "c945c347-3336-43f4-9a46-f9317c1e00bb",
+          "id": "1ef34a65-b03e-4c7c-ba93-63cfd4f55195",
           "name": "Upsert password migration configuration",
           "request": {
             "name": "Upsert password migration configuration",
@@ -1539,7 +1539,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7a7bea35-31fc-4d93-99e8-f89c2bc4c74a",
+              "id": "e7e18a05-7527-4073-bac6-b19566afcedd",
               "name": "OK\n\nFeature registered or updated successfully.",
               "originalRequest": {
                 "url": {
@@ -1610,7 +1610,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "44d52342-7309-4b17-b3a0-9b45cb8360bb",
+              "id": "05d3af16-fbd8-48e3-b3ef-c5317fd401d9",
               "name": "Bad Request\n\nUnknown feature name or invalid secret format.",
               "originalRequest": {
                 "url": {
@@ -1681,7 +1681,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "939af492-5b51-41e4-9736-4ba86c4380a6",
+              "id": "1b34cbfa-f1d3-403e-b26b-bc200b12c364",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1753,7 +1753,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "f1f2c52e-755c-4daf-a8fe-17f490c0839e",
+                "id": "4ca15eb6-d1da-40a4-bb71-0fe5f386e365",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1766,7 +1766,7 @@
           }
         },
         {
-          "id": "a35b5705-d4c8-4d2d-8444-a0521c250dd7",
+          "id": "7aa8de52-c84a-4d13-b40c-d0fb03ac9acf",
           "name": "Enable or disable password migration",
           "request": {
             "name": "Enable or disable password migration",
@@ -1841,7 +1841,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0a6c8675-da26-4f96-8bd7-e8a3735bc47f",
+              "id": "726dc260-d394-4aaf-ba14-962063fef854",
               "name": "OK\n\nFeature toggled successfully.",
               "originalRequest": {
                 "url": {
@@ -1912,7 +1912,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "56fbc5d9-0762-4681-8352-e1cee1133bc2",
+              "id": "838575ee-2621-4a2a-afb2-fc19f5ea4f6c",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -1983,7 +1983,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "6e44f808-b9e5-4597-b87b-3140f8aaa50a",
+              "id": "2d81620c-8020-4e25-8317-6259f76e7ecb",
               "name": "Not Found\n\nFeature not registered for this tenant.",
               "originalRequest": {
                 "url": {
@@ -2054,7 +2054,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "9ed37a0e-866c-4ff4-8517-fc9fe1c01c05",
+              "id": "21007e5c-4e62-401b-ad62-321d347d952d",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -2126,7 +2126,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "b0a7812c-5f99-4dbb-ba95-4a6ccfc43744",
+                "id": "127f1cd6-998e-47e9-84e9-25e4e2e5c882",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -2139,7 +2139,7 @@
           }
         },
         {
-          "id": "55f210a4-c5e1-4342-aae7-2354f0cb057f",
+          "id": "6b49dc63-3658-4bcc-82ed-c9afcf5c8c46",
           "name": "Delete password migration configuration",
           "request": {
             "name": "Delete password migration configuration",
@@ -2192,7 +2192,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "258e4307-e3c4-42e9-94b5-829c63b7fc33",
+              "id": "9e8d0399-4566-450b-bdaf-bdcc8dbcb310",
               "name": "No Content\n\nFeature deleted successfully.",
               "originalRequest": {
                 "url": {
@@ -2241,7 +2241,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "444696a7-fdc8-4e58-8559-fe295ec9e453",
+              "id": "8823bb48-dd9f-43b0-84ed-694782b8238b",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -2290,7 +2290,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0568e713-726b-44ad-83fe-f23c422bf0ff",
+              "id": "4b0eed97-8ac7-4793-beb4-a2247a286fc1",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -2340,7 +2340,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "22b16386-a975-4cf2-8a52-cb728d57a0b7",
+                "id": "7270ad32-3101-46c6-b3c1-dbe30e278c04",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -2396,7 +2396,7 @@
     }
   ],
   "info": {
-    "_postman_id": "f71565f2-3596-4942-ae34-e894ecf7c51d",
+    "_postman_id": "a7066933-156f-443c-aeb7-2c8fade1c774",
     "name": "Authenticator",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/PostmanCollections/VTEX - Authenticator API.json
+++ b/PostmanCollections/VTEX - Authenticator API.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "160b3753-29d8-43eb-a49a-cdc14908b7d9"
+    "postman_id": "f71565f2-3596-4942-ae34-e894ecf7c51d"
   },
   "item": [
     {
-      "id": "13e5c04c-9868-412c-9a68-aeb493704e12",
+      "id": "1f5e924c-32ed-47ba-b574-0610bb97bcbb",
       "name": "Storefront users",
       "description": {
         "content": "",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "327b66d3-0982-4b2e-88cf-5846ea4483c9",
+          "id": "cfec2c44-e83d-46a8-bae7-cca8ee801642",
           "name": "Create storefront user",
           "request": {
             "name": "Create storefront user",
@@ -109,7 +109,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "fc821aa1-dca5-46f8-8460-5eee55d0f3d7",
+              "id": "ad0d02ef-b6b6-445e-8abd-08a4626ae050",
               "name": "Created\n\nUser created successfully.",
               "originalRequest": {
                 "url": {
@@ -199,7 +199,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "840359db-c241-4089-9ae1-ac20842307b4",
+              "id": "d4dd782a-2554-4e01-a282-6eef3b06425b",
               "name": "Bad Request\n\nInvalid request format or missing required fields or unsupported identifier type.",
               "originalRequest": {
                 "url": {
@@ -289,7 +289,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "8285ba81-c204-468a-9d0c-a93eae422079",
+              "id": "72632140-5b33-4a36-92f9-b173f6d70b86",
               "name": "Unauthorized\n\nInvalid or missing authentication credentials.",
               "originalRequest": {
                 "url": {
@@ -369,7 +369,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "58e1268d-f3e3-46f8-bae0-16414f5eb39b",
+              "id": "20f18082-13db-45be-9895-5548ceb5e2b5",
               "name": "Forbidden\n\nInsufficient permissions to create users.",
               "originalRequest": {
                 "url": {
@@ -449,7 +449,7 @@
               "_": {
                 "postman_previewlanguage": "json"
               },
-              "id": "58059065-e94b-47fa-bfe3-27b8e4755f84",
+              "id": "a830d450-4d0e-4803-bdca-32e0d479e936",
               "name": "Conflict\n\nOne or more of the provided identifiers already exist for another user.",
               "originalRequest": {
                 "url": {
@@ -540,7 +540,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "1eb2bef6-3740-45d5-8368-d30fa4aa392a",
+                "id": "42c6a595-f53a-4a87-a557-fe682ec830ca",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[POST]::/api/authenticator/v1/storefront/users - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -554,12 +554,909 @@
           "protocolProfileBehavior": {
             "disableBodyPruning": true
           }
+        },
+        {
+          "id": "3654b8ae-0167-4fb5-a8f6-a984dc615101",
+          "name": "Get storefront user by user ID",
+          "request": {
+            "name": "Get storefront user by user ID",
+            "description": {
+              "content": "Fetches a storefront user's unique ID and all associated authentication identifiers (username, email, phone number, or API key) by the user's unique ID.\r\n\r\n> ⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/docs/tutorials/b2b-buyer-portal), which is currently available to selected accounts.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| VTEX ID | User Management | **Read Users** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "api",
+                "authenticator",
+                "v1",
+                "users",
+                ":userId"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) Unique identifier (GUID) of the storefront user.",
+                    "type": "text/plain"
+                  },
+                  "type": "any",
+                  "value": "1761fad7-d87a-45da-af04-5284017fe4b5",
+                  "key": "userId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) Type of the content being sent.",
+                  "type": "text/plain"
+                },
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                  "type": "text/plain"
+                },
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "body": {},
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "type": "any",
+                  "value": "X-VTEX-API-AppKey",
+                  "key": "key"
+                },
+                {
+                  "type": "any",
+                  "value": "{{apiKey}}",
+                  "key": "value"
+                },
+                {
+                  "type": "any",
+                  "value": "header",
+                  "key": "in"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "24affa1f-7bd1-4671-ada4-fd2b58f3467f",
+              "name": "OK\n\nUser found.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    ":userId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"userId\": \"1761fad7-d87a-45da-af04-5284017fe4b5\",\n  \"identifiers\": [\n    {\n      \"type\": \"email\",\n      \"value\": \"test_user@acme.com\"\n    },\n    {\n      \"type\": \"username\",\n      \"value\": \"test_user\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"00123456789\"\n    }\n  ]\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "13654905-5e81-4b3b-9ab5-ee7c939ee747",
+              "name": "Unauthorized\n\nThe current user could not be resolved.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    ":userId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "19e06676-2c53-46e9-88f5-6e353354a267",
+              "name": "Forbidden\n\nAccess denied.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    ":userId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "ade9dc17-d962-48a3-a795-b7cf47770884",
+              "name": "Not Found\n\nUser not found for the given user ID.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    ":userId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "8371241a-2521-43aa-b100-e226b699cc9f",
+              "name": "Internal Server Error\n\nUnknown server error.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    ":userId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [],
+              "cookie": []
+            }
+          ],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "ea003548-f7e4-4308-9221-a136decfa0cc",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/v1/users/:userId - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/authenticator/v1/users/:userId - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/api/authenticator/v1/users/:userId - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"userId\":{\"type\":\"string\",\"description\":\"Unique user identifier (GUID).\"},\"identifiers\":{\"type\":\"array\",\"description\":\"Array of authentication identifiers associated with the user.\",\"items\":{\"type\":\"object\",\"description\":\"Authentication identifier object containing the type and value.\",\"properties\":{\"type\":{\"type\":\"string\",\"enum\":[\"username\",\"email\",\"phoneNumber\"],\"description\":\"Type of authentication identifier.\"},\"value\":{\"type\":\"string\",\"description\":\"The identifier value.\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/authenticator/v1/users/:userId - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "de465f4e-993c-466a-bdba-77c7674e0f2b",
+          "name": "Get storefront user by identifier",
+          "request": {
+            "name": "Get storefront user by identifier",
+            "description": {
+              "content": "Fetches a storefront user's unique ID and all associated authentication identifiers by looking up one known identifier (username, email, phone number, or API key).\r\n\r\n> ⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/docs/tutorials/b2b-buyer-portal), which is currently available to selected accounts.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| VTEX ID | User Management | **Read Users** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "api",
+                "authenticator",
+                "v1",
+                "users",
+                "info"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "disabled": false,
+                  "description": {
+                    "content": "(Required) The identifier value to look up (e.g., an email address, username, phone number, or API key).",
+                    "type": "text/plain"
+                  },
+                  "key": "identifier",
+                  "value": "test_user@acme.com"
+                },
+                {
+                  "disabled": true,
+                  "description": {
+                    "content": "Identifier type used to narrow the search. When omitted, the search considers all identifier types.",
+                    "type": "text/plain"
+                  },
+                  "key": "type",
+                  "value": "email"
+                }
+              ],
+              "variable": []
+            },
+            "header": [
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) Type of the content being sent.",
+                  "type": "text/plain"
+                },
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "disabled": false,
+                "description": {
+                  "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                  "type": "text/plain"
+                },
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "body": {},
+            "auth": {
+              "type": "apikey",
+              "apikey": [
+                {
+                  "type": "any",
+                  "value": "X-VTEX-API-AppKey",
+                  "key": "key"
+                },
+                {
+                  "type": "any",
+                  "value": "{{apiKey}}",
+                  "key": "value"
+                },
+                {
+                  "type": "any",
+                  "value": "header",
+                  "key": "in"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "_": {
+                "postman_previewlanguage": "json"
+              },
+              "id": "726f0323-6ff0-402f-9f18-da145b4f5ab5",
+              "name": "OK\n\nUser found.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    "info"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) The identifier value to look up (e.g., an email address, username, phone number, or API key).",
+                        "type": "text/plain"
+                      },
+                      "key": "identifier",
+                      "value": "test_user@acme.com"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Identifier type used to narrow the search. When omitted, the search considers all identifier types.",
+                        "type": "text/plain"
+                      },
+                      "key": "type",
+                      "value": "email"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"userId\": \"1761fad7-d87a-45da-af04-5284017fe4b5\",\n  \"identifiers\": [\n    {\n      \"type\": \"email\",\n      \"value\": \"test_user@acme.com\"\n    },\n    {\n      \"type\": \"username\",\n      \"value\": \"test_user\"\n    },\n    {\n      \"type\": \"phoneNumber\",\n      \"value\": \"00123456789\"\n    }\n  ]\n}",
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "ade63a12-bc6c-4f1e-bfb8-4e2dfdde787f",
+              "name": "Unauthorized\n\nThe current user could not be resolved.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    "info"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) The identifier value to look up (e.g., an email address, username, phone number, or API key).",
+                        "type": "text/plain"
+                      },
+                      "key": "identifier",
+                      "value": "test_user@acme.com"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Identifier type used to narrow the search. When omitted, the search considers all identifier types.",
+                        "type": "text/plain"
+                      },
+                      "key": "type",
+                      "value": "email"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "ea5b76a6-6876-40d5-ae10-d073ab716646",
+              "name": "Forbidden\n\nAccess denied.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    "info"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) The identifier value to look up (e.g., an email address, username, phone number, or API key).",
+                        "type": "text/plain"
+                      },
+                      "key": "identifier",
+                      "value": "test_user@acme.com"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Identifier type used to narrow the search. When omitted, the search considers all identifier types.",
+                        "type": "text/plain"
+                      },
+                      "key": "type",
+                      "value": "email"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "0801654f-4db3-4aa5-950c-2383203aaf42",
+              "name": "Not Found\n\nUser not found for the given identifier.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    "info"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) The identifier value to look up (e.g., an email address, username, phone number, or API key).",
+                        "type": "text/plain"
+                      },
+                      "key": "identifier",
+                      "value": "test_user@acme.com"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Identifier type used to narrow the search. When omitted, the search considers all identifier types.",
+                        "type": "text/plain"
+                      },
+                      "key": "type",
+                      "value": "email"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [],
+              "cookie": []
+            },
+            {
+              "_": {
+                "postman_previewlanguage": "text"
+              },
+              "id": "6c7fe050-130e-4046-9609-bffd0cb057b7",
+              "name": "Internal Server Error\n\nUnknown server error.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "api",
+                    "authenticator",
+                    "v1",
+                    "users",
+                    "info"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "disabled": false,
+                      "description": {
+                        "content": "(Required) The identifier value to look up (e.g., an email address, username, phone number, or API key).",
+                        "type": "text/plain"
+                      },
+                      "key": "identifier",
+                      "value": "test_user@acme.com"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "Identifier type used to narrow the search. When omitted, the search considers all identifier types.",
+                        "type": "text/plain"
+                      },
+                      "key": "type",
+                      "value": "email"
+                    }
+                  ],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) Type of the content being sent.",
+                      "type": "text/plain"
+                    },
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "disabled": false,
+                    "description": {
+                      "content": "(Required) HTTP Client Negotiation _Accept_ Header. Indicates the types of responses the client can understand.",
+                      "type": "text/plain"
+                    },
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "X-VTEX-API-AppKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [],
+              "cookie": []
+            }
+          ],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "73f10715-23e3-4954-99a6-25a0cf093e31",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate status 2xx \npm.test(\"[GET]::/api/authenticator/v1/users/info - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/authenticator/v1/users/info - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/api/authenticator/v1/users/info - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"object\",\"properties\":{\"userId\":{\"type\":\"string\",\"description\":\"Unique user identifier (GUID).\"},\"identifiers\":{\"type\":\"array\",\"description\":\"Array of authentication identifiers associated with the user.\",\"items\":{\"type\":\"object\",\"description\":\"Authentication identifier object containing the type and value.\",\"properties\":{\"type\":{\"type\":\"string\",\"enum\":[\"username\",\"email\",\"phoneNumber\"],\"description\":\"Type of authentication identifier.\"},\"value\":{\"type\":\"string\",\"description\":\"The identifier value.\"}}}}}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/authenticator/v1/users/info - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
         }
       ],
       "event": []
     },
     {
-      "id": "97e421f7-8270-4271-8309-31b549258e56",
+      "id": "892b7cc3-a555-4bc5-a1e7-ace268f0f656",
       "name": "Password migration",
       "description": {
         "content": "",
@@ -567,7 +1464,7 @@
       },
       "item": [
         {
-          "id": "1e9799e3-51df-4338-8333-e57619322671",
+          "id": "c945c347-3336-43f4-9a46-f9317c1e00bb",
           "name": "Upsert password migration configuration",
           "request": {
             "name": "Upsert password migration configuration",
@@ -642,7 +1539,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "c2d94053-37f8-4503-ba93-5cbe5f0a6d74",
+              "id": "7a7bea35-31fc-4d93-99e8-f89c2bc4c74a",
               "name": "OK\n\nFeature registered or updated successfully.",
               "originalRequest": {
                 "url": {
@@ -713,7 +1610,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "e29135ed-fe70-42e1-bc97-b1ffb0f99790",
+              "id": "44d52342-7309-4b17-b3a0-9b45cb8360bb",
               "name": "Bad Request\n\nUnknown feature name or invalid secret format.",
               "originalRequest": {
                 "url": {
@@ -784,7 +1681,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "172a3340-6d66-46ea-baa9-a3ca375678ce",
+              "id": "939af492-5b51-41e4-9736-4ba86c4380a6",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -856,7 +1753,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "bb81a2f7-12ba-4461-9c46-60ab2a2791a1",
+                "id": "f1f2c52e-755c-4daf-a8fe-17f490c0839e",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PUT]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -869,7 +1766,7 @@
           }
         },
         {
-          "id": "a951413f-0785-43be-a36a-db0e7c1b621a",
+          "id": "a35b5705-d4c8-4d2d-8444-a0521c250dd7",
           "name": "Enable or disable password migration",
           "request": {
             "name": "Enable or disable password migration",
@@ -944,7 +1841,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "b52c4a03-5a0e-4c99-b52e-2615362e4f8b",
+              "id": "0a6c8675-da26-4f96-8bd7-e8a3735bc47f",
               "name": "OK\n\nFeature toggled successfully.",
               "originalRequest": {
                 "url": {
@@ -1015,7 +1912,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "aff5bef1-52bb-4ee5-af35-4d1b09273cd9",
+              "id": "56fbc5d9-0762-4681-8352-e1cee1133bc2",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -1086,7 +1983,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a7d743a9-4fe6-489f-a07a-2d6fc49eb97a",
+              "id": "6e44f808-b9e5-4597-b87b-3140f8aaa50a",
               "name": "Not Found\n\nFeature not registered for this tenant.",
               "originalRequest": {
                 "url": {
@@ -1157,7 +2054,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "a11aab63-2589-4d0a-a5ec-19e2b87e9a22",
+              "id": "9ed37a0e-866c-4ff4-8517-fc9fe1c01c05",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1229,7 +2126,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "51ff8f2c-a18d-45e3-96b3-a372d2d9e229",
+                "id": "b0a7812c-5f99-4dbb-ba95-4a6ccfc43744",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[PATCH]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n"
@@ -1242,7 +2139,7 @@
           }
         },
         {
-          "id": "594a1d5b-9498-47ed-9f9f-3a019ff65189",
+          "id": "55f210a4-c5e1-4342-aae7-2354f0cb057f",
           "name": "Delete password migration configuration",
           "request": {
             "name": "Delete password migration configuration",
@@ -1295,7 +2192,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "99628e1a-ace7-4b18-9df0-014830eb090a",
+              "id": "258e4307-e3c4-42e9-94b5-829c63b7fc33",
               "name": "No Content\n\nFeature deleted successfully.",
               "originalRequest": {
                 "url": {
@@ -1344,7 +2241,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "0920c77a-27a3-4ee4-ac8a-0bf4ec910d19",
+              "id": "444696a7-fdc8-4e58-8559-fe295ec9e453",
               "name": "Bad Request\n\nUnknown feature name.",
               "originalRequest": {
                 "url": {
@@ -1393,7 +2290,7 @@
               "_": {
                 "postman_previewlanguage": "text"
               },
-              "id": "7d9ca771-7248-4cc3-8ba2-dff45c63c0ae",
+              "id": "0568e713-726b-44ad-83fe-f23c422bf0ff",
               "name": "Internal Server Error\n\nUnknown server error.",
               "originalRequest": {
                 "url": {
@@ -1443,7 +2340,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "8164321d-82dc-4983-afff-6698035ccd79",
+                "id": "22b16386-a975-4cf2-8a52-cb728d57a0b7",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate status 2xx \npm.test(\"[DELETE]::/api/authenticator/v1/tenants/features/:name - Status code is 2xx\", function () {\n   pm.response.to.be.success;\n});\n",
@@ -1499,7 +2396,7 @@
     }
   ],
   "info": {
-    "_postman_id": "160b3753-29d8-43eb-a49a-cdc14908b7d9",
+    "_postman_id": "f71565f2-3596-4942-ae34-e894ecf7c51d",
     "name": "Authenticator",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/VTEX - Authenticator API.json
+++ b/VTEX - Authenticator API.json
@@ -214,6 +214,228 @@
                 ]
             }
         },
+        "/api/authenticator/v1/users/{userId}": {
+            "get": {
+                "tags": [
+                    "Storefront users"
+                ],
+                "summary": "Get storefront user by user ID",
+                "description": "Fetches a storefront user's unique ID and all associated authentication identifiers (username, email, phone number, or API key) by the user's unique ID.\r\n\r\n> ⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/docs/tutorials/b2b-buyer-portal), which is currently available to selected accounts.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| VTEX ID | User Management | **Read Users** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/components/parameters/Accept"
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "Unique identifier (GUID) of the storefront user.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "1761fad7-d87a-45da-af04-5284017fe4b5"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK\n\nUser found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "userId": {
+                                            "type": "string",
+                                            "description": "Unique user identifier (GUID)."
+                                        },
+                                        "identifiers": {
+                                            "type": "array",
+                                            "description": "Array of authentication identifiers associated with the user.",
+                                            "items": {
+                                                "type": "object",
+                                                "description": "Authentication identifier object containing the type and value.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "username",
+                                                            "email",
+                                                            "phoneNumber"
+                                                        ],
+                                                        "description": "Type of authentication identifier."
+                                                    },
+                                                    "value": {
+                                                        "type": "string",
+                                                        "description": "The identifier value."
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+                                    "identifiers": [
+                                        {
+                                            "type": "email",
+                                            "value": "test_user@acme.com"
+                                        },
+                                        {
+                                            "type": "username",
+                                            "value": "test_user"
+                                        },
+                                        {
+                                            "type": "phoneNumber",
+                                            "value": "00123456789"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized\n\nThe current user could not be resolved."
+                    },
+                    "403": {
+                        "description": "Forbidden\n\nAccess denied."
+                    },
+                    "404": {
+                        "description": "Not Found\n\nUser not found for the given user ID."
+                    },
+                    "500": {
+                        "description": "Internal Server Error\n\nUnknown server error."
+                    }
+                },
+                "security": [
+                    {
+                        "appKey": [],
+                        "appToken": []
+                    }
+                ]
+            }
+        },
+        "/api/authenticator/v1/users/info": {
+            "get": {
+                "tags": [
+                    "Storefront users"
+                ],
+                "summary": "Get storefront user by identifier",
+                "description": "Fetches a storefront user's unique ID and all associated authentication identifiers by looking up one known identifier (username, email, phone number, or API key).\r\n\r\n> ⚠️ This feature is only available for stores using [B2B Buyer Portal](https://help.vtex.com/docs/tutorials/b2b-buyer-portal), which is currently available to selected accounts.\r\n\r\n## Permissions\r\n\r\nAny user or [API key](https://developers.vtex.com/docs/guides/authentication-overview#api-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| VTEX ID | User Management | **Read Users** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint.\r\nTo learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication-overview#machine-authentication).\r\n\r\n>❗ To prevent integrations from having excessive permissions, consider the [best practices for managing API keys](https://help.vtex.com/en/tutorial/best-practices-api-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/components/parameters/Accept"
+                    },
+                    {
+                        "name": "identifier",
+                        "in": "query",
+                        "description": "The identifier value to look up (e.g., an email address, username, phone number, or API key).",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "test_user@acme.com"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Identifier type used to narrow the search. When omitted, the search considers all identifier types.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "username",
+                                "email",
+                                "phonenumber",
+                                "apikey"
+                            ],
+                            "example": "email"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK\n\nUser found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "userId": {
+                                            "type": "string",
+                                            "description": "Unique user identifier (GUID)."
+                                        },
+                                        "identifiers": {
+                                            "type": "array",
+                                            "description": "Array of authentication identifiers associated with the user.",
+                                            "items": {
+                                                "type": "object",
+                                                "description": "Authentication identifier object containing the type and value.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "username",
+                                                            "email",
+                                                            "phoneNumber"
+                                                        ],
+                                                        "description": "Type of authentication identifier."
+                                                    },
+                                                    "value": {
+                                                        "type": "string",
+                                                        "description": "The identifier value."
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+                                    "identifiers": [
+                                        {
+                                            "type": "email",
+                                            "value": "test_user@acme.com"
+                                        },
+                                        {
+                                            "type": "username",
+                                            "value": "test_user"
+                                        },
+                                        {
+                                            "type": "phoneNumber",
+                                            "value": "00123456789"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized\n\nThe current user could not be resolved."
+                    },
+                    "403": {
+                        "description": "Forbidden\n\nAccess denied."
+                    },
+                    "404": {
+                        "description": "Not Found\n\nUser not found for the given identifier."
+                    },
+                    "500": {
+                        "description": "Internal Server Error\n\nUnknown server error."
+                    }
+                },
+                "security": [
+                    {
+                        "appKey": [],
+                        "appToken": []
+                    }
+                ]
+            }
+        },
         "/api/authenticator/v1/tenants/features/{name}": {
             "servers": [
                 {

--- a/VTEX - Authenticator API.json
+++ b/VTEX - Authenticator API.json
@@ -121,11 +121,11 @@
                                 "identifiers": [
                                     {
                                         "type": "username",
-                                        "value": "beneson_test_21"
+                                        "value": "john_doe"
                                     },
                                     {
                                         "type": "email",
-                                        "value": "beneson2010@gmail.com"
+                                        "value": "john.doe@acme.com"
                                     },
                                     {
                                         "type": "phoneNumber",
@@ -156,7 +156,7 @@
                                 },
                                 "example": {
                                     "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
-                                    "identifier": "beneson_test_21"
+                                    "identifier": "john_doe"
                                 }
                             }
                         }
@@ -235,7 +235,7 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "example": "1761fad7-d87a-45da-af04-5284017fe4b5"
+                            "example": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332"
                         }
                     }
                 ],
@@ -277,19 +277,19 @@
                                     }
                                 },
                                 "example": {
-                                    "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+                                    "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
                                     "identifiers": [
                                         {
                                             "type": "email",
-                                            "value": "test_user@acme.com"
+                                            "value": "john.doe@acme.com"
                                         },
                                         {
                                             "type": "username",
-                                            "value": "test_user"
+                                            "value": "john_doe"
                                         },
                                         {
                                             "type": "phoneNumber",
-                                            "value": "00123456789"
+                                            "value": "415-602-8838"
                                         }
                                     ]
                                 }
@@ -338,7 +338,7 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "example": "test_user@acme.com"
+                            "example": "john.doe@acme.com"
                         }
                     },
                     {
@@ -396,19 +396,19 @@
                                     }
                                 },
                                 "example": {
-                                    "userId": "1761fad7-d87a-45da-af04-5284017fe4b5",
+                                    "userId": "f0a15a42-f7fc-4b09-a9ab-fabc76d9f332",
                                     "identifiers": [
                                         {
                                             "type": "email",
-                                            "value": "test_user@acme.com"
+                                            "value": "john.doe@acme.com"
                                         },
                                         {
                                             "type": "username",
-                                            "value": "test_user"
+                                            "value": "john_doe"
                                         },
                                         {
                                             "type": "phoneNumber",
-                                            "value": "00123456789"
+                                            "value": "415-602-8838"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
## Summary
- Documents `GET /api/authenticator/v1/users/{userId}`: retrieve a storefront user by user ID.
- Documents `GET /api/authenticator/v1/users/info`: retrieve a storefront user by identifier (`identifier` required, `type` optional, one of `username`, `email`, `phonenumber`, `apikey`).
- Both endpoints require the `VTEX ID > User Management > Read Users` License Manager resource.
- Response codes: `200`, `401`, `403`, `404`, `500`.

Ref: EDU-19489

## Test plan
- [x] Validated JSON syntax
- [x] Passed Spectral lint (`.spectral.yml`) with no errors